### PR TITLE
Removing front page text as moved into docs

### DIFF
--- a/static/styles/nav.css
+++ b/static/styles/nav.css
@@ -29,17 +29,19 @@
   margin: 0px;
 }
 
-.ui.secondary.pointing.menu .item {
-  line-height: 1.5rem;
+.ui.secondary.pointing.menu .item,
+.ui.secondary.pointing.menu .active.item {
+  border-bottom: 5px solid transparent;
 }
 
 .ui.secondary.pointing.menu .item:hover {
-  border-color: var(--rcpch_light_blue);
-  border-width: 5px;
+  /* border-color: var(--rcpch_light_blue);
+  border-width: 5px; */
+  border-bottom: 5px solid var(--rcpch_light_blue);
 }
 
 .ui.secondary.pointing.menu .active.item {
-  /* color: var(--rcpch_strong_blue); */
+  color: var(--rcpch_strong_blue);
   border-width: 5px;
   line-height: 1.125rem;
   border-color: var(--rcpch_strong_blue);
@@ -48,10 +50,6 @@
 
 .ui.secondary.pointing.menu .active.item:hover {
   border-color: var(--rcpch_light_blue)
-}
-
-.ui.secondary.pointing.menu a.item:hover {
-  line-height: 1.1rem;  
 }
 
 

--- a/static/styles/nav.css
+++ b/static/styles/nav.css
@@ -49,7 +49,8 @@
 }
 
 .ui.secondary.pointing.menu .active.item:hover {
-  border-color: var(--rcpch_light_blue)
+  border-color: var(--rcpch_light_blue);
+  color: var(--rcpch_strong_blue);
 }
 
 

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -116,7 +116,8 @@ ul {
   color: pink;
 }
 
-/* hero updated */
+/* hero */
+
 .ui.center.aligned.segment.rcpch_masthead {
   padding: 4em 0em;
   background: linear-gradient( rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5) ), url('images/blue-wallpaper-wheel.png');
@@ -124,52 +125,30 @@ ul {
   background-size: cover;
 }
 
+.rcpch_masthead>div.row>div>img.epilepsy12_logo {
+  margin-top: 4vw;
+  max-width: 60%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .masthead_text_row {
   padding-top: 1em;
 }
 
-.masthead_text_row>div>* {
+.masthead_text_row>div.masthead_text>* {
   color: var(--rcpch_white);
   font-family: var(--rcpch_standard_font);
+  font-weight: 900;
 }
 
-/* hero */
-
-.ui.fluid.container.hero_container {
-  padding-top: 1rem;
-  height: 40vh;
-  background: linear-gradient( rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5) ), url('images/blue-wallpaper-wheel.png');
-  background-repeat: no-repeat;
-  background-size: cover;
-}
-
-.rcpch_hero {
-  position: relative;
-  text-align: center;
-}
-
-.rcpch_hero_wallpaper > .row {
-  height: 100%;
-}
-
-.epilepsy12_logo {
-  margin-top: 4vw;
-  max-width: 300px;
-}
-
-.rcpch_hero > .row > div > * {
-  color: var(--rcpch_white);
-  text-align: center;
-  font-family: var(--rcpch_standard_font);
-}
-
-.rcpch_hero > .row > div > h1 {
+.masthead_text_row>div>h1 {
   font-size: 3em;
 }
-
-.rcpch_hero > .row > div > h2 {
+.masthead_text_row>div>h2 {
   font-size: 1.5em;
 }
+
 
 
 /* links */

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -116,6 +116,22 @@ ul {
   color: pink;
 }
 
+/* hero updated */
+.ui.center.aligned.segment.rcpch_masthead {
+  padding: 4em 0em;
+  background: linear-gradient( rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5) ), url('images/blue-wallpaper-wheel.png');
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+.masthead_text_row {
+  padding-top: 1em;
+}
+
+.masthead_text_row>div>* {
+  color: var(--rcpch_white);
+  font-family: var(--rcpch_standard_font);
+}
 
 /* hero */
 

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -124,7 +124,7 @@ ul {
   height: 40vh;
   background: linear-gradient( rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5) ), url('images/blue-wallpaper-wheel.png');
   background-repeat: no-repeat;
-  background-size: 100% auto;
+  background-size: cover;
 }
 
 .rcpch_hero {

--- a/templates/epilepsy12/docs.html
+++ b/templates/epilepsy12/docs.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
 {% load static %}
 {% block content %}
-    <div class='ui container'>
-        <h1>Docs will go here...</h1>
-    </div>
+    
+        <div class="ui embed">
+        <iframe src='https://epilepsy12docs.rcpch.tech/'></iframe>
+        </div>
+ 
 {% endblock %}

--- a/templates/epilepsy12/epilepsy12index.html
+++ b/templates/epilepsy12/epilepsy12index.html
@@ -71,26 +71,7 @@
                 Epilepsy12 is delivered by the Royal College of Paediatrics and Child Health (RCPCH). The RCPCH mission
                 is to transform child health through knowledge, innovation and expertise.
             </p>
-            <h3>National Data Opt Out Implementation (England only)</h3>
-            <p>
-                The Epilepsy12 audit is now exempt from the NHS National Data Opt-Out. Healthcare providers in England
-                no longer need to screen patients against the opt-out list prior to entering their data. Patients can
-                still opt out of Epilepsy12 specifically by contacting their clinical team. You can indicate this in the
-                first year of care form and the record will be deleted.
-                Please take a look at our <a
-                    href="https://www.rcpch.ac.uk/work-we-do/quality-improvement-patient-safety/epilepsy12-audit/methodology-data-submission">methodology
-                    and data submission</a> page for more information.
-            </p>
-            <h3>Childhood epilepsy</h3>
-            <p>
-                Epilepsy affects around one in every 200 children and young people in the UK (aged 18 and under). The
-                condition is one of the most common significant long-term health conditions of childhood. Epilepsy can
-                have a huge impact on children and families. Epileptic seizures can happen in any part of the brain
-                cortex and what happens depends on where in the brain the seizure is happening. Seizures can be
-                distressing but it's not just the seizures that are the problem. Children and young people may
-                experience issues with learning, behaviour and emotions. That's why children and parents need support
-                and guidance from healthcare professionals throughout the stages of diagnosis and treatment.
-            </p>
+            
             <h3>About Epilepsy12</h3>
             <p>
                 Epilepsy12 (The UK collaborative clinical audit of health care for children and young people with

--- a/templates/epilepsy12/epilepsy12index.html
+++ b/templates/epilepsy12/epilepsy12index.html
@@ -1,89 +1,124 @@
 {% extends "base.html" %}
 {% load static %}
 {% block content %}
-    <div class="ui fluid container hero_container">
-        <div class="ui middle aligned six column centered grid rcpch_hero">
-            <div class="four wide column centered">
-                <img src="{% static 'images/EP12_ID_COLOUR_Digital_full_screen.png' %}"
-                     class='ui image epilepsy12_logo'/>
-            </div>
-            <div class="row">
-                <div class="ten wide column centered">
-                    <h1 class='ui header content'>The UK national audit for childhood epilepsies.</h1>
-                    <h2 class='ui header'>
-                        A platform for clinicians and families, built by the Royal College of Paediatrics and Child Health.
-                    </h2>
-                </div>
+
+<div class="ui center aligned segment rcpch_masthead">
+    <div class="row">
+        <div class="ui centered text container">
+            <img src="{% static 'images/EP12_ID_COLOUR_Digital_full_screen.png' %}" 
+            class='ui image epilepsy12_logo' />
+        </div>
+    </div>
+    <div class="row masthead_text_row">
+        <div class="ui centered text container">
+            <h1 class="">The UK national audit for childhood epilepsies.</h1>
+            <h2 class=''>
+                A platform for clinicians and families, built by the Royal College of Paediatrics and Child Health.
+            </h2>
+        </div>
+    </div>
+</div>
+
+<br><br>
+<div class="ui fluid container hero_container">
+    <div class="ui middle aligned six column centered grid rcpch_hero">
+        <div class="four wide column centered">
+            <img src="{% static 'images/EP12_ID_COLOUR_Digital_full_screen.png' %}" class='ui image epilepsy12_logo' />
+        </div>
+        <div class="row">
+            <div class="ten wide column centered">
+                <h1 class='ui header content'>The UK national audit for childhood epilepsies.</h1>
+                <h2 class='ui header'>
+                    A platform for clinicians and families, built by the Royal College of Paediatrics and Child Health.
+                </h2>
             </div>
         </div>
     </div>
+</div>
+<div class='ui fluid rcpch container'>
     <div class='ui fluid rcpch container'>
-        <div class='ui fluid rcpch container'>
-            <div class="ui two column stackable grid">
-                <div class="column">
-                    <div class="ui raised rcpch_dark_blue card">
-                        <div class="content">
-                            <div class="header">Community and hospital</div>
-                            <div class="meta">
-                                <span class="category">Clinician access</span>
-                            </div>
-                            <div class="description">
-                                <p></p>
-                            </div>
-                            <div class="center aligned image">
-                                <i class="huge hospital outline icon"></i>
-                            </div>
+        <div class="ui two column stackable grid">
+            <div class="column">
+                <div class="ui raised rcpch_dark_blue card">
+                    <div class="content">
+                        <div class="header">Community and hospital</div>
+                        <div class="meta">
+                            <span class="category">Clinician access</span>
                         </div>
-                        <div class="extra content">
-                            <a href={% url 'hospital_reports' %}>
-                                <button class="ui fluid rcpch_primary button">Select</button>
-                            </a>
+                        <div class="description">
+                            <p></p>
+                        </div>
+                        <div class="center aligned image">
+                            <i class="huge hospital outline icon"></i>
                         </div>
                     </div>
-                </div>
-                <div class="column">
-                    <div class="ui rcpch_dark_blue raised card">
-                        <div class="content">
-                            <div class="header">Children and families</div>
-                            <div class="meta">
-                                <span class="category">Patient access</span>
-                            </div>
-                            <div class="description">
-                                <p></p>
-                            </div>
-                            <div class="center aligned image">
-                                <i class="huge white child icon"></i>
-                            </div>
-                        </div>
-                        <div class="extra content">
-                            <a href={% url 'patient' %}>
-                                <button class="ui fluid rcpch_primary button">Select</button>
-                            </a>
-                        </div>
+                    <div class="extra content">
+                        <a href={% url 'hospital_reports' %}>
+                            <button class="ui fluid rcpch_primary button">Select</button>
+                        </a>
                     </div>
                 </div>
             </div>
-            <div class="ui segment">
-                <h2>Welcome to the Epilepsy12 data platform</h2>
-                <p>
-                    Epilepsy12 is delivered by the Royal College of Paediatrics and Child Health (RCPCH). The RCPCH mission is to transform child health through knowledge, innovation and expertise.
-                </p>
-                <h3>National Data Opt Out Implementation (England only)</h3>
-                <p>
-                    The Epilepsy12 audit is now exempt from the NHS National Data Opt-Out. Healthcare providers in England no longer need to screen patients against the opt-out list prior to entering their data. Patients can still opt out of Epilepsy12 specifically by contacting their clinical team. You can indicate this in the first year of care form and the record will be deleted.
-                    Please take a look at our <a href="https://www.rcpch.ac.uk/work-we-do/quality-improvement-patient-safety/epilepsy12-audit/methodology-data-submission">methodology and data submission</a> page for more information.
-                </p>
-                <h3>Childhood epilepsy</h3>
-                <p>
-                    Epilepsy affects around one in every 200 children and young people in the UK (aged 18 and under). The condition is one of the most common significant long-term health conditions of childhood. Epilepsy can have a huge impact on children and families. Epileptic seizures can happen in any part of the brain cortex and what happens depends on where in the brain the seizure is happening. Seizures can be distressing but it's not just the seizures that are the problem. Children and young people may experience issues with learning, behaviour and emotions. That's why children and parents need support and guidance from healthcare professionals throughout the stages of diagnosis and treatment.
-                </p>
-                <h3>About Epilepsy12</h3>
-                <p>
-                    Epilepsy12 (The UK collaborative clinical audit of health care for children and young people with suspected epileptic seizures) is a national clinical audit established in 2009 and has the continued aim of helping epilepsy services, and those who commission health services, to measure and improve the quality of care for children and young people with seizures and epilepsies. As per rounds 1 - 3 of the audit the audit is overseen by a project board and a dedicated project team within the RCPCH.
-                </p>
-                <p>
-                    You can contact the team at: epilepsy12@rcpch.ac.uk or on 020 7092 6157/6056. Dr Colin Dunkley, Consultant Paediatrician, is the current clinical lead for Epilepsy12.
-                </p>
+            <div class="column">
+                <div class="ui rcpch_dark_blue raised card">
+                    <div class="content">
+                        <div class="header">Children and families</div>
+                        <div class="meta">
+                            <span class="category">Patient access</span>
+                        </div>
+                        <div class="description">
+                            <p></p>
+                        </div>
+                        <div class="center aligned image">
+                            <i class="huge white child icon"></i>
+                        </div>
+                    </div>
+                    <div class="extra content">
+                        <a href={% url 'patient' %}>
+                            <button class="ui fluid rcpch_primary button">Select</button>
+                        </a>
+                    </div>
+                </div>
             </div>
         </div>
+        <div class="ui segment">
+            <h2>Welcome to the Epilepsy12 data platform</h2>
+            <p>
+                Epilepsy12 is delivered by the Royal College of Paediatrics and Child Health (RCPCH). The RCPCH mission
+                is to transform child health through knowledge, innovation and expertise.
+            </p>
+            <h3>National Data Opt Out Implementation (England only)</h3>
+            <p>
+                The Epilepsy12 audit is now exempt from the NHS National Data Opt-Out. Healthcare providers in England
+                no longer need to screen patients against the opt-out list prior to entering their data. Patients can
+                still opt out of Epilepsy12 specifically by contacting their clinical team. You can indicate this in the
+                first year of care form and the record will be deleted.
+                Please take a look at our <a
+                    href="https://www.rcpch.ac.uk/work-we-do/quality-improvement-patient-safety/epilepsy12-audit/methodology-data-submission">methodology
+                    and data submission</a> page for more information.
+            </p>
+            <h3>Childhood epilepsy</h3>
+            <p>
+                Epilepsy affects around one in every 200 children and young people in the UK (aged 18 and under). The
+                condition is one of the most common significant long-term health conditions of childhood. Epilepsy can
+                have a huge impact on children and families. Epileptic seizures can happen in any part of the brain
+                cortex and what happens depends on where in the brain the seizure is happening. Seizures can be
+                distressing but it's not just the seizures that are the problem. Children and young people may
+                experience issues with learning, behaviour and emotions. That's why children and parents need support
+                and guidance from healthcare professionals throughout the stages of diagnosis and treatment.
+            </p>
+            <h3>About Epilepsy12</h3>
+            <p>
+                Epilepsy12 (The UK collaborative clinical audit of health care for children and young people with
+                suspected epileptic seizures) is a national clinical audit established in 2009 and has the continued aim
+                of helping epilepsy services, and those who commission health services, to measure and improve the
+                quality of care for children and young people with seizures and epilepsies. As per rounds 1 - 3 of the
+                audit the audit is overseen by a project board and a dedicated project team within the RCPCH.
+            </p>
+            <p>
+                You can contact the team at: epilepsy12@rcpch.ac.uk or on 020 7092 6157/6056. Dr Colin Dunkley,
+                Consultant Paediatrician, is the current clinical lead for Epilepsy12.
+            </p>
+        </div>
+    </div>
     {% endblock %}

--- a/templates/epilepsy12/epilepsy12index.html
+++ b/templates/epilepsy12/epilepsy12index.html
@@ -10,7 +10,7 @@
         </div>
     </div>
     <div class="row masthead_text_row">
-        <div class="ui centered text container">
+        <div class="masthead_text">
             <h1 class="">The UK national audit for childhood epilepsies.</h1>
             <h2 class=''>
                 A platform for clinicians and families, built by the Royal College of Paediatrics and Child Health.
@@ -19,22 +19,6 @@
     </div>
 </div>
 
-<br><br>
-<div class="ui fluid container hero_container">
-    <div class="ui middle aligned six column centered grid rcpch_hero">
-        <div class="four wide column centered">
-            <img src="{% static 'images/EP12_ID_COLOUR_Digital_full_screen.png' %}" class='ui image epilepsy12_logo' />
-        </div>
-        <div class="row">
-            <div class="ten wide column centered">
-                <h1 class='ui header content'>The UK national audit for childhood epilepsies.</h1>
-                <h2 class='ui header'>
-                    A platform for clinicians and families, built by the Royal College of Paediatrics and Child Health.
-                </h2>
-            </div>
-        </div>
-    </div>
-</div>
 <div class='ui fluid rcpch container'>
     <div class='ui fluid rcpch container'>
         <div class="ui two column stackable grid">


### PR DESCRIPTION
Just removing front page text as moved into docs site (with E12 PR [#7](https://github.com/rcpch/epilepsy12-documentation/pull/7))

Fixes #278 