### PR TITLE
Change-group

### DIFF
--- a/epilepsy12/common_view_functions/__init__.py
+++ b/epilepsy12/common_view_functions/__init__.py
@@ -21,3 +21,4 @@ from .report_queries import (
     get_all_open_uk_regions,
 )
 from .sanction_user_access import return_selected_organisation, sanction_user
+from .group_for_group import group_for_role

--- a/epilepsy12/common_view_functions/group_for_group.py
+++ b/epilepsy12/common_view_functions/group_for_group.py
@@ -1,0 +1,55 @@
+# python
+# django
+from django.contrib.auth.models import Group
+
+# rcpch
+from epilepsy12.constants.user_types import (
+    ROLES,
+    TITLES,
+    AUDIT_CENTRE_LEAD_CLINICIAN,
+    TRUST_AUDIT_TEAM_FULL_ACCESS,
+    AUDIT_CENTRE_CLINICIAN,
+    TRUST_AUDIT_TEAM_EDIT_ACCESS,
+    AUDIT_CENTRE_ADMINISTRATOR,
+    TRUST_AUDIT_TEAM_EDIT_ACCESS,
+    RCPCH_AUDIT_LEAD,
+    EPILEPSY12_AUDIT_TEAM_FULL_ACCESS,
+    RCPCH_AUDIT_ANALYST,
+    EPILEPSY12_AUDIT_TEAM_EDIT_ACCESS,
+    RCPCH_AUDIT_ADMINISTRATOR,
+    EPILEPSY12_AUDIT_TEAM_VIEW_ONLY,
+    RCPCH_AUDIT_PATIENT_FAMILY,
+    PATIENT_ACCESS,
+    TRUST_AUDIT_TEAM_VIEW_ONLY,
+    AUDIT_CENTRE_MANAGER,
+)
+
+
+def group_for_role(role_key):
+    """
+    Returns group for a role key
+    """
+    """
+    Allocate Groups - the groups already have permissions allocated
+    """
+    if role_key == AUDIT_CENTRE_LEAD_CLINICIAN:
+        group = Group.objects.get(name=TRUST_AUDIT_TEAM_FULL_ACCESS)
+    elif role_key == AUDIT_CENTRE_CLINICIAN:
+        group = Group.objects.get(name=TRUST_AUDIT_TEAM_EDIT_ACCESS)
+    elif role_key == AUDIT_CENTRE_ADMINISTRATOR:
+        group = Group.objects.get(name=TRUST_AUDIT_TEAM_VIEW_ONLY)
+    elif role_key == AUDIT_CENTRE_MANAGER:
+        group = Group.objects.get(name=TRUST_AUDIT_TEAM_VIEW_ONLY)
+    elif role_key == RCPCH_AUDIT_LEAD:
+        group = Group.objects.get(name=EPILEPSY12_AUDIT_TEAM_FULL_ACCESS)
+    elif role_key == RCPCH_AUDIT_ANALYST:
+        group = Group.objects.get(name=EPILEPSY12_AUDIT_TEAM_EDIT_ACCESS)
+    elif role_key == RCPCH_AUDIT_ADMINISTRATOR:
+        group = Group.objects.get(name=EPILEPSY12_AUDIT_TEAM_VIEW_ONLY)
+    elif role_key == RCPCH_AUDIT_PATIENT_FAMILY:
+        group = Group.objects.get(name=PATIENT_ACCESS)
+    else:
+        # no group
+        group = Group.objects.get(name=TRUST_AUDIT_TEAM_VIEW_ONLY)
+
+    return group

--- a/epilepsy12/constants/user_types.py
+++ b/epilepsy12/constants/user_types.py
@@ -6,9 +6,9 @@
 # AUDIT_ADMINISTRATOR = 6
 
 VIEW_PREFERENCES = (
-    (0, 'organisation'),
-    (1, 'trust'),
-    (2, 'national'),
+    (0, "organisation"),
+    (1, "trust"),
+    (2, "national"),
 )
 
 AUDIT_CENTRE_LEAD_CLINICIAN = 1
