### PR TITLE
First-paediatric-assessment-date-fix

### DIFF
--- a/epilepsy12/common_view_functions/validate_form_update_model.py
+++ b/epilepsy12/common_view_functions/validate_form_update_model.py
@@ -10,11 +10,8 @@ from django.apps import apps
 from psycopg2 import DatabaseError
 
 # RCPCH imports
-from ..general_functions import (
-    # dates_for_cohort,
-    # cohort_number_from_first_paediatric_assessment_date,
-    cohorts_and_dates,
-)
+from ..general_functions import cohorts_and_dates
+
 from ..validators import epilepsy12_date_validator
 
 

--- a/epilepsy12/common_view_functions/validate_form_update_model.py
+++ b/epilepsy12/common_view_functions/validate_form_update_model.py
@@ -11,8 +11,9 @@ from psycopg2 import DatabaseError
 
 # RCPCH imports
 from ..general_functions import (
-    dates_for_cohort,
-    cohort_number_from_first_paediatric_assessment_date,
+    # dates_for_cohort,
+    # cohort_number_from_first_paediatric_assessment_date,
+    cohorts_and_dates,
 )
 from ..validators import epilepsy12_date_validator
 
@@ -145,15 +146,26 @@ def validate_and_update_model(
 
         # the registration date cannot be before the child's cohort
         # To get cohort, we require Registration.first_paediatric_assessment_date. Of course this is not yet set. Therefore, get Cohort based on current field value
-        current_cohort = cohort_number_from_first_paediatric_assessment_date(
+        child_cohort_data = cohorts_and_dates(
             first_paediatric_assessment_date=field_value
         )
-        child_cohort_data = dates_for_cohort(current_cohort)
-        if field_value < child_cohort_data["cohort_start_date"]:
-            errors = f'The date you entered cannot be before the cohort {{registration.cohort}} start date ({child_cohort_data["cohort_start_date"].strftime("%d %B %Y")})'
+        if (
+            child_cohort_data.get("currently_recruiting_cohort_start_date", None)
+            is None
+        ):
+            # NoneType returned - cohort does not exist / before cohort 4
+            errors = f"You cannot enter a date before cohort 4 start date."
             raise ValueError(errors)
-        elif field_value > child_cohort_data["cohort_end_date"]:
-            errors = f'The date you entered cannot be after the current cohort end date ({child_cohort_data["cohort_end_date"].strftime("%d %B %Y")})'
+
+        if (
+            field_value < child_cohort_data["currently_recruiting_cohort_start_date"]
+        ):  # represents the cohort that was actively recruiting at the time of first paediatric assessment
+            errors = f'The date you entered cannot be before the cohort {{registration.cohort}} start date ({child_cohort_data["currently_recruiting_cohort_start_date"].strftime("%d %B %Y")})'
+            raise ValueError(errors)
+        elif (
+            field_value > child_cohort_data["currently_recruiting_cohort_end_date"]
+        ):  # represents the cohort that was closing at the time of first paediatric assessment
+            errors = f'The date you entered cannot be after the current cohort end date ({child_cohort_data["currently_recruiting_cohort_end_date"].strftime("%d %B %Y")})'
             raise ValueError(errors)
 
         else:

--- a/epilepsy12/general_functions/cohort_number.py
+++ b/epilepsy12/general_functions/cohort_number.py
@@ -95,31 +95,42 @@ def cohorts_and_dates(first_paediatric_assessment_date: date):
         )
     )
 
-    # submitting_cohort_number is always 1 less than currently_recruiting_cohort_number
-    submitting_cohort_number = currently_recruiting_cohort_number - 1
+    if currently_recruiting_cohort_number is not None:
+        # submitting_cohort_number is always 1 less than currently_recruiting_cohort_number
+        submitting_cohort_number = currently_recruiting_cohort_number - 1
 
-    currently_recruiting_cohort = dates_for_cohort(
-        cohort=currently_recruiting_cohort_number
-    )
-    submitting_cohort = dates_for_cohort(cohort=submitting_cohort_number)
+        currently_recruiting_cohort = dates_for_cohort(
+            cohort=currently_recruiting_cohort_number
+        )
+        submitting_cohort = dates_for_cohort(cohort=submitting_cohort_number)
+    else:
+        currently_recruiting_cohort = {}
+        submitting_cohort_number = None
+        submitting_cohort = {}
 
     return {
         "currently_recruiting_cohort": currently_recruiting_cohort_number,
-        "currently_recruiting_cohort_start_date": currently_recruiting_cohort[
-            "cohort_start_date"
-        ],
-        "currently_recruiting_cohort_end_date": currently_recruiting_cohort[
-            "cohort_end_date"
-        ],
-        "currently_recruiting_cohort_submission_date": currently_recruiting_cohort[
-            "submission_date"
-        ],
-        "currently_recruiting_cohort_days_remaining": currently_recruiting_cohort[
-            "days_remaining"
-        ],
+        "currently_recruiting_cohort_start_date": currently_recruiting_cohort.get(
+            "cohort_start_date", None
+        ),
+        "currently_recruiting_cohort_end_date": currently_recruiting_cohort.get(
+            "cohort_end_date", None
+        ),
+        "currently_recruiting_cohort_submission_date": currently_recruiting_cohort.get(
+            "submission_date", None
+        ),
+        "currently_recruiting_cohort_days_remaining": currently_recruiting_cohort.get(
+            "days_remaining", None
+        ),
         "submitting_cohort": submitting_cohort_number,
-        "submitting_cohort_start_date": submitting_cohort["cohort_start_date"],
-        "submitting_cohort_end_date": submitting_cohort["cohort_end_date"],
-        "submitting_cohort_submission_date": submitting_cohort["submission_date"],
-        "submitting_cohort_days_remaining": submitting_cohort["days_remaining"],
+        "submitting_cohort_start_date": submitting_cohort.get(
+            "cohort_start_date", None
+        ),
+        "submitting_cohort_end_date": submitting_cohort.get("cohort_end_date", None),
+        "submitting_cohort_submission_date": submitting_cohort.get(
+            "submission_date", None
+        ),
+        "submitting_cohort_days_remaining": submitting_cohort.get(
+            "days_remaining", None
+        ),
     }

