### PR TITLE
Adds button for jumping to Individual Measures as per # 648

### DIFF
--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -1635,6 +1635,11 @@ a.ui.button {
   color: var(--rcpch_white);
 }
 
+.all-kpis-header {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .ui.bottom.attached.rcpch_footer.message {
   /* margin-top: -1em; */
   border-radius: 0%;

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -1614,10 +1614,13 @@ a.ui.button {
   border-radius: 0%;
   border-width: medium;
   border-color: var(--rcpch_purple);
+  display: flex;
+  justify-content: flex-end;
 }
 
 .ui.top.attached.rcpch_purple.clearing.segment > h5 {
   color: white;
+  font-size: large;
 }
 
 .ui.raised.attached.segment {

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -702,6 +702,20 @@ div.ui.card > div.content > div.organisation_address_container {
   border-color: var(--rcpch_light_blue);
   font-weight: 400;
 }
+
+.ui.rcpch_primary.button.jump {
+  margin: 5px;
+  width: 130.23px;
+  height: 25.98px;
+  font-size: .85714286rem;
+  white-space: normal;
+}
+
+.topbar {
+  display: flex !important;
+  justify-content: space-between;
+}
+
 .ui.rcpch_info.button {
   border-radius: 0% !important;
   color: black;
@@ -895,6 +909,11 @@ a.ui.button {
   color: white;
   background-color: var(--rcpch_light_blue);
   margin: 5px;
+}
+
+.topbar > .ui.rcpch_light_blue.label {
+  margin:0%;
+  font-size: medium;
 }
 
 .ui.rcpch_purple.label {

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -1600,6 +1600,8 @@ a.ui.button {
   border-radius: 0%;
   border-width: medium;
   border-color: var(--rcpch_dark_blue);
+  display: flex;
+  justify-content: flex-end;
 }
 
 .ui.top.attached.rcpch_dark_blue.clearing.segment > h5 {

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -906,14 +906,15 @@ a.ui.button {
 
 .ui.rcpch_light_blue.label {
   border-radius: 0% !important;
-  color: white;
-  background-color: var(--rcpch_light_blue);
+  color: black;
+  background-color: white;
   margin: 5px;
+  font-family: 'Montserrat-Bold';
+  font-size: large;
 }
 
 .topbar > .ui.rcpch_light_blue.label {
   margin:0%;
-  font-size: medium;
 }
 
 .ui.rcpch_purple.label {

--- a/templates/epilepsy12/partials/kpis/kpis.html
+++ b/templates/epilepsy12/partials/kpis/kpis.html
@@ -25,18 +25,21 @@ will be persisted and run as a cron job once a day.
                     </p>
                     
                 </div>
-                {% if not open %}
-                    <!-- anyone can refresh and rerun aggregations that is not a member of the public  -->
-                    <button 
-                        class='ui right floated rcpch_primary button'
-                        hx-get="{% url 'selected_trust_kpis' organisation_id=organisation.pk access='private' %}"
-                        name="refresh" 
-                        hx-trigger="click"
-                        >
-                        Refresh
-                        <i class="htmx-indicator spinner loading icon"></i>
-                    </button>
-                {% endif %}
+                <div class="all-kpis-header">
+                    <button class='ui right floated rcpch_primary button' _="on click go to the top of #selected_trust_select_kpi_marker">Jump to Individual Measures</button>
+                    {% if not open %}
+                        <!-- anyone can refresh and rerun aggregations that is not a member of the public  -->
+                        <button 
+                            class='ui right floated rcpch_primary button'
+                            hx-get="{% url 'selected_trust_kpis' organisation_id=organisation.pk access='private' %}"
+                            name="refresh" 
+                            hx-trigger="click"
+                            >
+                            Refresh
+                            <i class="htmx-indicator spinner loading icon"></i>
+                        </button>
+                    {% endif %}
+                </div>
             </div>
             {% if last_published_date %}
                 <label><small>Published on {{last_published_date}}</small></label>

--- a/templates/epilepsy12/partials/organisation/individual_metrics.html
+++ b/templates/epilepsy12/partials/organisation/individual_metrics.html
@@ -12,16 +12,19 @@
                 {% endif %}
             </div>
             
-            <button 
-                class='ui right floated rcpch_primary button'
-                hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                hx-post="{% url 'selected_trust_select_kpi' organisation_id=selected_organisation.pk %}"
-                hx-trigger="click" hx-swap='innerHTML'
-                hx_indicator='#selected_trust_select_kpi'
-                hx-target="#selected_trust_select_kpi">
-                Refresh
-                <i class="htmx-indicator spinner loading icon" id="spinner"></i>
-            </button>
+            <div class="all-kpis-header">
+              <button class="ui right floated rcpch_primary button" _="on click go to top of #kpis">Jump to All KPI Metrics</button>
+              <button 
+                  class='ui right floated rcpch_primary button'
+                  hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                  hx-post="{% url 'selected_trust_select_kpi' organisation_id=selected_organisation.pk %}"
+                  hx-trigger="click" hx-swap='innerHTML'
+                  hx_indicator='#selected_trust_select_kpi'
+                  hx-target="#selected_trust_select_kpi">
+                  Refresh
+                  <i class="htmx-indicator spinner loading icon" id="spinner"></i>
+              </button>
+            </div>
             
         </div>
       

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -5,7 +5,7 @@
 <div class="ui grid container selected_organisation_container">
 
         <div class="sixteen wide unpadded fluid column topbar">
-            <button class="ui rcpch_positive button jump" _="on click go to top of #selected_trust_select_kpi_marker">Jump to Individual Measures</button>
+            <button class="ui rcpch_positive button jump" _="on click go to top of #kpis">Jump to All KPI Metrics</button>
             <div class="ui rcpch_light_blue label">Organisation View</div>
         </div>
     

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -4,7 +4,8 @@
 
 <div class="ui grid container selected_organisation_container">
 
-        <div class="right aligned sixteen wide unpadded fluid column">
+        <div class="sixteen wide unpadded fluid column topbar">
+            <button class="ui rcpch_positive button jump" _="on click go to top of #selected_trust_select_kpi_marker">Jump to Individual Measures</button>
             <div class="ui rcpch_light_blue label">Organisation View</div>
         </div>
     


### PR DESCRIPTION
Closes #648 

Adds button for jumping to All KPIs to the top of the landing page. Adds button to jump from all KPI table to Individual Measures and vice versa. Also resizes the Organisation View, Epilepsy12Users, and Cohort View labels in order for smoother UI - there was confusion about the previous Organisation View being a button.

<img width="1438" alt="image" src="https://github.com/rcpch/rcpch-audit-engine/assets/65614251/bf53de46-d9b8-44ab-af41-cf367b642dc8">