@@ -21,14 +21,27 @@ RCPCH_AUDIT_ADMINISTRATOR = 6
 RCPCH_AUDIT_PATIENT_FAMILY = 7
 
 ROLES = (
-    (AUDIT_CENTRE_LEAD_CLINICIAN, 'Audit Centre Lead Clinician'),
-    (AUDIT_CENTRE_CLINICIAN, 'Audit Centre Clinician'),
-    (AUDIT_CENTRE_ADMINISTRATOR, 'Audit Centre Administrator'),
-    (AUDIT_CENTRE_MANAGER, 'Audit Centre Manager'),
-    (RCPCH_AUDIT_LEAD, 'RCPCH Audit Lead'),
-    (RCPCH_AUDIT_ANALYST, 'RCPCH Audit Analyst'),
-    (RCPCH_AUDIT_ADMINISTRATOR, 'RCPCH Audit Administrator'),
-    (RCPCH_AUDIT_PATIENT_FAMILY, 'RCPCH Audit Children and Family'),
+    (AUDIT_CENTRE_LEAD_CLINICIAN, "Audit Centre Lead Clinician"),
+    (AUDIT_CENTRE_CLINICIAN, "Audit Centre Clinician"),
+    (AUDIT_CENTRE_ADMINISTRATOR, "Audit Centre Administrator"),
+    (AUDIT_CENTRE_MANAGER, "Audit Centre Manager"),
+    (RCPCH_AUDIT_LEAD, "RCPCH Audit Lead"),
+    (RCPCH_AUDIT_ANALYST, "RCPCH Audit Analyst"),
+    (RCPCH_AUDIT_ADMINISTRATOR, "RCPCH Audit Administrator"),
+    (RCPCH_AUDIT_PATIENT_FAMILY, "RCPCH Audit Children and Family"),
+)
+
+AUDIT_CENTRE_ROLES = (
+    (AUDIT_CENTRE_LEAD_CLINICIAN, "Audit Centre Lead Clinician"),
+    (AUDIT_CENTRE_CLINICIAN, "Audit Centre Clinician"),
+    (AUDIT_CENTRE_ADMINISTRATOR, "Audit Centre Administrator"),
+    (AUDIT_CENTRE_MANAGER, "Audit Centre Manager"),
+)
+
+RCPCH_AUDIT_TEAM_ROLES = (
+    (RCPCH_AUDIT_LEAD, "RCPCH Audit Lead"),
+    (RCPCH_AUDIT_ANALYST, "RCPCH Audit Analyst"),
+    (RCPCH_AUDIT_ADMINISTRATOR, "RCPCH Audit Administrator"),
 )
 
 MR = 1
@@ -37,37 +50,31 @@ MS = 3
 DR = 4
 PROFESSOR = 5
 
-TITLES = (
-    (MR, "Mr"),
-    (MRS, "Mrs"),
-    (MS, "Ms"),
-    (DR, "Dr"),
-    (PROFESSOR, "Professor")
-)
+TITLES = ((MR, "Mr"), (MRS, "Mrs"), (MS, "Ms"), (DR, "Dr"), (PROFESSOR, "Professor"))
 
 """
 Groups
 """
 # logged in user can view all national data but not logs
-EPILEPSY12_AUDIT_TEAM_VIEW_ONLY = 'epilepsy12_audit_team_view_only'
+EPILEPSY12_AUDIT_TEAM_VIEW_ONLY = "epilepsy12_audit_team_view_only"
 
 # logged in user can edit but not delete national data. Cannot view or edit logs or permissions.
-EPILEPSY12_AUDIT_TEAM_EDIT_ACCESS = 'epilepsy12_audit_team_edit_access'
+EPILEPSY12_AUDIT_TEAM_EDIT_ACCESS = "epilepsy12_audit_team_edit_access"
 
 # logged in user access all areas: can create/update/delete any audit data, logs, epilepsy key words and organisation trusts, groups and permissions
-EPILEPSY12_AUDIT_TEAM_FULL_ACCESS = 'epilepsy12_audit_team_full_access'
+EPILEPSY12_AUDIT_TEAM_FULL_ACCESS = "epilepsy12_audit_team_full_access"
 
 # logged in user can view all data relating to their trust(s) but not logs
-TRUST_AUDIT_TEAM_VIEW_ONLY = 'trust_audit_team_view_only'
+TRUST_AUDIT_TEAM_VIEW_ONLY = "trust_audit_team_view_only"
 
 # logged in user can edit but not delete all data relating to their trust(s) but not view or edit logs, epilepsy key words and organisation trusts, groups and permissions
