### PR TITLE
Eatyourpeas/issue707

### DIFF
--- a/epilepsy12/views/user_management_views.py
+++ b/epilepsy12/views/user_management_views.py
@@ -60,8 +60,17 @@ def epilepsy12_user_list(request, organisation_id):
 
     filter_term = request.GET.get("filtered_epilepsy12_user_list")
 
-    # get all organisations which are in the same parent trust
-    organisation_children = Organisation.objects.filter(trust=organisation.trust).all()
+    # get trust or health board
+    if organisation.country.boundary_identifier == "W92000004":
+        parent_trust = organisation.local_health_board
+        # Wales - get all organisations which are in the same local health board
+        organisation_children = Organisation.objects.filter(
+            local_health_board=parent_trust
+        ).all()
+    else:
+        parent_trust = organisation.trust
+        # England - get all organisations which are in the same parent trust
+        organisation_children = Organisation.objects.filter(trust=parent_trust).all()
 
     if filter_term:
         filter_term_Q = (
@@ -246,16 +255,29 @@ def epilepsy12_user_list(request, organisation_id):
         or request.user.is_rcpch_staff
         or request.user.is_superuser
     ):
-        rcpch_choices = (
-            (0, "Organisation level"),
-            (1, "Trust level"),
-            (2, "National level"),
-        )
+        if organisation.country.boundary_identifier == "W92000004":
+            rcpch_choices = (
+                (0, "Organisation level"),
+                (1, "Local Health Board level"),
+                (2, "National level"),
+            )
+        else:
+            rcpch_choices = (
+                (0, "Organisation level"),
+                (1, "Trust level"),
+                (2, "National level"),
+            )
     else:
-        rcpch_choices = (
-            (0, "Organisation level"),
-            (1, "Trust level"),
-        )
+        if organisation.country.boundary_identifier == "W92000004":
+            rcpch_choices = (
+                (0, "Organisation level"),
+                (1, "Local Health Board level"),
+            )
+        else:
+            rcpch_choices = (
+                (0, "Organisation level"),
+                (1, "Trust level"),
+            )
 
     paginator = Paginator(epilepsy12_user_list, 10)
     page_number = request.GET.get("page", 1)


### PR DESCRIPTION
### Overview

This issue (#707) has a raised a fairly urgent vulnerability in the filtering of cases and to a lesser extent, filtering of staff in trusts/health boards.

3 problems were identified and fixed.

1. the filter Q object was not using dot notation against trusts, so the query was failing and raising an error
2. there was no equivalent filter for health boards in Wales as compared with England, leading the query to search against trusts in welsh organisations, leading to an error
3. The toggle between organisation / trust / national was not showing local health boards if the organisation selected was Welsh


### Code changes

All fixes are in the case_list function in the organisation_views.py file
The organisation is interrogated for its associated country and this used to both create a Q object to query against local health board rather than trust, as well as to update the text in the toggle between the same.

A similar fix to the text is made in the epilepsy user table, but the filtering logic was already in place.

### Documentation changes (done or required as a result of this PR)

This is a bug fix so no documentation probably necessary beyond what is in the code. 

### Related Issues

#707
