### PR TITLE
643 end point for e12 staff to download patient data

### DIFF
--- a/epilepsy12/general_functions/__init__.py
+++ b/epilepsy12/general_functions/__init__.py
@@ -5,7 +5,7 @@ from .cohort_number import *
 from .index_multiple_deprivation import *
 from .postcode import *
 from .fuzzy_matching import *
-from .time_elapsed import stringify_time_elapsed
+from .time_elapsed import stringify_time_elapsed, rcpch_requested_time_elapsed
 from .value_from_key import *
 from .date_functions import *
 from .construct_confirm_email import *

--- a/epilepsy12/general_functions/time_elapsed.py
+++ b/epilepsy12/general_functions/time_elapsed.py
@@ -45,3 +45,36 @@ def stringify_time_elapsed(start_date, end_date):
 
     else:
         raise ValueError("Both start and end dates must be provided")
+
+def rcpch_requested_time_elapsed(start_date, end_date):
+    """
+    Calculated field. Returns time elapsed between two dates.
+
+    If less than 2 years of difference, time elapsed is returned in months
+    
+    If greater than 2 years of difference, time elapseed is returned in years
+
+    Note - elapsed.months cannot be larger than 12, as this value then moves over to elapsed.years + 1
+    """
+    if end_date and start_date:
+        elapsed = relativedelta(end_date, start_date)
+        string_delta = ""
+
+        # <= 2 years return months
+        if elapsed.years <= 2:
+            if elapsed.years == 1:
+                # Adds 12 to elapsed.months to represent a year in months
+                # Returns data in months
+
+                string_delta += handle_interval(elapsed.months+12, "month")
+                return string_delta 
+            else:
+                string_delta += handle_interval(elapsed.months, "month")
+                return string_delta
+
+        else:
+            # Returns data in years
+            string_delta += handle_interval(elapsed.years, "year")
+            return string_delta
+    else:
+        raise ValueError("Both start and end dates must be provided")

--- a/epilepsy12/urls.py
+++ b/epilepsy12/urls.py
@@ -299,6 +299,11 @@ case_patterns = [
         case_list,
         name="sort_by_days_remaining_before_submission_down",
     ),
+    path(
+        "organisation/<int:organisation_id>/cases/full_case_list",
+        view=all_epilepsy12_cases_list,
+        name="download_all_cases"
+    ),
 ]
 
 organisation_patterns = [

--- a/epilepsy12/views/case_views.py
+++ b/epilepsy12/views/case_views.py
@@ -31,7 +31,7 @@ from ..decorator import (
     login_and_otp_required,
 )
 
-from ..general_functions import construct_transfer_epilepsy12_site_outcome_email
+from ..general_functions import construct_transfer_epilepsy12_site_outcome_email, imd_for_postcode
 from ..tasks import asynchronously_send_email_to_recipients
 
 
@@ -742,7 +742,7 @@ def consent_confirmation(request, case_id, consent_type):
     has_error = False
 
     if consent_type == "consent":
-        AuditProgress.objects.filter(pk=case.registration.audit_progress.pk).update(
+        AuditProgress.objects.filter(pk=case.registration.audit_progress.pk).up(
             consent_patient_confirmed=True
         )
         case = Case.objects.get(pk=case_id)
@@ -795,6 +795,19 @@ def all_epilepsy12_cases_list(request, organisation_id):
     )
 
     df = pd.DataFrame(all_cases)
+
+
+
+
+    df['first_name'] = df['first_name'].str[:2]
+    df['surname'] = df['surname'].str[:2]
+
+    df['postcode'] = df['postcode'].apply(imd_for_postcode)
+
+    df.rename(columns={'postcode': 'depriv_quintile'}, inplace=True)
+
+    # Need to add age at first assessment which will be added to the case in the audit
+    # Need to make a call to imd_for_postcode in index_multiple_deprivation to calculate postcode 
 
     csv_data =  df.to_csv(index=False)
 

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -1620,6 +1620,13 @@ a.ui.button {
   /* margin-top: -1em; */
   border-radius: 0%;
   box-shadow: 0em 0em 0em 1px rgba(113, 89, 170, 0.15) inset;
+  display: flex;
+  align-items: center;
+}
+
+.download-users {
+  display:flex;
+  justify-content: space-between;
 }
 
 .list-unstyled {

--- a/templates/epilepsy12/cases/cases.html
+++ b/templates/epilepsy12/cases/cases.html
@@ -47,15 +47,19 @@
 
       
     </div>
-    <div class="ui bottom attached rcpch_purple_footer message">
-      <i class="warning info circle icon"></i>
-      These are all the children and young people registered in all audits since 2022.
-      {% if request.user|has_group:'epilepsy12_audit_team_full_access' or user.is_superuser %}
-        <button 
-        class="ui rcpch_positive download button">
-          <a href="{% url 'download_all_cases' organisation_id=organisation.pk %}">Download all E12 Cases list</a>
-        </button>
-      {% endif %}
+    <div class="ui bottom attached rcpch_purple_footer message download-users">
+      <div class="message">
+        <i class="warning info circle icon"></i>
+        These are all the children and young people registered in all audits since 2022.
+      </div>
+      <div>
+        {% if request.user|has_group:'epilepsy12_audit_team_full_access' or user.is_superuser %}
+          <button 
+          class="ui rcpch_positive download button">
+            <a href="{% url 'download_all_cases' organisation_id=organisation.pk %}">Download all E12 Cases list</a>
+          </button>
+        {% endif %}
+      </div>
     </div>
 
   </div>

--- a/templates/epilepsy12/cases/cases.html
+++ b/templates/epilepsy12/cases/cases.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}  
+{% load epilepsy12_template_tags %}
 {% block content %}
 
 <div class="ui rcpch container">
@@ -49,6 +50,12 @@
     <div class="ui bottom attached rcpch_purple_footer message">
       <i class="warning info circle icon"></i>
       These are all the children and young people registered in all audits since 2022.
+      {% if request.user|has_group:'epilepsy12_audit_team_full_access' or user.is_superuser %}
+        <button 
+        class="ui rcpch_positive download button">
+          <a href="{% url 'download_all_cases' organisation_id=organisation.pk %}">Download all E12 Cases list</a>
+        </button>
+      {% endif %}
     </div>
 
   </div>


### PR DESCRIPTION
Creates a feature to address the issue in #643.

A .csv file is created which contains 4 columns - sex, deprivation quintile (calculated from case's postcode), date of first assessment and age of case at first assessment.

Also adds button to bottom of case cohort list to download this csv, where permitted users are the rcpch audit team.

Please note that further testing is yet to be implemented which will provide insurance for intended use.

Update - I've just seen @nikyraja 's comment on #643 , and pending a meeting will add more features and columns as requested from the E12 team.

Button:
<img width="1099" alt="image" src="https://github.com/rcpch/rcpch-audit-engine/assets/65614251/afd608ba-a041-4d67-99e9-75a7e90fa8d1">

.csv contents:
<img width="380" alt="image" src="https://github.com/rcpch/rcpch-audit-engine/assets/65614251/82ea6afd-8e2f-4b26-9688-6da8b458add8">

