### PR TITLE
Refactor cohort data

### DIFF
--- a/epilepsy12/general_functions/cohort_number.py
+++ b/epilepsy12/general_functions/cohort_number.py
@@ -80,3 +80,48 @@ def dates_for_cohort(cohort: int):
     }
 
     return cohort_data
+
+
+def cohorts_and_dates(first_paediatric_assessment_date: date):
+    """
+    Returns:
+    * currently-recruiting cohort and dates
+    * submitting-cohort and dates
+    """
+
+    today = date.today()
+    currently_recruiting_cohort_number = (
+        cohort_number_from_first_paediatric_assessment_date(
+            first_paediatric_assessment_date=first_paediatric_assessment_date
+        )
+    )
+    if today < date(year=today.year, month=12, day=1):
+        submitting_cohort_number = currently_recruiting_cohort_number
+    else:
+        submitting_cohort_number = currently_recruiting_cohort_number - 1
+
+    currently_recruiting_cohort = dates_for_cohort(
+        cohort=currently_recruiting_cohort_number
+    )
+    submitting_cohort = dates_for_cohort(cohort=submitting_cohort_number)
+
+    return {
+        "currently_recruiting_cohort": currently_recruiting_cohort_number,
+        "currently_recruiting_cohort_start_date": currently_recruiting_cohort[
+            "cohort_start_date"
+        ],
+        "currently_recruiting_cohort_end_date": currently_recruiting_cohort[
+            "cohort_end_date"
+        ],
+        "currently_recruiting_cohort_submission_date": currently_recruiting_cohort[
+            "submission_date"
+        ],
+        "currently_recruiting_cohort_days_remaining": currently_recruiting_cohort[
+            "days_remaining"
+        ],
+        "submitting_cohort": submitting_cohort_number,
+        "submitting_cohort_start_date": submitting_cohort["cohort_start_date"],
+        "submitting_cohort_end_date": submitting_cohort["cohort_end_date"],
+        "submitting_cohort_submission_date": submitting_cohort["submission_date"],
+        "submitting_cohort_days_remaining": submitting_cohort["days_remaining"],
+    }