-TRUST_AUDIT_TEAM_EDIT_ACCESS = 'trust_audit_team_edit_access'
+TRUST_AUDIT_TEAM_EDIT_ACCESS = "trust_audit_team_edit_access"
 
 # logged in user can delete all data relating to their trust(s) but not view or edit logs, epilepsy key words and organisation trusts, groups and permissions
-TRUST_AUDIT_TEAM_FULL_ACCESS = 'trust_audit_team_full_access'
+TRUST_AUDIT_TEAM_FULL_ACCESS = "trust_audit_team_full_access"
 
 # logged in user can view their own audit data, consent to participation and remove that consent/opt out. Opting out would delete all data relating to them, except the epilepsy12 unique identifier
-PATIENT_ACCESS = 'patient_access'
+PATIENT_ACCESS = "patient_access"
 
 GROUPS = (
     EPILEPSY12_AUDIT_TEAM_VIEW_ONLY,
@@ -80,54 +87,74 @@ GROUPS = (
 )
 
 # Case
-CAN_LOCK_CHILD_CASE_DATA_FROM_EDITING = ('can_lock_child_case_data_from_editing',
-                                         'Can lock a child\'s record from editing.')
-CAN_UNLOCK_CHILD_CASE_DATA_FROM_EDITING = ('can_unlock_child_case_data_from_editing',
-                                           'Can unlock a child\'s record from editing.')
-CAN_OPT_OUT_CHILD_FROM_INCLUSION_IN_AUDIT = ('can_opt_out_child_from_inclusion_in_audit',
-                                             'Can sanction an opt out from participating in the audit. Note all the child\'s date except Epilepsy12 unique identifier are irretrievably deleted.')
+CAN_LOCK_CHILD_CASE_DATA_FROM_EDITING = (
+    "can_lock_child_case_data_from_editing",
+    "Can lock a child's record from editing.",
+)
+CAN_UNLOCK_CHILD_CASE_DATA_FROM_EDITING = (
+    "can_unlock_child_case_data_from_editing",
+    "Can unlock a child's record from editing.",
+)
+CAN_OPT_OUT_CHILD_FROM_INCLUSION_IN_AUDIT = (
+    "can_opt_out_child_from_inclusion_in_audit",
+    "Can sanction an opt out from participating in the audit. Note all the child's date except Epilepsy12 unique identifier are irretrievably deleted.",
+)
 
 # Registration
-CAN_APPROVE_ELIGIBILITY = ('can_approve_eligibility',
-                           'Can approve eligibility for Epilepsy12.')
-CAN_REMOVE_APPROVAL_OF_ELIGIBILITY = ('can_remove_approval_of_eligibility',
-                                      'Can remove approval of eligibiltiy for Epilepsy12.')
+CAN_APPROVE_ELIGIBILITY = (
+    "can_approve_eligibility",
+    "Can approve eligibility for Epilepsy12.",
+)
+CAN_REMOVE_APPROVAL_OF_ELIGIBILITY = (
+    "can_remove_approval_of_eligibility",
+    "Can remove approval of eligibiltiy for Epilepsy12.",
+)
 
-CAN_REGISTER_CHILD_IN_EPILEPSY12 = ('can_register_child_in_epilepsy12',
-                                    'Can register child in Epilepsy12. (A cohort number is automatically allocaeted)')
-CAN_UNREGISTER_CHILD_IN_EPILEPSY12 = ('can_unregister_child_in_epilepsy12',
-                                      'Can unregister a child in Epilepsy. Their record and previously entered data is untouched.')
+CAN_REGISTER_CHILD_IN_EPILEPSY12 = (
+    "can_register_child_in_epilepsy12",
+    "Can register child in Epilepsy12. (A cohort number is automatically allocaeted)",
+)
+CAN_UNREGISTER_CHILD_IN_EPILEPSY12 = (
+    "can_unregister_child_in_epilepsy12",
+    "Can unregister a child in Epilepsy. Their record and previously entered data is untouched.",
+)
 
-CAN_ALLOCATE_EPILEPSY12_LEAD_CENTRE = ('can_allocate_epilepsy12_lead_centre',
-                                       'Can allocate this child to any Epilepsy12 centre.')
+CAN_ALLOCATE_EPILEPSY12_LEAD_CENTRE = (
+    "can_allocate_epilepsy12_lead_centre",
+    "Can allocate this child to any Epilepsy12 centre.",
+)
 
-CAN_TRANSFER_EPILEPSY12_LEAD_CENTRE = ('can_transfer_epilepsy12_lead_centre',
-                                       'Can transfer this child to another Epilepsy12 centre.')
+CAN_TRANSFER_EPILEPSY12_LEAD_CENTRE = (
+    "can_transfer_epilepsy12_lead_centre",
+    "Can transfer this child to another Epilepsy12 centre.",
+)
 
-CAN_EDIT_EPILEPSY12_LEAD_CENTRE = ('can_edit_epilepsy12_lead_centre',
-                                   'Can edit this child\'s current Epilepsy12 lead centre.')
+CAN_EDIT_EPILEPSY12_LEAD_CENTRE = (
+    "can_edit_epilepsy12_lead_centre",
+    "Can edit this child's current Epilepsy12 lead centre.",
+)
 
-CAN_DELETE_EPILEPSY12_LEAD_CENTRE = ('can_delete_epilepsy12_lead_centre',
-                                     'Can delete Epilepsy12 lead centre.')
+CAN_DELETE_EPILEPSY12_LEAD_CENTRE = (
+    "can_delete_epilepsy12_lead_centre",
+    "Can delete Epilepsy12 lead centre.",
+)
 
-CAN_CONSENT_TO_AUDIT_PARTICIPATION = ('can_consent_to_audit_participation',
-                                      'Can consent to participating in Epilepsy12.')
+CAN_CONSENT_TO_AUDIT_PARTICIPATION = (
+    "can_consent_to_audit_participation",
+    "Can consent to participating in Epilepsy12.",
+)
 
 PERMISSIONS = (
-
     CAN_LOCK_CHILD_CASE_DATA_FROM_EDITING,
     CAN_UNLOCK_CHILD_CASE_DATA_FROM_EDITING,
     CAN_OPT_OUT_CHILD_FROM_INCLUSION_IN_AUDIT,
-
     CAN_APPROVE_ELIGIBILITY,
     CAN_REMOVE_APPROVAL_OF_ELIGIBILITY,
     CAN_REGISTER_CHILD_IN_EPILEPSY12,
     CAN_UNREGISTER_CHILD_IN_EPILEPSY12,
-
     CAN_EDIT_EPILEPSY12_LEAD_CENTRE,
     CAN_ALLOCATE_EPILEPSY12_LEAD_CENTRE,
     CAN_TRANSFER_EPILEPSY12_LEAD_CENTRE,
     CAN_DELETE_EPILEPSY12_LEAD_CENTRE,
-    CAN_CONSENT_TO_AUDIT_PARTICIPATION
-
+    CAN_CONSENT_TO_AUDIT_PARTICIPATION,
 )

--- a/epilepsy12/general_functions/__init__.py
+++ b/epilepsy12/general_functions/__init__.py
@@ -17,3 +17,4 @@ from .random_generator import *
 from .nhs_number import *
 from .ods_search import *
 from .calculate_kpi_average import *
+from .item_from_choice import *

--- a/epilepsy12/general_functions/item_from_choice.py
+++ b/epilepsy12/general_functions/item_from_choice.py
@@ -1,0 +1,5 @@
+def match_in_choice_key(choice, match):
+    for k, v in choice:
+        if k == match:
+            return True
+    return False

--- a/epilepsy12/view_folder/user_management_views.py
+++ b/epilepsy12/view_folder/user_management_views.py
@@ -6,7 +6,7 @@ from django.core.paginator import Paginator
 from django.contrib.auth import get_user_model
 from django.contrib import messages
 from django.http import HttpResponseForbidden, HttpResponse
-from django.core.mail import send_mail, BadHeaderError, EmailMessage
+from django.core.mail import send_mail, BadHeaderError
 
 from django.urls import reverse_lazy
 from django.contrib.auth.views import PasswordResetView
@@ -16,9 +16,10 @@ from django.utils.html import strip_tags
 from django_htmx.http import HttpResponseClientRedirect
 from ..models import Epilepsy12User, Organisation
 from epilepsy12.forms_folder.epilepsy12_user_form import Epilepsy12UserAdminCreationForm
-from ..general_functions import construct_confirm_email
+from ..general_functions import construct_confirm_email, match_in_choice_key
 from ..common_view_functions import group_for_role
 from ..decorator import user_may_view_this_organisation
+from ..constants import RCPCH_AUDIT_TEAM_ROLES, AUDIT_CENTRE_ROLES
 
 
 @user_may_view_this_organisation()
@@ -266,13 +267,20 @@ def create_epilepsy12_user(request, organisation_id, user_type):
         prepopulated_data = {
             "organisation_employer": organisation,
         }
-        form = Epilepsy12UserAdminCreationForm(initial=prepopulated_data)
+        form = Epilepsy12UserAdminCreationForm(
+            rcpch_organisation=user_type, initial=prepopulated_data
+        )
     elif user_type == "rcpch-staff":
         admin_title = "Add RCPCH Epilepsy12 staff member"
-        form = Epilepsy12UserAdminCreationForm(initial=None)
+        form = Epilepsy12UserAdminCreationForm(
+            rcpch_organisation=user_type, initial=None
+        )
 
     if request.method == "POST":
-        form = Epilepsy12UserAdminCreationForm(request.POST or None)
+        form = Epilepsy12UserAdminCreationForm(
+            user_type,
+            request.POST or None,
+        )
 
         if form.is_valid():
             # success message - return to user list
@@ -308,6 +316,7 @@ def create_epilepsy12_user(request, organisation_id, user_type):
         "form": form,
         "organisation_id": organisation_id,
         "admin_title": admin_title,
+        "user_type": user_type,
     }
 
     return render(
@@ -334,9 +343,15 @@ def edit_epilepsy12_user(request, organisation_id, epilepsy12_user_id):
         or request.user.is_rcpch_audit_team_member
     ):
         can_edit = True
