### PR TITLE
Date validations - remove first_paediatric_assessment_date

### DIFF
--- a/epilepsy12/views/assessment_views.py
+++ b/epilepsy12/views/assessment_views.py
@@ -99,7 +99,7 @@ def consultant_paediatrician_referral_date(request, assessment_id):
             page_element="date_field",
             comparison_date_field_name="consultant_paediatrician_input_date",
             is_earliest_date=True,
-            earliest_allowable_date=assessment.registration.first_paediatric_assessment_date,
+            earliest_allowable_date=None,
         )
     except ValueError as error:
         error_message = error
@@ -155,7 +155,7 @@ def consultant_paediatrician_input_date(request, assessment_id):
             page_element="date_field",
             comparison_date_field_name="consultant_paediatrician_referral_date",
             is_earliest_date=False,
-            earliest_allowable_date=assessment.registration.first_paediatric_assessment_date,
+            earliest_allowable_date=assessment.registration.assessment.consultant_paediatrician_referral_date,
         )
     except ValueError as error:
         error_message = error

--- a/epilepsy12/views/assessment_views.py
+++ b/epilepsy12/views/assessment_views.py
@@ -1516,7 +1516,7 @@ def epilepsy_specialist_nurse_referral_date(request, assessment_id):
             page_element="date_field",
             comparison_date_field_name="epilepsy_specialist_nurse_input_date",
             is_earliest_date=True,
-            earliest_allowable_date=assessment.registration.first_paediatric_assessment_date,
+            earliest_allowable_date=None,
         )
     except ValueError as error:
         error_message = error
@@ -1559,7 +1559,7 @@ def epilepsy_specialist_nurse_input_date(request, assessment_id):
             page_element="date_field",
             comparison_date_field_name="epilepsy_specialist_nurse_referral_date",
             is_earliest_date=False,
-            earliest_allowable_date=assessment.registration.first_paediatric_assessment_date,
+            earliest_allowable_date=assessment.registration.assessment.epilepsy_specialist_nurse_referral_date,
         )
     except ValueError as error:
         error_message = error

--- a/epilepsy12/views/investigation_views.py
+++ b/epilepsy12/views/investigation_views.py
@@ -135,7 +135,7 @@ def eeg_request_date(request, investigations_id):
             page_element="date_field",
             comparison_date_field_name="eeg_performed_date",
             is_earliest_date=True,
-            earliest_allowable_date=investigations.registration.first_paediatric_assessment_date,
+            earliest_allowable_date=None,
         )
 
     except ValueError as error:
@@ -186,7 +186,7 @@ def eeg_performed_date(request, investigations_id):
             page_element="date_field",
             comparison_date_field_name="eeg_request_date",
             is_earliest_date=False,
-            earliest_allowable_date=investigations.registration.first_paediatric_assessment_date,
+            earliest_allowable_date=investigations.registration.investigations.eeg_request_date,
         )
 
     except ValueError as errors:


### PR DESCRIPTION
as earliest date for EEG and nurse referral
Fixes #713

### Overview

Some centres organise ESN and EEG prior to the first paediatric assessment, so the validation rule for those fields must not have first paediatric assessment date as the ealiest allowable date as a rule

### Code changes

The earliest allowable date has been removed in esn referral date (assessment_views.py) and eeg_request date (investigation_views.py), and the esn review date and eeg_performed_date have their earliest allowable date as the referral or request date.

### Documentation changes (done or required as a result of this PR)
No documentation implications

### Related Issues

#713

### Mentions

@pacharanero