--- a/templates/epilepsy12/partials/case_table.html
+++ b/templates/epilepsy12/partials/case_table.html
@@ -119,21 +119,35 @@
           <td>{% if case.registration.days_remaining_before_submission is not None %}{{ case.registration.days_remaining_before_submission }}{% endif %}</td>
           <td class='two wide'>
             <div class='ui buttons'>
-              <button data-tooltip='Edit child details.' class="ui rcpch_purple icon button" tabindexed="0" {% if case.locked or not perms.epilepsy12.change_case %}disabled{% endif %}><a href="{% url 'update_case' organisation_id=organisation_id case_id=case.id%}" {% if case.locked %}disabled{% endif %}><i
-                class="edit outline icon"></i></a></button>
-              {% comment %}
-              <button data-tooltip='Delete Child. This is irreversible.' class="ui rcpch_danger icon button" tabindexed="1" {% if case.locked or not perms.epilepsy12.delete_case %}disabled{% endif %}><a href="{% url 'delete_case' organisation_id=organisation_id case_id=case.id%}"><i
-                class="trash alternate outline icon"></i></a></button>
-              {% endcomment %}
+              <button 
+                data-tooltip='Edit child details.'
+                {% if case.locked or case.registration.days_remaining_before_submission == 0 %}
+                  class="ui rcpch_purple icon disabled button"
+                {% else %}
+                  class="ui rcpch_purple icon button"
+                {% endif %}
+                tabindexed="0" {% if case.locked or not perms.epilepsy12.change_case %}disabled{% endif %}>
+                <a href="{% url 'update_case' organisation_id=organisation_id case_id=case.id%}">
+                  <i class="edit outline icon"></i>
+                </a>
+              </button>
+              
               {% if case.registration.first_paediatric_assessment_date %}
                 {% if case.locked %}
-                <button data-tooltip='Complete audit details.'class="ui rcpch_dark_purple button" tabindexed="2" 
-                disabled
-                onclick="location.href='{% url 'register'  case.id %}'">Audit</button>
+                <button 
+                  data-tooltip='Complete audit details.'
+                  class="ui rcpch_dark_purple disabled button" 
+                  tabindexed="2" 
+                  onclick="location.href='{% url 'register'  case.id %}'"
+                >Audit</button>
                 {% else %}
                 <button 
                   data-tooltip='Complete audit details.'
-                  class="ui rcpch_dark_purple button" 
+                  {% if case.registration.days_remaining_before_submission == 0 %}
+                    class="ui rcpch_dark_purple disabled button"
+                  {% else %}
+                    class="ui rcpch_dark_purple button"
+                  {% endif %}
                   tabindexed="2"
                   onclick="location.href='{% url 'register'  case.id %}'"
                   >Audit</button>
@@ -143,8 +157,8 @@
                 {% if case.locked %}
 
                 <button 
-                  class="ui rcpch_dark_purple button" 
-                  tabindexed="2" disabled
+                  class="ui rcpch_dark_purple disabled button" 
+                  tabindexed="2"
                   onclick="location.href='{% url 'register' case_id=case.id %}'"
                 >Audit</button>
 

--- a/templates/registration/user_management/epilepsy12_user_table.html
+++ b/templates/registration/user_management/epilepsy12_user_table.html
@@ -293,7 +293,7 @@
             <th colspan="10" class="right aligned">
             {% if epilepsy12_user_list.has_previous %}
             <div class="ui rcpch_primary button" hx-target="#epilepsy12_user_table"
-                hx-get="{% url 'epilepsy12_user_list' organisation_id=organisation.pk epilepsy12_user_id=user.id %}?page={{epilepsy12_user_list.previous_page_number}}&sort_flag={{sort_flag}}"
+                hx-get="{% url 'epilepsy12_user_list' organisation_id=organisation.pk %}?page={{epilepsy12_user_list.previous_page_number}}&sort_flag={{sort_flag}}"
                 hx-swap="innerHTML">Previous 10</div>
             {% endif %}
             {% if epilepsy12_user_list.has_next %}


### PR DESCRIPTION
### Overview

A fairly urgent fix as high risk of affecting user experience.

Fixes 2 vulnerabilities.
1. the first paediatric assessment date error handling was broken in the recent cohort date refactor. This has been fixed.
2. The pagination in the epilepsy12 user table was not working due to an extra param added to the url get request
3. If a case was disabled, the buttons associated were not clickable but did not render as disabled

### Code changes

A refactor to the cohort dates function to return NoneType if a cohort < 4 was requested

A refactor to throw a meaningful error in the template if the user selects a first paediatric assessment date before cohort 4. This is found in validate_field_update_model file

Remove the epilepsy12_user_id in the epilepsy12_user_list pagination button

Refactor to case_table partial to add disabled when row or child has passed submission date

### Documentation changes (done or required as a result of this PR)

Bug fixes - documentation not needed (except comments in the code)

### Related Issues

Closes #687

### Mentions

@pacharanero