+    if match_in_choice_key(AUDIT_CENTRE_ROLES, epilepsy12_user_to_edit.role):
+        user_type = "organisation-staff"
+    elif match_in_choice_key(RCPCH_AUDIT_TEAM_ROLES, epilepsy12_user_to_edit.role):
+        user_type = "rcpch-staff"
     if can_edit:
         form = Epilepsy12UserAdminCreationForm(
-            request.POST or None, instance=epilepsy12_user_to_edit
+            user_type,
+            request.POST or None,
+            instance=epilepsy12_user_to_edit,
         )
     else:
         return HttpResponseForbidden()
@@ -409,13 +424,20 @@ def edit_epilepsy12_user(request, organisation_id, epilepsy12_user_id):
 
     if epilepsy12_user_to_edit.is_staff:
         admin_title = "Edit RCPCH Epilepsy12 staff member"
+        user_type = "rcpch-staff"
     else:
         admin_title = "Edit Epilepsy12 User"
+        user_type = "organisation-staff"
 
     return render(
         request,
         template_name,
-        {"organisation_id": organisation_id, "form": form, "admin_title": admin_title},
+        {
+            "organisation_id": organisation_id,
+            "form": form,
+            "admin_title": admin_title,
+            "user_type": user_type,
+        },
     )
 
 

--- a/templates/registration/admin_create_user.html
+++ b/templates/registration/admin_create_user.html
@@ -78,9 +78,9 @@
           {% endif %}
           
 
-          <div class='three fields'>
+          <div class='two fields'>
 
-            {% if user.is_staff or user.is_superuser%}
+            {% if user_type == 'organisation-staff' %}
               <div class='eight wide field'>
                 <label for="{{form.is_rcpch_audit_team_member.id_for_label}}">RCPCH Audit Team member</label>
                 <div class='ui toggle checkbox' id='is_staff' _="js $('.ui.toggle.checkbox').checkbox(); end">


### PR DESCRIPTION
- create rcpch user only presented with rcpch roles
-create organisation user only presented with audit centre roles
- is_rcpch_audit_team_member toggle only available to clinicians
- set is_staff and is_rcpch_team_member to true for all rcpch staff, remove allocation to any organisation
- form titles/buttons to reflect user-type