### PR TITLE
Eatyourpeas/issue170

### DIFF
--- a/epilepsy12/models/case.py
+++ b/epilepsy12/models/case.py
@@ -178,6 +178,14 @@ class Case(TimeStampAbstractBaseClass, UserStampAbstractBaseClass, HelpTextMixin
                 self.postcode)
         return super().save(*args, **kwargs)
 
+    def delete(self, *args, **kwargs):
+        # Deleting a Case involves deleting any registrations associated that exist first
+        try:
+            self.registration.delete()
+        except:
+            pass
+        super(Case, self).delete(*args, **kwargs)
+
     class Meta:
         verbose_name = 'Patient'
         verbose_name_plural = 'Patients'

--- a/epilepsy12/serializers.py
+++ b/epilepsy12/serializers.py
@@ -54,7 +54,7 @@ class RegistrationSerializer(serializers.HyperlinkedModelSerializer):
         case = serializers.PrimaryKeyRelatedField(queryset=Case.objects.all())
         audit_progress = serializers.PrimaryKeyRelatedField(
             queryset=AuditProgress.objects.all())
-        fields = ['case', 'registration_date',
+        fields = ['pk', 'case', 'registration_date',
                   'registration_close_date', 'cohort', 'eligibility_criteria_met', 'child_name']
 
 
@@ -64,7 +64,7 @@ class AuditProgressSerializer(serializers.HyperlinkedModelSerializer):
         fields = '__all__'
 
 
-class EpilepsyContextSerializer(serializers.HyperlinkedModelSerializer):
+class EpilepsyContextSerializer(serializers.ModelSerializer):
     class Meta:
         model = EpilepsyContext
         registration = serializers.PrimaryKeyRelatedField(
@@ -74,19 +74,25 @@ class EpilepsyContextSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class CaseSerializer(serializers.HyperlinkedModelSerializer):
+
     class Meta:
         model = Case
         fields = ['locked', 'locked_at', 'locked_by', 'nhs_number', 'first_name', 'surname', 'sex',
                   'date_of_birth', 'postcode', 'ethnicity', 'index_of_multiple_deprivation_quintile']
 
 
-class FirstPaediatricAssessmentSerializer(serializers.HyperlinkedModelSerializer):
+class FirstPaediatricAssessmentSerializer(serializers.ModelSerializer):
+    child_name = serializers.CharField(
+        source='registration.case', required=False)
+
     class Meta:
         model = FirstPaediatricAssessment
         registration = serializers.PrimaryKeyRelatedField(
             queryset=Registration.objects.all())
-        fields = ['first_paediatric_assessment_in_acute_or_nonacute_setting', 'has_number_of_episodes_since_the_first_been_documented',
-                  'general_examination_performed', 'neurological_examination_performed', 'developmental_learning_or_schooling_problems', 'behavioural_or_emotional_problems']
+        audit_progress = serializers.PrimaryKeyRelatedField(
+            queryset=AuditProgress.objects.all())
+        fields = ['id', 'first_paediatric_assessment_in_acute_or_nonacute_setting', 'has_number_of_episodes_since_the_first_been_documented',
+                  'general_examination_performed', 'neurological_examination_performed', 'developmental_learning_or_schooling_problems', 'behavioural_or_emotional_problems', 'child_name']
 
 
 class MultiaxialDiagnosisSerializer(serializers.HyperlinkedModelSerializer):
@@ -160,6 +166,8 @@ class AntiEpilepsyMedicineSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class SiteSerializer(serializers.HyperlinkedModelSerializer):
+    child_name = serializers.CharField(source='case')
+
     class Meta:
         model = Site
         case = serializers.PrimaryKeyRelatedField(
@@ -167,7 +175,7 @@ class SiteSerializer(serializers.HyperlinkedModelSerializer):
         hospital_trust = serializers.PrimaryKeyRelatedField(
             queryset=HospitalTrust.objects.all())
         fields = ['site_is_actively_involved_in_epilepsy_care', 'site_is_primary_centre_of_epilepsy_care',
-                  'site_is_childrens_epilepsy_surgery_centre', 'site_is_paediatric_neurology_centre', 'site_is_general_paediatric_centre']
+                  'site_is_childrens_epilepsy_surgery_centre', 'site_is_paediatric_neurology_centre', 'site_is_general_paediatric_centre', 'case', 'hospital_trust', 'child_name']
 
 
 class HospitalTrustSerializer(serializers.HyperlinkedModelSerializer):

--- a/epilepsy12/serializers.py
+++ b/epilepsy12/serializers.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from django.contrib.auth.models import Group
 from rest_framework import serializers
 from rest_framework.views import APIView
@@ -26,16 +27,48 @@ class CaseSerializer(serializers.HyperlinkedModelSerializer):
                   'date_of_birth', 'postcode', 'ethnicity', 'index_of_multiple_deprivation_quintile', 'hospital_trusts']
 
 
+def is_future_date(value):
+    if value > datetime.now().date():
+        raise serializers.ValidationError(
+            {'registration_date': 'First paediatric assessment cannot be in the future.'})
+    return value
+
+
+def is_true(value):
+    if not value:
+        raise serializers.ValidationError(
+            {'eligibility_criteria_met': 'Eligibility criteria must have been met to be registered in Epilepsy12.'})
+    return value
+
+
 class RegistrationSerializer(serializers.HyperlinkedModelSerializer):
+    registration_close_date = serializers.DateField(read_only=True)
+    cohort = serializers.IntegerField(read_only=True)
+    registration_date = serializers.DateField(validators=[is_future_date])
+    eligibility_criteria_met = serializers.BooleanField(
+        required=True, validators=[is_true])
+    child_name = serializers.CharField(source='case', required=False)
+
     class Meta:
         model = Registration
-        fields = ['registration_date', 'registration_close_date',
-                  'eligibility_criteria_met', 'cohort']
+        case = serializers.PrimaryKeyRelatedField(queryset=Case.objects.all())
+        audit_progress = serializers.PrimaryKeyRelatedField(
+            queryset=AuditProgress.objects.all())
+        fields = ['case', 'registration_date',
+                  'registration_close_date', 'cohort', 'eligibility_criteria_met', 'child_name']
+
+
+class AuditProgressSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = AuditProgress
+        fields = '__all__'
 
 
 class EpilepsyContextSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = EpilepsyContext
+        registration = serializers.PrimaryKeyRelatedField(
+            queryset=Registration.objects.all())
         fields = ['previous_febrile_seizure', 'previous_acute_symptomatic_seizure', 'is_there_a_family_history_of_epilepsy', 'previous_neonatal_seizures', 'diagnosis_of_epilepsy_withdrawn',
                   'were_any_of_the_epileptic_seizures_convulsive', 'experienced_prolonged_generalized_convulsive_seizures', 'experienced_prolonged_focal_seizures']
 
@@ -50,6 +83,8 @@ class CaseSerializer(serializers.HyperlinkedModelSerializer):
 class FirstPaediatricAssessmentSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = FirstPaediatricAssessment
+        registration = serializers.PrimaryKeyRelatedField(
+            queryset=Registration.objects.all())
         fields = ['first_paediatric_assessment_in_acute_or_nonacute_setting', 'has_number_of_episodes_since_the_first_been_documented',
                   'general_examination_performed', 'neurological_examination_performed', 'developmental_learning_or_schooling_problems', 'behavioural_or_emotional_problems']
 
@@ -57,6 +92,8 @@ class FirstPaediatricAssessmentSerializer(serializers.HyperlinkedModelSerializer
 class MultiaxialDiagnosisSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = MultiaxialDiagnosis
+        registration = serializers.PrimaryKeyRelatedField(
+            queryset=Registration.objects.all())
         fields = ['syndrome_present', 'epilepsy_cause_known', 'epilepsy_cause', 'epilepsy_cause_categories',
                   'relevant_impairments_behavioural_educational', 'mental_health_screen', 'mental_health_issue_identified', 'mental_health_issue']
 
@@ -64,6 +101,8 @@ class MultiaxialDiagnosisSerializer(serializers.HyperlinkedModelSerializer):
 class EpisodeSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Episode
+        multiaxial_diagnosis = serializers.PrimaryKeyRelatedField(
+            queryset=MultiaxialDiagnosis.objects.all())
         fields = ['seizure_onset_date', 'seizure_onset_date_confidence', 'episode_definition', 'has_description_of_the_episode_or_episodes_been_gathered', 'description', 'description_keywords', 'epilepsy_or_nonepilepsy_status', 'epileptic_seizure_onset_type', 'nonepileptic_seizure_type', 'epileptic_generalised_onset', 'focal_onset_impaired_awareness', 'focal_onset_automatisms', 'focal_onset_atonic', 'focal_onset_clonic', 'focal_onset_left', 'focal_onset_right', 'focal_onset_epileptic_spasms', 'focal_onset_hyperkinetic', 'focal_onset_myoclonic', 'focal_onset_tonic', 'focal_onset_autonomic',
                   'focal_onset_behavioural_arrest', 'focal_onset_cognitive', 'focal_onset_emotional', 'focal_onset_sensory', 'focal_onset_centrotemporal', 'focal_onset_temporal', 'focal_onset_frontal', 'focal_onset_parietal', 'focal_onset_occipital', 'focal_onset_gelastic', 'focal_onset_focal_to_bilateral_tonic_clonic', 'nonepileptic_seizure_unknown_onset', 'nonepileptic_seizure_syncope', 'nonepileptic_seizure_behavioural', 'nonepileptic_seizure_sleep', 'nonepileptic_seizure_paroxysmal', 'nonepileptic_seizure_migraine', 'nonepileptic_seizure_miscellaneous', 'nonepileptic_seizure_other']
 
@@ -71,18 +110,24 @@ class EpisodeSerializer(serializers.HyperlinkedModelSerializer):
 class SyndromeSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Syndrome
+        multiaxial_diagnosis = serializers.PrimaryKeyRelatedField(
+            queryset=MultiaxialDiagnosis.objects.all())
         fields = ['syndrome_diagnosis_date', 'syndrome_name']
 
 
 class ComorbiditySerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Comorbidity
+        multiaxial_diagnosis = serializers.PrimaryKeyRelatedField(
+            queryset=MultiaxialDiagnosis.objects.all())
         fields = ['comorbidity_diagnosis_date', 'comorbidity_diagnosis']
 
 
 class InvestigationsSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Investigations
+        registration = serializers.PrimaryKeyRelatedField(
+            queryset=Registration.objects.all())
         fields = ['eeg_indicated', 'eeg_request_date', 'eeg_performed_date', 'twelve_lead_ecg_status', 'ct_head_scan_status',
                   'mri_indicated', 'mri_brain_requested_date', 'mri_brain_reported_date', 'mri_wait', 'eeg_wait']
 
@@ -90,6 +135,8 @@ class InvestigationsSerializer(serializers.HyperlinkedModelSerializer):
 class AssessmentSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Assessment
+        registration = serializers.PrimaryKeyRelatedField(
+            queryset=Registration.objects.all())
         fields = ['childrens_epilepsy_surgical_service_referral_criteria_met', 'consultant_paediatrician_referral_made', 'consultant_paediatrician_referral_date', 'consultant_paediatrician_input_date', 'paediatric_neurologist_referral_made', 'paediatric_neurologist_referral_date', 'paediatric_neurologist_input_date',
                   'childrens_epilepsy_surgical_service_referral_made', 'childrens_epilepsy_surgical_service_referral_date', 'childrens_epilepsy_surgical_service_input_date', 'epilepsy_specialist_nurse_referral_made', 'epilepsy_specialist_nurse_referral_date', 'epilepsy_specialist_nurse_input_date']
 
@@ -97,6 +144,8 @@ class AssessmentSerializer(serializers.HyperlinkedModelSerializer):
 class ManagementSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Management
+        registration = serializers.PrimaryKeyRelatedField(
+            queryset=Registration.objects.all())
         fields = ['has_an_aed_been_given', 'has_rescue_medication_been_prescribed', 'individualised_care_plan_in_place', 'individualised_care_plan_date', 'individualised_care_plan_has_parent_carer_child_agreement', 'individualised_care_plan_includes_service_contact_details', 'individualised_care_plan_include_first_aid', 'individualised_care_plan_parental_prolonged_seizure_care',
                   'individualised_care_plan_includes_general_participation_risk', 'individualised_care_plan_addresses_water_safety', 'individualised_care_plan_addresses_sudep', 'individualised_care_plan_includes_ehcp', 'has_individualised_care_plan_been_updated_in_the_last_year', 'has_been_referred_for_mental_health_support', 'has_support_for_mental_health_support']
 
@@ -104,6 +153,8 @@ class ManagementSerializer(serializers.HyperlinkedModelSerializer):
 class AntiEpilepsyMedicineSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = AntiEpilepsyMedicine
+        management = serializers.PrimaryKeyRelatedField(
+            queryset=Management.objects.all())
         fields = ['medicine_id', 'medicine_name', 'is_rescue_medicine', 'antiepilepsy_medicine_snomed_code', 'antiepilepsy_medicine_snomed_preferred_name', 'antiepilepsy_medicine_start_date',
                   'antiepilepsy_medicine_stop_date', 'antiepilepsy_medicine_risk_discussed', 'is_a_pregnancy_prevention_programme_needed', 'is_a_pregnancy_prevention_programme_in_place']
 
@@ -111,6 +162,10 @@ class AntiEpilepsyMedicineSerializer(serializers.HyperlinkedModelSerializer):
 class SiteSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Site
+        case = serializers.PrimaryKeyRelatedField(
+            queryset=Case.objects.all())
+        hospital_trust = serializers.PrimaryKeyRelatedField(
+            queryset=HospitalTrust.objects.all())
         fields = ['site_is_actively_involved_in_epilepsy_care', 'site_is_primary_centre_of_epilepsy_care',
                   'site_is_childrens_epilepsy_surgery_centre', 'site_is_paediatric_neurology_centre', 'site_is_general_paediatric_centre']
 

--- a/epilepsy12/serializers.py
+++ b/epilepsy12/serializers.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import Group
 from rest_framework import serializers
+from rest_framework.views import APIView
 from .models import *
 
 # AuditProgress model here not included as only relevant to the Epilepsy12 app

--- a/epilepsy12/urls.py
+++ b/epilepsy12/urls.py
@@ -2,6 +2,7 @@ from . import views
 from .view_folder import *
 from django.urls import path
 from rest_framework import routers
+from rest_framework.authtoken.views import obtain_auth_token
 from django.urls import path, include
 
 router = routers.DefaultRouter()
@@ -388,6 +389,7 @@ htmx_paths = [
 drf_routes = [
     # rest framework paths
     path('api/v1/', include(router.urls)),
+    path('api-token-auth/', obtain_auth_token, name='api_token_auth'),
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]
 

--- a/epilepsy12/urls.py
+++ b/epilepsy12/urls.py
@@ -1,6 +1,6 @@
 from . import views
 from .view_folder import *
-from .views import RegisterCase
+from .views import RegisterCase, CaseHospitalTrust
 from django.urls import path
 from rest_framework import routers
 from rest_framework.authtoken.views import obtain_auth_token
@@ -11,7 +11,7 @@ router = routers.DefaultRouter()
 router.register(r'epilepsy12users', views.Epilepsy12UserViewSet)
 router.register(r'registration', views.RegistrationViewSet)
 router.register(r'case', views.CaseViewSet)
-router.register(r'firstpaediatricassessment',
+router.register(r'first_paediatric_assessments',
                 views.FirstPaediatricAssessmentViewSet)
 router.register(r'epilepsycontext', views.EpilepsyContextViewSet)
 router.register(r'multiaxialdiagnosis', views.MultiaxialDiagnosisViewSet)
@@ -391,7 +391,11 @@ htmx_paths = [
 drf_routes = [
     # rest framework paths
     path('api/v1/', include(router.urls)),
+    # Registers child to a Lead site by NHS Number
     path('api/v1/register_case', view=RegisterCase.as_view()),
+    # Creates a new case associated with a lead site
+    path('api/v1/add_case_to_hospital_list',
+         view=CaseHospitalTrust.as_view()),
     # returns a Token (OAuth2 key: Token) against email and password of existing user
     path('api/v1/api-token-auth/', obtain_auth_token, name='api_token_auth'),
     # returns the standard Django views for authentication of the DRF

--- a/epilepsy12/urls.py
+++ b/epilepsy12/urls.py
@@ -1,5 +1,6 @@
 from . import views
 from .view_folder import *
+from .views import RegisterCase
 from django.urls import path
 from rest_framework import routers
 from rest_framework.authtoken.views import obtain_auth_token
@@ -24,6 +25,7 @@ router.register(r'antiepilepsymedicine', views.AntiEpilepsyMedicineViewSet)
 router.register(r'site', views.SiteViewSet)
 router.register(r'hospitaltrust', views.HospitalTrustViewSet)
 router.register(r'keyword', views.KeywordViewSet)
+router.register(r'auditprogress', views.AuditProgressViewSet)
 
 urlpatterns = [
     path("favicon", views.favicon),
@@ -389,8 +391,11 @@ htmx_paths = [
 drf_routes = [
     # rest framework paths
     path('api/v1/', include(router.urls)),
-    path('api-token-auth/', obtain_auth_token, name='api_token_auth'),
-    path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+    path('api/v1/register_case', view=RegisterCase.as_view()),
+    # returns a Token (OAuth2 key: Token) against email and password of existing user
+    path('api/v1/api-token-auth/', obtain_auth_token, name='api_token_auth'),
+    # returns the standard Django views for authentication of the DRF
+    path('api/v1/api-auth/', include('rest_framework.urls', namespace='rest_framework')),
 ]
 
 

--- a/epilepsy12/view_folder/case_views.py
+++ b/epilepsy12/view_folder/case_views.py
@@ -356,7 +356,7 @@ def update_case(request, hospital_id, case_id):
 def delete_case(request, hospital_id, case_id):
     case = get_object_or_404(Case, id=case_id)
     case.delete()
-    return redirect('cases')
+    return redirect('cases', hospital_id=hospital_id)
 
 
 @login_required

--- a/epilepsy12/views.py
+++ b/epilepsy12/views.py
@@ -496,7 +496,7 @@ class CaseViewSet(viewsets.ModelViewSet):
 
 class RegistrationViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows registrations in Epilepsy12 to be viewed or edited.
     """
     queryset = Registration.objects.all().order_by('-registration_date')
     serializer_class = RegistrationSerializer
@@ -505,7 +505,7 @@ class RegistrationViewSet(viewsets.ModelViewSet):
 
 class FirstPaediatricAssessmentViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows details relating to the first paediatric assessment to be viewed or edited.
     """
     queryset = FirstPaediatricAssessment.objects.all()
     serializer_class = FirstPaediatricAssessmentSerializer
@@ -514,7 +514,7 @@ class FirstPaediatricAssessmentViewSet(viewsets.ModelViewSet):
 
 class EpilepsyContextViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows children's epilepsy risk factors to be viewed or edited.
     """
     queryset = EpilepsyContext.objects.all()
     serializer_class = EpilepsyContextSerializer
@@ -523,7 +523,7 @@ class EpilepsyContextViewSet(viewsets.ModelViewSet):
 
 class MultiaxialDiagnosisViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows a multiaxial diagnosis of the child's epilepsy to be viewed or edited.
     """
     queryset = MultiaxialDiagnosis.objects.all()
     serializer_class = MultiaxialDiagnosisSerializer
@@ -532,7 +532,7 @@ class MultiaxialDiagnosisViewSet(viewsets.ModelViewSet):
 
 class EpisodeViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows each seizure episode to be viewed or edited.
     """
     queryset = Episode.objects.all()
     serializer_class = EpisodeSerializer
@@ -541,7 +541,7 @@ class EpisodeViewSet(viewsets.ModelViewSet):
 
 class SyndromeViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows each syndrome to be viewed or edited.
     """
     queryset = Syndrome.objects.all()
     serializer_class = SyndromeSerializer
@@ -550,7 +550,7 @@ class SyndromeViewSet(viewsets.ModelViewSet):
 
 class ComorbidityViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows each comorbidity to be viewed or edited.
     """
     queryset = Comorbidity.objects.all()
     serializer_class = ComorbiditySerializer
@@ -559,7 +559,7 @@ class ComorbidityViewSet(viewsets.ModelViewSet):
 
 class InvestigationsViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows a panel of investigations for each registration to be viewed or edited.
     """
     queryset = Investigations.objects.all()
     serializer_class = InvestigationsSerializer
@@ -568,7 +568,7 @@ class InvestigationsViewSet(viewsets.ModelViewSet):
 
 class AssessmentViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows key Epilepsy12 milestones to be viewed or edited.
     """
     queryset = Assessment.objects.all()
     serializer_class = AssessmentSerializer
@@ -577,7 +577,7 @@ class AssessmentViewSet(viewsets.ModelViewSet):
 
 class ManagementViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows management plans (including medications and individualised care plans) to be viewed or edited.
     """
     queryset = Management.objects.all()
     serializer_class = ManagementSerializer
@@ -586,7 +586,7 @@ class ManagementViewSet(viewsets.ModelViewSet):
 
 class AntiEpilepsyMedicineViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows antiseizure medicines to be viewed or edited.
     """
     queryset = AntiEpilepsyMedicine.objects.all()
     serializer_class = AntiEpilepsyMedicineSerializer
@@ -595,7 +595,7 @@ class AntiEpilepsyMedicineViewSet(viewsets.ModelViewSet):
 
 class SiteViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows allocated sites to be viewed or edited.
     """
     queryset = Site.objects.all()
     serializer_class = SiteSerializer
@@ -604,7 +604,7 @@ class SiteViewSet(viewsets.ModelViewSet):
 
 class HospitalTrustViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows a list of hospital and community trusts to be viewed or edited.
     """
     queryset = HospitalTrust.objects.all()
     serializer_class = HospitalTrustSerializer
@@ -613,7 +613,7 @@ class HospitalTrustViewSet(viewsets.ModelViewSet):
 
 class KeywordViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows epilepsy semiology keywords to be viewed or edited.
     """
     queryset = Keyword.objects.all()
     serializer_class = KeywordSerializer
@@ -622,7 +622,7 @@ class KeywordViewSet(viewsets.ModelViewSet):
 
 class AuditProgressViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows a child's progress through audit completion to be viewed or edited.
     """
     queryset = AuditProgress.objects.all()
     serializer_class = AuditProgressSerializer
@@ -632,7 +632,7 @@ class AuditProgressViewSet(viewsets.ModelViewSet):
 
 
 class RegisterCase(APIView):
-    permission_classes = (permissions.AllowAny,)
+    permission_classes = (permissions.IsAuthenticated,)
     serializer = RegistrationSerializer
 
     def post(self, request):
@@ -728,4 +728,76 @@ class RegisterCase(APIView):
                 },
                 status=status.HTTP_200_OK
             )
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class CaseHospitalTrust(APIView):
+    permission_classes = (permissions.IsAuthenticated,)
+    serializer = CaseSerializer
+
+    def post(self, request):
+        # params
+        nhs_number = request.POST.get('nhs_number')
+        organisationID = request.POST.get('OrganisationID')
+        case_params = {
+            'nhs_number': request.POST.get('nhs_number'),
+            'first_name': request.POST.get('first_name'),
+            'surname': request.POST.get('surname'),
+            'date_of_birth': request.POST.get('date_of_birth'),
+            'sex': request.POST.get('sex'),
+            'ethnicity': request.POST.get('ethnicity'),
+        }
+        if nhs_number:
+            if Case.objects.filter(nhs_number=nhs_number).exists():
+                case = Case.objects.filter(nhs_number=nhs_number).get()
+                raise serializers.ValidationError(
+                    {'Case': f'{case} already exists. No record created.'})
+            else:
+                serializer = self.serializer(data=case_params)
+
+                if organisationID:
+
+                    if serializer.is_valid(raise_exception=True):
+                        if HospitalTrust.objects.filter(OrganisationID=request.POST.get('OrganisationID')).exists():
+                            hospital_trust = HospitalTrust.objects.filter(
+                                OrganisationID=request.POST.get('OrganisationID')).get()
+                        else:
+                            raise serializers.ValidationError(
+                                {'Case': f'Organisation {organisationID} does not exist. No record saved.'})
+
+                        try:
+                            case = Case.objects.create(**case_params)
+                        except Exception as error:
+                            raise serializers.ValidationError(
+                                {'Case': error})
+
+                        print(f'{case} created')
+
+                        try:
+                            Site.objects.create(
+                                case=case,
+                                hospital_trust=hospital_trust,
+                                site_is_actively_involved_in_epilepsy_care=True,
+                                site_is_primary_centre_of_epilepsy_care=True
+                            )
+                        except Exception as error:
+                            case.delete()
+                            raise serializers.ValidationError(
+                                {'Case': error})
+
+                        return Response(
+                            {
+                                "status": "success",
+                                "data": case_params
+                            },
+                            status=status.HTTP_200_OK
+                        )
+
+                else:
+                    raise serializers.ValidationError(
+                        {'Case': f'OrganisationID Not supplied. No record created.'})
+        else:
+            raise serializers.ValidationError(
+                {'Case': f'NHS number not supplied. No record created.'})
+
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/rcpch-audit-engine/settings.py
+++ b/rcpch-audit-engine/settings.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = [
     # third party
     'widget_tweaks',
     'django_htmx',
+    'rest_framework.authtoken'
 ]
 
 MIDDLEWARE = [
@@ -188,6 +189,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.BasicAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',


### PR DESCRIPTION
This marks addition of the API for the key routes and closes #170
It adds 2 custom routes:
1. /add_case_to_hospital_list: a route to create a new child associated with a lead hospital
2. /register_case: registers an existing child in the audit by accepting eligibility, allocating lead hospital and setting date of first paediatric assessment
It also tidies the drf model lists