--- a/epilepsy12/general_functions/cohort_number.py
+++ b/epilepsy12/general_functions/cohort_number.py
@@ -89,16 +89,14 @@ def cohorts_and_dates(first_paediatric_assessment_date: date):
     * submitting-cohort and dates
     """
 
-    today = date.today()
     currently_recruiting_cohort_number = (
         cohort_number_from_first_paediatric_assessment_date(
             first_paediatric_assessment_date=first_paediatric_assessment_date
         )
     )
-    if today < date(year=today.year, month=12, day=1):
-        submitting_cohort_number = currently_recruiting_cohort_number
-    else:
-        submitting_cohort_number = currently_recruiting_cohort_number - 1
+
+    # submitting_cohort_number is always 1 less than currently_recruiting_cohort_number
+    submitting_cohort_number = currently_recruiting_cohort_number - 1
 
     currently_recruiting_cohort = dates_for_cohort(
         cohort=currently_recruiting_cohort_number

--- a/epilepsy12/views/organisation_views.py
+++ b/epilepsy12/views/organisation_views.py
@@ -27,6 +27,7 @@ from ..general_functions import (
     cohort_number_from_first_paediatric_assessment_date,
     dates_for_cohort,
     value_from_key,
+    cohorts_and_dates,
 )
 from ..tasks import (
     asynchronously_aggregate_kpis_and_update_models_for_cohort_and_abstraction_level,
@@ -83,14 +84,16 @@ def selected_organisation_summary(request, organisation_id):
         london_borough_tiles = return_tile_for_region("london_borough")
 
     # get latest cohort - in future will be selectable
-    cohort = cohort_number_from_first_paediatric_assessment_date(date.today())
-    cohort_data = dates_for_cohort(cohort)
+    # cohort = cohort_number_from_first_paediatric_assessment_date(date.today())
+    # cohort_data = dates_for_cohort(cohort)
+    # get submitting_cohort number
+    cohort_data = cohorts_and_dates(first_paediatric_assessment_date=date.today())
 
     # query to return all completed E12 cases in the current cohort in this organisation
     count_of_current_cohort_registered_completed_cases_in_this_organisation = (
         all_registered_cases_for_cohort_and_abstraction_level(
             organisation_instance=selected_organisation,
-            cohort=cohort_data["cohort"],
+            cohort=cohort_data["submitting_cohort"],
             case_complete=True,
             abstraction_level="organisation",
         ).count()
@@ -99,7 +102,7 @@ def selected_organisation_summary(request, organisation_id):
     count_of_current_cohort_registered_completed_cases_in_this_trust = (
         all_registered_cases_for_cohort_and_abstraction_level(
             organisation_instance=selected_organisation,
-            cohort=cohort_data["cohort"],
+            cohort=cohort_data["submitting_cohort"],
             case_complete=True,
             abstraction_level=abstraction_level,
         ).count()
@@ -108,7 +111,7 @@ def selected_organisation_summary(request, organisation_id):
     count_of_all_current_cohort_registered_cases_in_this_organisation = (
         all_registered_cases_for_cohort_and_abstraction_level(
             organisation_instance=selected_organisation,
-            cohort=cohort_data["cohort"],
+            cohort=cohort_data["submitting_cohort"],
             case_complete=False,
             abstraction_level="organisation",
         ).count()
@@ -117,7 +120,7 @@ def selected_organisation_summary(request, organisation_id):
     count_of_all_current_cohort_registered_cases_in_this_trust = (
         all_registered_cases_for_cohort_and_abstraction_level(
             organisation_instance=selected_organisation,
-            cohort=cohort_data["cohort"],
+            cohort=cohort_data["submitting_cohort"],
             case_complete=False,
             abstraction_level=abstraction_level,
         ).count()

--- a/epilepsy12/views/organisation_views.py
+++ b/epilepsy12/views/organisation_views.py
@@ -367,7 +367,9 @@ def selected_trust_select_kpi(request, organisation_id):
         # on page load there may be no kpi_name - default to paediatrician_with_experise_in_epilepsy
         kpi_name = INDIVIDUAL_KPI_MEASURES[0][0]
     kpi_name_title_case = value_from_key(key=kpi_name, choices=INDIVIDUAL_KPI_MEASURES)
-    cohort = cohort_number_from_first_paediatric_assessment_date(date.today())
+    cohort = cohorts_and_dates(first_paediatric_assessment_date=date.today())[
+        "submitting_cohort"
+    ]
 
     all_data = get_all_kpi_aggregation_data_for_view(
         organisation=organisation, cohort=cohort, open_access=False

--- a/templates/epilepsy12/partials/kpis/kpis.html
+++ b/templates/epilepsy12/partials/kpis/kpis.html
@@ -1,7 +1,7 @@
 {% load epilepsy12_template_tags %}
 {% csrf_token %}
 {% comment %}
-This template is the kpis table and is called from selected_trust_kpis, that latter for 
+This template is the kpis table and is called from selected_trust_kpis, that latter for
 open access. The open_access flag passed in from both endpoints denotes this.
 Currently the aggregation queries are run with every page load, but in future, the open_access results
 will be persisted and run as a cron job once a day.
@@ -11,10 +11,9 @@ will be persisted and run as a cron job once a day.
         <div class="ui top attached inverted clearing segment" id="audit_top_attached_segment">
             <div class='ui header'>
                 <div class='content kpi_header'>
-                    <p>Real-time Key Performance Indicator (KPI) Metrics for cohort {{cohort_data.submitting_cohort}}</p>
-                    
-                    
-                    <p>{{organisation.name}} 
+                    <p>Real-time Key Performance Indicator (KPI) Metrics for Cohort {{cohort_data.submitting_cohort}}</p>
+
+                    <p>{{organisation.name}}
                         (
                             {% if organisation.trust %}
                                 {{ organisation.trust.name }}
@@ -23,16 +22,16 @@ will be persisted and run as a cron job once a day.
                             {% endif %}
                         )
                     </p>
-                    
+
                 </div>
                 <div class="all-kpis-header">
                     <button class='ui right floated rcpch_primary button' _="on click go to the top of #selected_trust_select_kpi_marker">Jump to Individual Measures</button>
                     {% if not open %}
                         <!-- anyone can refresh and rerun aggregations that is not a member of the public  -->
-                        <button 
+                        <button
                             class='ui right floated rcpch_primary button'
                             hx-get="{% url 'selected_trust_kpis' organisation_id=organisation.pk access='private' %}"
-                            name="refresh" 
+                            name="refresh"
                             hx-trigger="click"
                             >
                             Refresh
@@ -49,25 +48,25 @@ will be persisted and run as a cron job once a day.
         </div>
 
         {% if all_data.ORGANISATION_KPIS.aggregation_model is not None %}
-        
+
             <div class="ui raised attached inverted rcpch_dark_blue segment" id="audit_body_segment">
 
                     <h3>Clinical Team</h3>
                     <table class='ui rcpch stackable small table kpi_table'>
                         {% include './kpi_table_head.html' with kpi_head_id=1 %}
                         <tbody>
-                        {% comment %} 
+                        {% comment %}
                         [
-                        'paediatrician_with_expertise_in_epilepsies', 
-                        'epilepsy_specialist_nurse', 
-                        ] 
+                        'paediatrician_with_expertise_in_epilepsies',
+                        'epilepsy_specialist_nurse',
+                        ]
                         {% endcomment %}
                         {% for kpi_name in kpi_names_list|slice:":2" %}
                             <tr>
                                 <td>
                                     <div class="rcpch_td_data_indicator_wrapper">
                                     <p>{% get_help_label_text_for_kpi kpi_name kpis %}</p>
-                                    <i 
+                                    <i
                                         class="rcpch question circle icon"
                                         id='{{ kpi_name }}'
                                         data-title='{% render_title_kpi_name kpi_name|title %}'
@@ -77,15 +76,15 @@ will be persisted and run as a cron job once a day.
                                     </i>
                                     </div>
                                 </td>
-                                
+
                                 {% for abstraction, data in all_data.items %}
                                 {% if data.aggregation_model %}
 
-                                    
+
                                     <td class='right aligned'>
                                         {% get_pct_passed_and_total_eligible data.aggregation_model kpi_name as kpi_data %}
                                         {% if kpi_data == -1 %}
-                                            <i 
+                                            <i
                                                 class="rcpch clock icon"
                                                 id='_{{abstraction}}_{{kpi_name}}'
                                                 data-title='No aggregation data'
@@ -94,8 +93,8 @@ will be persisted and run as a cron job once a day.
                                                 _="init js $('#_{{abstraction}}_{{kpi_name}}').popup(); end">
                                             </i>
                                         {% elif kpi_data == 0 %}
-                                        
-                                            <i 
+
+                                            <i
                                                 class="rcpch exclamation circle icon"
                                                 id='{{ kpi_name }}_none_eligible_model_icon_{{abstraction}}'
                                                 data-title='None eligible'
@@ -119,14 +118,14 @@ will be persisted and run as a cron job once a day.
                                 {% endfor %}
                             </tr>
                         {% endfor %}
-                        
+
                         {% comment %} tertiary input {% endcomment %}
-                        <tr class="subcategory-header"> 
+                        <tr class="subcategory-header">
                             {% with kpi_name='tertiary_input' %}
                             <td>
                                 <div class="rcpch_td_data_indicator_wrapper">
                                     <p>{% get_help_label_text_for_kpi kpi_name kpis %}</p>
-                                    <i 
+                                    <i
                                         class="rcpch question circle icon"
                                         id='{{ kpi_name }}'
                                         data-title='{% render_title_kpi_name kpi_name|title %}'
@@ -135,14 +134,14 @@ will be persisted and run as a cron job once a day.
                                         _="init js $('#{{ kpi_name }}').popup(); end">
                                     </i>
                                 </div>
-                            
+
                             </td>
                             {% for abstraction, data in all_data.items %}
                             {% if data.aggregation_model %}
                                 {% get_pct_passed_and_total_eligible data.aggregation_model kpi_name as kpi_data %}
                                     <td class='right aligned'>
                                         {% if kpi_data == -1 %}
-                                            <i 
+                                            <i
                                                 class="rcpch clock icon"
                                                 id='_{{abstraction}}_{{kpi_name}}'
                                                 data-title='No aggregation data'
@@ -151,7 +150,7 @@ will be persisted and run as a cron job once a day.
                                                 _="init js $('#_{{abstraction}}_{{kpi_name}}').popup(); end">
                                             </i>
                                         {% elif kpi_data == 0 %}
-                                            <i 
+                                            <i
                                                 class="rcpch exclamation circle icon"
                                                 id='{{ kpi_name }}_none_eligible_model_icon_{{abstraction}}'
                                                 data-title='None eligible'
@@ -173,7 +172,7 @@ will be persisted and run as a cron job once a day.
                                     </td>
                                 {% endif %}
                                 {% endfor %}
-                            {% endwith %} 
+                            {% endwith %}
                         </tr>
 
                         {% comment %} 'epilepsy surgery referral', {% endcomment %}
@@ -182,7 +181,7 @@ will be persisted and run as a cron job once a day.
                             <td>
                                 <div class="rcpch_td_data_indicator_wrapper">
                                 <p>{% get_help_label_text_for_kpi kpi_name kpis %}</p>
-                                <i 
+                                <i
                                     class="rcpch question circle icon"
                                     id='{{ kpi_name }}'
                                     data-title='{% render_title_kpi_name kpi_name|title %}'
@@ -197,7 +196,7 @@ will be persisted and run as a cron job once a day.
                                 <td class='right aligned'>
                                     {% get_pct_passed_and_total_eligible data.aggregation_model kpi_name as kpi_data %}
                                     {% if kpi_data == -1 %}
-                                        <i 
+                                        <i
                                             class="rcpch clock icon"
                                             id='_{{abstraction}}_{{kpi_name}}'
                                             data-title='No aggregation data'
@@ -206,7 +205,7 @@ will be persisted and run as a cron job once a day.
                                             _="init js $('#_{{abstraction}}_{{kpi_name}}').popup(); end">
                                         </i>
                                     {% elif kpi_data == 0 %}
-                                        <i 
+                                        <i
                                             class="rcpch exclamation circle icon"
                                             id='{{ kpi_name }}_none_eligible_model_icon_{{abstraction}}'
                                             data-title='None eligible'
@@ -238,13 +237,13 @@ will be persisted and run as a cron job once a day.
                     <table class='ui rcpch small table'>
                         {% include './kpi_table_head.html' with kpi_head_id=2  %}
                         <tbody>
-                        
+
                         {% for kpi_name in kpi_names_list|slice:"4:6" %}
                             <tr>
                                 <td>
                                     <div class="rcpch_td_data_indicator_wrapper">
                                     <p>{% get_help_label_text_for_kpi kpi_name kpis %}</p>
-                                    <i 
+                                    <i
                                         class="rcpch question circle icon"
                                         id='{{ kpi_name }}'
                                         data-title='{% render_title_kpi_name kpi_name|title %}'
@@ -259,7 +258,7 @@ will be persisted and run as a cron job once a day.
                                     <td class='right aligned'>
                                         {% get_pct_passed_and_total_eligible data.aggregation_model kpi_name as kpi_data %}
                                         {% if kpi_data == -1 %}
-                                            <i 
+                                            <i
                                                 class="rcpch clock icon"
                                                 id='_{{abstraction}}_{{kpi_name}}'
                                                 data-title='No aggregation data'
@@ -268,7 +267,7 @@ will be persisted and run as a cron job once a day.
                                                 _="init js $('#_{{abstraction}}_{{kpi_name}}').popup(); end">
                                             </i>
                                         {% elif kpi_data == 0 %}
-                                            <i 
+                                            <i
                                                 class="rcpch exclamation circle icon"
                                                 id='{{ kpi_name }}_none_eligible_model_icon_{{abstraction}}'
                                                 data-title='None eligible'
@@ -300,13 +299,13 @@ will be persisted and run as a cron job once a day.
                     <table class='ui rcpch small table'>
                         {% include './kpi_table_head.html' with kpi_head_id=3  %}
                         <tbody>
-                        
+
                         {% for kpi_name in kpi_names_list|slice:"6:8" %}
                             <tr>
                                 <td>
                                     <div class="rcpch_td_data_indicator_wrapper">
                                     <p>{% get_help_label_text_for_kpi kpi_name kpis %}</p>
-                                    <i 
+                                    <i
                                         class="rcpch question circle icon"
                                         id='{{ kpi_name }}'
                                         data-title='{% render_title_kpi_name kpi_name|title %}'
@@ -321,7 +320,7 @@ will be persisted and run as a cron job once a day.
                                     <td class='right aligned'>
                                         {% get_pct_passed_and_total_eligible data.aggregation_model kpi_name as kpi_data %}
                                         {% if kpi_data == -1 %}
-                                            <i 
+                                            <i
                                                 class="rcpch clock icon"
                                                 id='_{{abstraction}}_{{kpi_name}}'
                                                 data-title='No aggregation data'
@@ -330,7 +329,7 @@ will be persisted and run as a cron job once a day.
                                                 _="init js $('#_{{abstraction}}_{{kpi_name}}').popup(); end">
                                             </i>
                                         {% elif kpi_data == 0 %}
-                                            <i 
+                                            <i
                                                 class="rcpch exclamation circle icon"
                                                 id='{{ kpi_name }}_none_eligible_model_icon_{{abstraction}}'
                                                 data-title='None eligible'
@@ -356,7 +355,7 @@ will be persisted and run as a cron job once a day.
                         {% endfor %}
                         </tbody>
                     </table>
-                    
+
                     <h3>Medication</h3>
                     {% comment %} [Sodium valproate] {% endcomment %}
                     <table class='ui rcpch small table'>
@@ -368,7 +367,7 @@ will be persisted and run as a cron job once a day.
                                 <td>
                                     <div class="rcpch_td_data_indicator_wrapper">
                                     <p>{% get_help_label_text_for_kpi kpi_name kpis %}</p>
-                                    <i 
+                                    <i
                                         class="rcpch question circle icon"
                                         id='{{ kpi_name }}'
                                         data-title='{% render_title_kpi_name kpi_name|title %}'
@@ -383,7 +382,7 @@ will be persisted and run as a cron job once a day.
                                     <td class='right aligned'>
                                         {% get_pct_passed_and_total_eligible data.aggregation_model kpi_name as kpi_data %}
                                         {% if kpi_data == -1 %}
-                                            <i 
+                                            <i
                                                 class="rcpch clock icon"
                                                 id='_{{abstraction}}_{{kpi_name}}'
                                                 data-title='No aggregation data'
@@ -392,7 +391,7 @@ will be persisted and run as a cron job once a day.
                                                 _="init js $('#_{{abstraction}}_{{kpi_name}}').popup(); end">
                                             </i>
                                         {% elif kpi_data == 0 %}
-                                            <i 
+                                            <i
                                                 class="rcpch exclamation circle icon"
                                                 id='{{ kpi_name }}_none_eligible_model_icon_{{abstraction}}'
                                                 data-title='None eligible'
@@ -425,12 +424,12 @@ will be persisted and run as a cron job once a day.
                         {% include './kpi_table_head.html' with kpi_head_id=5 %}
                         <tbody>
                             {% comment %} comprehensive_care_planning_agreement {% endcomment %}
-                            <tr class="subcategory-header"> 
+                            <tr class="subcategory-header">
                                 {% with kpi_name='comprehensive_care_planning_agreement' %}
                                 <td>
                                     <div class="rcpch_td_data_indicator_wrapper">
                                         <p>{% get_help_label_text_for_kpi kpi_name kpis %}</p>
-                                        <i 
+                                        <i
                                             class="rcpch question circle icon"
                                             id='{{ kpi_name }}'
                                             data-title='{% render_title_kpi_name kpi_name|title %}'
@@ -439,14 +438,14 @@ will be persisted and run as a cron job once a day.
                                             _="init js $('#{{ kpi_name }}').popup(); end">
                                         </i>
                                     </div>
-                                
+
                                 </td>
                                 {% for abstraction, data in all_data.items %}
                                 {% if data.aggregation_model %}
                                     {% get_pct_passed_and_total_eligible data.aggregation_model kpi_name as kpi_data %}
                                         <td class='right aligned'>
                                             {% if kpi_data == -1 %}
-                                                <i 
+                                                <i
                                                     class="rcpch clock icon"
                                                     id='_{{abstraction}}_{{kpi_name}}'
                                                     data-title='No aggregation data'
@@ -455,7 +454,7 @@ will be persisted and run as a cron job once a day.
                                                     _="init js $('#_{{abstraction}}_{{kpi_name}}').popup(); end">
                                                 </i>
                                             {% elif kpi_data == 0 %}
-                                                <i 
+                                                <i
                                                     class="rcpch exclamation circle icon"
                                                     id='{{ kpi_name }}_none_eligible_model_icon_{{abstraction}}'
                                                     data-title='None eligible'
@@ -477,7 +476,7 @@ will be persisted and run as a cron job once a day.
                                         </td>
                                     {% endif %}
                                     {% endfor %}
-                                {% endwith %} 
+                                {% endwith %}
                             </tr>
 
                             {% comment %} 'patient_held_individualised_epilepsy_document', 'patient_carer_parent_agreement_to_the_care_planning', 'care_planning_has_been_updated_when_necessary', {% endcomment %}
@@ -486,7 +485,7 @@ will be persisted and run as a cron job once a day.
                                 <td>
                                     <div class="rcpch_td_data_indicator_wrapper">
                                     <p>{% get_help_label_text_for_kpi kpi_name kpis %}</p>
-                                    <i 
+                                    <i
                                         class="rcpch question circle icon"
                                         id='{{ kpi_name }}'
                                         data-title='{% render_title_kpi_name kpi_name|title %}'
@@ -501,7 +500,7 @@ will be persisted and run as a cron job once a day.
                                     <td class='right aligned'>
                                         {% get_pct_passed_and_total_eligible data.aggregation_model kpi_name as kpi_data %}
                                         {% if kpi_data == -1 %}
-                                            <i 
+                                            <i
                                                 class="rcpch clock icon"
                                                 id='_{{abstraction}}_{{kpi_name}}'
                                                 data-title='No aggregation data'
@@ -510,7 +509,7 @@ will be persisted and run as a cron job once a day.
                                                 _="init js $('#_{{abstraction}}_{{kpi_name}}').popup(); end">
                                             </i>
                                         {% elif kpi_data == 0 %}
-                                            <i 
+                                            <i
                                                 class="rcpch exclamation circle icon"
                                                 id='{{ kpi_name }}_none_eligible_model_icon_{{abstraction}}'
                                                 data-title='None eligible'
@@ -536,12 +535,12 @@ will be persisted and run as a cron job once a day.
                             {% endfor %}
 
                             {% comment %} comprehensive_care_planning_content {% endcomment %}
-                            <tr class="subcategory-header"> 
+                            <tr class="subcategory-header">
                                 {% with kpi_name='comprehensive_care_planning_content' %}
                                 <td>
                                     <div class="rcpch_td_data_indicator_wrapper">
                                         <p>{% get_help_label_text_for_kpi kpi_name kpis %}</p>
-                                        <i 
+                                        <i
                                             class="rcpch question circle icon"
                                             id='{{ kpi_name }}'
                                             data-title='{% render_title_kpi_name kpi_name|title %}'
@@ -550,14 +549,14 @@ will be persisted and run as a cron job once a day.
                                             _="init js $('#{{ kpi_name }}').popup(); end">
                                         </i>
                                     </div>
-                                
+
                                 </td>
                                 {% for abstraction, data in all_data.items %}
                                 {% if data.aggregation_model %}
                                     {% get_pct_passed_and_total_eligible data.aggregation_model kpi_name as kpi_data %}
                                         <td class='right aligned'>
                                             {% if kpi_data == -1 %}
-                                                <i 
+                                                <i
                                                     class="rcpch clock icon"
                                                     id='_{{abstraction}}_{{kpi_name}}'
                                                     data-title='No aggregation data'
@@ -566,7 +565,7 @@ will be persisted and run as a cron job once a day.
                                                     _="init js $('#_{{abstraction}}_{{kpi_name}}').popup(); end">
                                                 </i>
                                             {% elif kpi_data == 0 %}
-                                                <i 
+                                                <i
                                                     class="rcpch exclamation circle icon"
                                                     id='{{ kpi_name }}_none_eligible_model_icon_{{abstraction}}'
                                                     data-title='None eligible'
@@ -588,7 +587,7 @@ will be persisted and run as a cron job once a day.
                                         </td>
                                     {% endif %}
                                     {% endfor %}
-                                {% endwith %} 
+                                {% endwith %}
                             </tr>
 
                             {% comment %} 'parental_prolonged_seizures_care_plan', 'water_safety', 'first_aid', 'general_participation_and_risk', 'sudep', 'service_contact_details' {% endcomment %}
@@ -597,7 +596,7 @@ will be persisted and run as a cron job once a day.
                                 <td>
                                     <div class="rcpch_td_data_indicator_wrapper">
                                     <p>{% get_help_label_text_for_kpi kpi_name kpis %}</p>
-                                    <i 
+                                    <i
                                         class="rcpch question circle icon"
                                         id='{{ kpi_name }}'
                                         data-title='{% render_title_kpi_name kpi_name|title %}'
@@ -612,7 +611,7 @@ will be persisted and run as a cron job once a day.
                                     <td class='right aligned'>
                                         {% get_pct_passed_and_total_eligible data.aggregation_model kpi_name as kpi_data %}
                                         {% if kpi_data == -1 %}
-                                            <i 
+                                            <i
                                                 class="rcpch clock icon"
                                                 id='_{{abstraction}}_{{kpi_name}}'
                                                 data-title='No aggregation data'
@@ -621,7 +620,7 @@ will be persisted and run as a cron job once a day.
                                                 _="init js $('#_{{abstraction}}_{{kpi_name}}').popup(); end">
                                             </i>
                                         {% elif kpi_data == 0 %}
-                                            <i 
+                                            <i
                                                 class="rcpch exclamation circle icon"
                                                 id='{{ kpi_name }}_none_eligible_model_icon_{{abstraction}}'
                                                 data-title='None eligible'
@@ -652,7 +651,7 @@ will be persisted and run as a cron job once a day.
                                 <td>
                                     <div class="rcpch_td_data_indicator_wrapper">
                                     <p>{% get_help_label_text_for_kpi kpi_name kpis %}</p>
-                                    <i 
+                                    <i
                                         class="rcpch question circle icon"
                                         id='{{ kpi_name }}'
                                         data-title='{% render_title_kpi_name kpi_name|title %}'
@@ -667,7 +666,7 @@ will be persisted and run as a cron job once a day.
                                     <td class='right aligned'>
                                         {% get_pct_passed_and_total_eligible data.aggregation_model kpi_name as kpi_data %}
                                         {% if kpi_data == -1 %}
-                                            <i 
+                                            <i
                                                 class="rcpch clock icon"
                                                 id='_{{abstraction}}_{{kpi_name}}'
                                                 data-title='No aggregation data'
@@ -676,7 +675,7 @@ will be persisted and run as a cron job once a day.
                                                 _="init js $('#_{{abstraction}}_{{kpi_name}}').popup(); end">
                                             </i>
                                         {% elif kpi_data == 0 %}
-                                            <i 
+                                            <i
                                                 class="rcpch exclamation circle icon"
                                                 id='{{ kpi_name }}_none_eligible_model_icon_{{abstraction}}'
                                                 data-title='None eligible'
@@ -706,9 +705,9 @@ will be persisted and run as a cron job once a day.
 
             <div class="ui bottom attached rcpch_footer info icon message">
                 <i class="info circle icon"></i>
-                These are key indicators for your Organisation, alongside aggregate higher-level data related to your Organisation. Please note that these data are provisional, and may be subject to change before the annual report publication.  
+                These are key indicators for your Organisation, alongside aggregate higher-level data related to your Organisation. Please note that these data are provisional, and may be subject to change before the annual report publication.
             </div>
-         
+
         {% else %}
             <div class="ui rcpch_info icon message">
                 <i class='exclamation circle icon'></i>
@@ -720,6 +719,6 @@ will be persisted and run as a cron job once a day.
                 </div>
             </div>
         {% endif %}
-    
+
     </div>
 

--- a/templates/epilepsy12/partials/kpis/kpis.html
+++ b/templates/epilepsy12/partials/kpis/kpis.html
@@ -11,7 +11,7 @@ will be persisted and run as a cron job once a day.
         <div class="ui top attached inverted clearing segment" id="audit_top_attached_segment">
             <div class='ui header'>
                 <div class='content kpi_header'>
-                    <p>Real-time Key Performance Indicator (KPI) Metrics</p>
+                    <p>Real-time Key Performance Indicator (KPI) Metrics for cohort {{cohort_data.submitting_cohort}}</p>
                     
                     
                     <p>{{organisation.name}} 
@@ -714,9 +714,9 @@ will be persisted and run as a cron job once a day.
                 <i class='exclamation circle icon'></i>
                 <div class="content">
                     <div class="Header">
-                        No published data
+                        No data
                     </div>
-                    <p>There is no data currently published for this cohort. For further information on publication dates, please check <a href="www.epilepsy12.rcpch.ac.uk">our Epilepsy12 website</a></p>
+                    <p>There is no data for this cohort. For further information on publication dates, please check <a href="www.epilepsy12.rcpch.ac.uk">our Epilepsy12 website</a></p>
                 </div>
             </div>
         {% endif %}

--- a/templates/epilepsy12/partials/organisation/individual_metrics.html
+++ b/templates/epilepsy12/partials/organisation/individual_metrics.html
@@ -4,17 +4,17 @@
     <div class="ui top attached inverted clearing segment" id="audit_top_attached_segment">
         <div class='ui header'>
             <div class='content kpi_header'>
-                <p>Real-time Individual Key Performance Indicator (KPI) Metrics</p>
+                <p>Real-time Individual Key Performance Indicator (KPI) Metrics for Cohort {{ cohort }}</p>
                 {% if selected_organisation.trust %}
                   <p>{{selected_organisation.name}} ({{ selected_organisation.trust.name }})</p>
                 {% else %}
                   <p>{{selected_organisation.name}} ({{ selected_organisation.local_health_board.name }})</p>
                 {% endif %}
             </div>
-            
+
             <div class="all-kpis-header">
               <button class="ui right floated rcpch_primary button" _="on click go to top of #kpis">Jump to All KPI Metrics</button>
-              <button 
+              <button
                   class='ui right floated rcpch_primary button'
                   hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                   hx-post="{% url 'selected_trust_select_kpi' organisation_id=selected_organisation.pk %}"
@@ -25,20 +25,20 @@
                   <i class="htmx-indicator spinner loading icon" id="spinner"></i>
               </button>
             </div>
-            
+
         </div>
-      
+
       </div>
-    
+
       <div class="ui raised attached rcpch_dark_blue segment" id="selected_trust_select_kpi_marker">
-        
+
         <div class="ui rcpch_info message">
           <p>
             Within the clinical audit there are 12 'Performance Indicator' measures
             which are derived from national guidelines and recommendations.
           </p>
         </div>
-          {% url "selected_trust_select_kpi" organisation_id=selected_organisation.pk as hx_post%} 
+          {% url "selected_trust_select_kpi" organisation_id=selected_organisation.pk as hx_post%}
           {% include 'epilepsy12/partials/page_elements/kpi_select.html' with hx_post=hx_post hx_target='#selected_trust_select_kpi' hx_trigger='change' hx_swap='innerHTML' label='Select a measure and then click on a region' reference="Select one of the 12 measures and then click on a region to view how it compares." choices=individual_kpi_choices test_positive=individual_kpi_choices.0.0 hx_name='kpi_name' %}
           <div
             hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
@@ -52,14 +52,14 @@
             <div id="selected_trust_select_kpi">
                 <div class="ui active centered inline loader"></div>
             </div>
-            
+
           </div>
 
       </div>
 
       <div class="ui bottom attached rcpch_footer info icon message">
         <i class="info circle icon"></i>
-        These are key indicators for your Health Board/Trust, compared to the percentages for your relevant ICB, NHS England Region, OPEN UK Region, Country and England and Wales combined.       
+        These are key indicators for your Health Board/Trust, compared to the percentages for your relevant ICB, NHS England Region, OPEN UK Region, Country and England and Wales combined.
       </div>
 
 </div>

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -114,27 +114,53 @@
                 <div class="ui card">
                     <div class="content">                      
                         <div class="rcpch_summary_stats">
-                            
-                            
+
+                            <div class="ui horizontal divider">
+                                Active Cohort  
+                            </div>
+
                                 <div class="rcpch_summary_stats_row">
-                                    <h1 class="">{{cohort_data.cohort}}</h1>
-                                    <h2>Current Cohort</h2>
+                                    <h1>{{cohort_data.currently_recruiting_cohort}}</h1>
                                     <h3>
-                                        {% if cohort_data.days_remaining > 0 %}
+                                        {% if cohort_data.currently_recruiting_cohort_end_date > now %}
                                             Actively recruiting
                                         {% else %}
                                             Recruitment closed
                                         {% endif %}
                                     </h3>
-                                    <h4>{{cohort_data.cohort_start_date}}-{{cohort_data.cohort_end_date}}</h4>
+                                    <h4>{{cohort_data.currently_recruiting_cohort_start_date}}-{{cohort_data.currently_recruiting_cohort_end_date}}</h4>
                                 </div>
 
                                 <div class="rcpch_summary_stats_row">
-                                    <h1>{{cohort_data.days_remaining}}</h1>
+                                    <h1>{{cohort_data.currently_recruiting_cohort_days_remaining}}</h1>
                                     <h2>Days remaining</h2>
                                     <h3>until latest submission date</h3>
-                                    <h4>({{cohort_data.submission_date}})</h4>
+                                    <h4>({{cohort_data.currently_recruiting_cohort_submission_date}})</h4>
                                 </div>
+
+                            <div class="ui horizontal divider">
+                            Submitting Cohort  
+                            </div>
+
+                                <div class="rcpch_summary_stats_row">
+                                    <h1>{{cohort_data.submitting_cohort}}</h1>
+                                    <h3>
+                                        {% if cohort_data.submitting_cohort_days_remaining > 0 %}
+                                            Actively recruiting
+                                        {% else %}
+                                            Recruitment closed
+                                        {% endif %}
+                                    </h3>
+                                    <h4>{{cohort_data.submitting_cohort_start_date}}-{{cohort_data.submitting_cohort_end_date}}</h4>
+                                </div>
+
+                                <div class="rcpch_summary_stats_row">
+                                    <h1>{{cohort_data.submitting_cohort_days_remaining}}</h1>
+                                    <h2>Days remaining</h2>
+                                    <h3>until latest submission date</h3>
+                                    <h4>({{cohort_data.submitting_cohort_submission_date}})</h4>
+                                </div>
+
                         </div>
                     </div>
                 </div>

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -1,6 +1,6 @@
 {% load static %}
 {% load epilepsy12_template_tags %}
-{% csrf_token %} 
+{% csrf_token %}
 
 <div class="ui grid container selected_organisation_container">
 
@@ -8,7 +8,7 @@
             <button class="ui rcpch_positive button jump" _="on click go to top of #kpis">Jump to All KPI Metrics</button>
             <div class="ui rcpch_light_blue label">Organisation View</div>
         </div>
-    
+
         {% if request.user.is_rcpch_audit_team_member or request.user.is_rcpch_staff or request.user.is_superuser %}
             <div class='sixteen wide column'>
                 <div class="field" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
@@ -18,7 +18,7 @@
             </div>
         {% endif %}
 
-            
+
             <div class="fluid row stackable org_view_all_buttons_wrapper three column grid">
                 {% if user.is_rcpch_audit_team_member or user.is_superuser %}
                         <!-- Only RCPCH Audit team members and superusers can publish aggregations to the open access page -->
@@ -35,7 +35,7 @@
                     <div class="column" id="publish_button">
                         {% include './organisation/publish_button.html' with selected_organisation=selected_organisation publish_success=publish_success %}
                     </div>
-            
+
                 {% else %}
 
                     <div class="eight wide column">
@@ -54,13 +54,12 @@
 
         <div class='sixteen wide fluid column'>
 
-            
+
             <div class="ui three stackable cards">
-                
+
                 <div class="ui card">
                     <div class="content">
-                        <div class="organisation_address_container">
-                            <div class="ui centered header organisation_address">
+                            <div class="ui centered header">
                                 <h3>{{ selected_organisation.name }}</h3>
                             </div>
                             <h4 class="ui horizontal divider">
@@ -107,51 +106,27 @@
                                     </div>
                                 </div>
                         </div>
-                    </div>
                 </div>
 
-                
+
                 <div class="ui card">
-                    <div class="content">                      
+                    <div class="content">
                         <div class="rcpch_summary_stats">
 
-                            <div class="ui horizontal divider">
-                                Active Cohort  
-                            </div>
-
-                                <div class="rcpch_summary_stats_row">
-                                    <h1>{{cohort_data.currently_recruiting_cohort}}</h1>
-                                    <h3>
-                                        {% if cohort_data.currently_recruiting_cohort_end_date > now %}
-                                            Actively recruiting
-                                        {% else %}
-                                            Recruitment closed
-                                        {% endif %}
-                                    </h3>
-                                    <h4>{{cohort_data.currently_recruiting_cohort_start_date}}-{{cohort_data.currently_recruiting_cohort_end_date}}</h4>
-                                </div>
-
-                                <div class="rcpch_summary_stats_row">
-                                    <h1>{{cohort_data.currently_recruiting_cohort_days_remaining}}</h1>
-                                    <h2>Days remaining</h2>
-                                    <h3>until latest submission date</h3>
-                                    <h4>({{cohort_data.currently_recruiting_cohort_submission_date}})</h4>
-                                </div>
-
-                            <div class="ui horizontal divider">
-                            Submitting Cohort  
+                            <div class="ui centered header">
+                                <h3>Currently Submitting Cohort</h3>
                             </div>
 
                                 <div class="rcpch_summary_stats_row">
                                     <h1>{{cohort_data.submitting_cohort}}</h1>
                                     <h3>
-                                        {% if cohort_data.submitting_cohort_days_remaining > 0 %}
-                                            Actively recruiting
+                                        {% if cohort_data.end_date > today %}
+                                            Actively recruiting and submitting data
                                         {% else %}
-                                            Recruitment closed
+                                            Recruitment closed, submitting data only
                                         {% endif %}
                                     </h3>
-                                    <h4>{{cohort_data.submitting_cohort_start_date}}-{{cohort_data.submitting_cohort_end_date}}</h4>
+                                    <h4>Recruitment dates for Cohort {{cohort_data.submitting_cohort}}: {{cohort_data.submitting_cohort_start_date}} - {{cohort_data.submitting_cohort_end_date}}</h4>
                                 </div>
 
                                 <div class="rcpch_summary_stats_row">
@@ -164,7 +139,7 @@
                         </div>
                     </div>
                 </div>
-                
+
 
                 <div class="ui  card">
                     <div class="content">
@@ -172,16 +147,16 @@
                             <h3>Completed Patient Records</h3>
                         </div>
                         <div class="">
-    
+
                                 <div class="column">
-                                    
+
                                     <div class="four wide stackable column">
                                         {% include 'epilepsy12/partials/charts/progress.html' with percentage=percent_completed_organisation numerator=count_of_current_cohort_registered_completed_cases_in_this_organisation denominator=count_of_all_current_cohort_registered_cases_in_this_organisation title="Completed Patient Records - Organisation" pie_size='med' %}
                                         <div class='rcpch_centred_text'>
                                             <p><small>{{selected_organisation.name}}</small></p>
                                         </div>
                                     </div>
-            
+
                                 </div>
                                 <div class="column">
                                     <div class="four wide stackable column">
@@ -194,32 +169,32 @@
                                             {% endif %}
                                         </div>
                                     </div>
-                                    
+
                                 </div>
-    
+
                         </div>
                     </div>
                 </div>
 
-                
-                
+
+
 
             </div>
-    
+
         </div>
 
-        
-        
+
+
         <div class='sixteen wide fluid column'>
 
-            
+
             <div class="ui three stackable cards">
-                               
+
                 <div class="ui rcpch_light_blue card">
                     <div class="content">
-                        
+
                         <h3 >Distribution by Ethnicity</h3>
-                        
+
                     </div>
 
                         <div class="">
@@ -230,15 +205,15 @@
                                     <h5>No data yet!<h5>
                                 {% endif %}
                             </div>
-                        
+
                     </div>
                 </div>
-                
+
                 <div class="ui rcpch_light_blue card">
                     <div class="content">
-                        
+
                             <h3>Distribution by Sex</h3>
-                        
+
                     </div>
                     <div class="">
                         <div class='description'>
@@ -255,10 +230,10 @@
 
                 <div class="ui rcpch_light_blue card">
                     <div class="content">
-                        
+
                             <h3>
                                 Distribution by Index of Multiple Deprivation
-                                <i 
+                                <i
                                     class="info circle icon"
                                     id='deprivation_help'
                                     data-title='Epilepsy12 Index of Multiple Deprivation'
@@ -267,7 +242,7 @@
                                     _="init js $('#deprivation_help').popup(); end"
                                 ></i>
                             </h3>
-                        
+
                     </div>
                     <div class="">
                         <div class='description'>
@@ -282,16 +257,16 @@
                     </div>
                 </div>
 
-                
-                
+
+
 
             </div>
-    
+
         </div>
-        
+
         <div class="sixteen wide right fluid column">
             <div class="ui three stackable cards">
-                               
+
                 <div class="ui rcpch_light_blue card">
                     <div class="content">
                         <!-- ENGLISH ORG -->
@@ -332,7 +307,7 @@
                     </div>
                 </div>
                 {% endif %}
-                
+
                 {% if selected_organisation.city != "LONDON" %}
                 <div class="ui rcpch_light_blue card">
                     <div class="content">
@@ -349,8 +324,8 @@
             </div>
         </div>
 
-        
-            
+
+
         <div class="sixteen wide column">
             <div
                 class="sixteen wide rcpch segment"
@@ -361,17 +336,17 @@
                 <div id='kpis'>
                     <div class="ui active centered inline loader"></div>
                 </div>
-            
+
             </div>
         </div>
-        
-        {% include 'epilepsy12/partials/organisation/individual_metrics.html' with organisation_id=selected_organisation.pk %}
-            
-        </div>
-                
-            
-            
 
-    
+        {% include 'epilepsy12/partials/organisation/individual_metrics.html' with organisation_id=selected_organisation.pk cohort=cohort_data.submitting_cohort %}
+
+        </div>
+
+
+
+
+
 </div>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@3.8.0/dist/chart.min.js" integrity="sha256-cHVO4dqZfamRhWD7s4iXyaXWVK10odD+qp4xidFzqTI=" crossorigin="anonymous"></script>


### PR DESCRIPTION
### Overview

Please describe the purpose of this PR here.

### Code changes

Changes the Cohort shown in the main Organisation View card so that it is showing the current data submission cohort instead of the currently recruiting cohort. This was done at the request of the E12 team to make this card less confusing for users.

### Documentation changes (done or required as a result of this PR)

No documentation changes required

### Related Issues

Related to #684 - this is a quick fix to get things ready for users to be added, but there will be a more complete fix in the future which will show Actively Recruiting Cohort (and relevant data/dates etc) as well as Current Submission Cohort (as relevant data/dates)

### Mentions

This was coded while pairing so has been reviewed by @eatyourpeas and @pacharanero already
