### PR TITLE
Some of the DESSCRIBE radio buttons need to allow multiple selection @coldunk

### DIFF
--- a/epilepsy12/view_folder/multiaxial_diagnosis_views.py
+++ b/epilepsy12/view_folder/multiaxial_diagnosis_views.py
@@ -827,8 +827,10 @@ def focal_onset_epilepsy_checked_changed(request, episode_id):
     """
     Function triggered by a change in any checkbox/toggle in the focal_onset_epilepsy template leading to a post request.
     The episode_id is also passed in allowing update of the model.
-    The id of the radio button clicked holds the name of the field in the desscribe model to update
-    the name of the radiobutton group clicked holds the name of the list from which to select model fields to update
+    The id of the radio button/checkbox clicked holds the name of the field in the desscribe model to update
+    the name of the radiobutton/checkbox group clicked holds the name of the list from which to select model fields to update
+    Laterality choices are radiobuttons (as can be either left or right, not both)
+    All other choices are checkboxes and multiselect is enabled here
     """
 
     if request.htmx.trigger_name == 'FOCAL_EPILEPSY_MOTOR_MANIFESTATIONS':
@@ -847,15 +849,24 @@ def focal_onset_epilepsy_checked_changed(request, episode_id):
 
     update_fields = {}
     for item in focal_fields:
+        item_status = getattr(episode, item.get('name'))
         if request.htmx.trigger == item.get('name'):
-            item_status = getattr(episode, item.get('name'))
+            # selects or deselects the chosen option - allows user to reverse previous selection
             update_fields.update({
                 item.get('name'): not item_status
             })
         else:
-            update_fields.update({
-                item.get('name'): False
-            })
+            if request.htmx.trigger_name == 'LATERALITY':
+                # sets the opposite side to that selected as false
+                update_fields.update({
+                    item.get('name'): False
+                })
+            else:
+                # leaves all other selections the same - allows therefore multiselect
+                update_fields.update({
+                    item.get('name'): item_status
+                })
+
     update_fields.update({
         'updated_at': timezone.now(),
         'updated_by': request.user

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -638,16 +638,16 @@ ul {
   background-color: var(--rcpch_light_blue);
   border: 2px solid var(--rcpch_light_blue);
   color: white;
-  -webkit-transform: scale(1.1, 1.1);
-  transform: scale(1.1, 1.1);
+  -webkit-transform: scale(0.9, 0.9);
+  transform: scale(0.9, 0.9);
 }
 
 .radio-tile-group .input-container .radio-button:checked+.radio-tile:hover {
 
-  border: 2px solid var(--rcpch_dark_blue);
+  border: 2px solid var(--rcpch_light_blue);
   color: white;
-  -webkit-transform: scale(1.0, 1.0);
-  transform: scale(1.0, 1.0);
+  -webkit-transform: scale(0.9, 0.9);
+  transform: scale(0.9, 0.9);
 }
 
 .radio-tile-group .input-container .radio-button:checked+.radio-tile .radio-tile-label {

--- a/templates/epilepsy12/partials/multiaxial_diagnosis/focal_onset_epilepsy.html
+++ b/templates/epilepsy12/partials/multiaxial_diagnosis/focal_onset_epilepsy.html
@@ -19,7 +19,7 @@
         </h5>
 
             {% url 'focal_onset_epilepsy_checked_changed' episode_id=episode.pk as hx_post %}
-            {% include 'epilepsy12/partials/page_elements/radio_button_group.html' with hx_post=hx_post hx_target="#focal_epilepsy" hx_model=episode hx_field_list=FOCAL_EPILEPSY_MOTOR_MANIFESTATIONS hx_field_list_name="FOCAL_EPILEPSY_MOTOR_MANIFESTATIONS" %}
+            {% include 'epilepsy12/partials/page_elements/check_box_group.html' with hx_post=hx_post hx_target="#focal_epilepsy" hx_model=episode hx_field_list=FOCAL_EPILEPSY_MOTOR_MANIFESTATIONS hx_field_list_name="FOCAL_EPILEPSY_MOTOR_MANIFESTATIONS" %}
     </div>
 
     <div class="four wide column">
@@ -31,7 +31,7 @@
             <div class="container">
                 <div class="radio-tile-group">
                     {% url 'focal_onset_epilepsy_checked_changed' episode_id=episode.pk as hx_post %}
-                    {% include 'epilepsy12/partials/page_elements/radio_button_group.html' with hx_post=hx_post hx_target="#focal_epilepsy" hx_model=episode hx_field_list=FOCAL_EPILEPSY_NONMOTOR_MANIFESTATIONS hx_field_list_name="FOCAL_EPILEPSY_NONMOTOR_MANIFESTATIONS" %}
+                    {% include 'epilepsy12/partials/page_elements/check_box_group.html' with hx_post=hx_post hx_target="#focal_epilepsy" hx_model=episode hx_field_list=FOCAL_EPILEPSY_NONMOTOR_MANIFESTATIONS hx_field_list_name="FOCAL_EPILEPSY_NONMOTOR_MANIFESTATIONS" %}
                 </div>
             </div>
     
@@ -40,13 +40,13 @@
     <div class="four wide column">
 
         <h5>
-        EEG manifestations
+        EEG findings
         </h5>
 
             <div class="container">
                 <div class="radio-tile-group">
                     {% url 'focal_onset_epilepsy_checked_changed' episode_id=episode.pk as hx_post %}
-                    {% include 'epilepsy12/partials/page_elements/radio_button_group.html' with hx_post=hx_post hx_target="#focal_epilepsy" hx_model=episode hx_field_list=FOCAL_EPILEPSY_EEG_MANIFESTATIONS hx_field_list_name="FOCAL_EPILEPSY_EEG_MANIFESTATIONS" %}
+                    {% include 'epilepsy12/partials/page_elements/check_box_group.html' with hx_post=hx_post hx_target="#focal_epilepsy" hx_model=episode hx_field_list=FOCAL_EPILEPSY_EEG_MANIFESTATIONS hx_field_list_name="FOCAL_EPILEPSY_EEG_MANIFESTATIONS" %}
                 </div>
             </div>
     

--- a/templates/epilepsy12/partials/page_elements/check_box_group.html
+++ b/templates/epilepsy12/partials/page_elements/check_box_group.html
@@ -31,7 +31,7 @@ hx_target: target element id
                         hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' 
                         id="{{hx_field.name}}" 
                         class="radio-button"
-                        type="radio" 
+                        type="checkbox" 
                         name="{{hx_field_list_name}}"
                         hx-post="{{hx_post}}"
                         hx-trigger="click"
@@ -43,7 +43,7 @@ hx_target: target element id
                         hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' 
                         id="{{hx_field.name}}" 
                         class="radio-button" 
-                        type="radio" 
+                        type="checkbox" 
                         name="{{hx_field_list_name}}"
                          hx-post="{{hx_post}}"
                         hx-trigger="click"


### PR DESCRIPTION
- Creates a new checkbox element for the motor, - 
- nonmotor and eeg manifestations options
- removes the time delay on select 
- alters conditionals in the callback to allow multiselect for all options except laterality
- alters label from EEG manifestations to EEG findings
Fixes #173