### PR TITLE
Eatyourpeas/issue538

### DIFF
--- a/epilepsy12/views/assessment_views.py
+++ b/epilepsy12/views/assessment_views.py
@@ -34,6 +34,9 @@ def update_site_model(
             "site_is_general_paediatric_centre": True,
             "site_is_paediatric_neurology_centre": False,
             "site_is_childrens_epilepsy_surgery_centre": False,
+            "active_transfer": False,
+            "transfer_origin_organisation": None,
+            "transfer_request_date": None,
         }
     elif centre_role == "paediatric_neurology_centre":
         update_field = {"site_is_paediatric_neurology_centre": True}
@@ -41,6 +44,9 @@ def update_site_model(
             "site_is_general_paediatric_centre": False,
             "site_is_paediatric_neurology_centre": True,
             "site_is_childrens_epilepsy_surgery_centre": False,
+            "active_transfer": False,
+            "transfer_origin_organisation": None,
+            "transfer_request_date": None,
         }
     elif centre_role == "epilepsy_surgery_centre":
         update_field = {"site_is_childrens_epilepsy_surgery_centre": True}
@@ -48,6 +54,9 @@ def update_site_model(
             "site_is_general_paediatric_centre": False,
             "site_is_paediatric_neurology_centre": False,
             "site_is_childrens_epilepsy_surgery_centre": True,
+            "active_transfer": False,
+            "transfer_request_date": None,
+            "transfer_origin_organisation": None,
         }
 
     # selected_organisation has never been involved in child's care
@@ -79,7 +88,9 @@ def update_site_model(
                 organisation=selected_organisation,
                 site_is_primary_centre_of_epilepsy_care=True,
                 site_is_actively_involved_in_epilepsy_care=True,
-            ).update(**update_field)
+            ).update(
+                **update_field
+            )  # update only the status requested
 
         # selected_organisation was previously lead centre
         elif Site.objects.filter(

--- a/epilepsy12/views/assessment_views.py
+++ b/epilepsy12/views/assessment_views.py
@@ -363,33 +363,6 @@ def general_paediatric_centre(request, assessment_id):
     )
     assessment = Assessment.objects.get(pk=assessment_id)
 
-    # if this registration already has a record in sites
-    #  associated with this organisation,
-    # update it include general paediatrics, else create a new record
-    # if Site.objects.filter(
-    #     case=assessment.registration.case,
-    #     organisation=general_paediatric_centre,
-    #     site_is_actively_involved_in_epilepsy_care=True,
-    # ).exists():
-    #     Site.objects.filter(
-    #         case=assessment.registration.case, organisation=general_paediatric_centre
-    #     ).update(
-    #         site_is_general_paediatric_centre=True,
-    #         site_is_actively_involved_in_epilepsy_care=True,
-    #         updated_at=timezone.now(),
-    #         updated_by=request.user,
-    #     )
-    # else:
-    #     site = Site.objects.create(
-    #         case=assessment.registration.case,
-    #         organisation=general_paediatric_centre,
-    #         site_is_primary_centre_of_epilepsy_care=False,
-    #         site_is_childrens_epilepsy_surgery_centre=False,
-    #         site_is_actively_involved_in_epilepsy_care=True,
-    #         site_is_paediatric_neurology_centre=False,
-    #         site_is_general_paediatric_centre=True,
-    #     )
-    #     site.save()
     update_site_model(
         centre_role="general_paediatric_centre",
         selected_organisation=general_paediatric_centre,
@@ -442,38 +415,6 @@ def edit_general_paediatric_centre(request, assessment_id, site_id):
 
     assessment = Assessment.objects.get(pk=assessment_id)
 
-    # if Site.objects.filter(
-    #     case=assessment.registration.case,
-    #     organisation=new_organisation,
-    #     site_is_actively_involved_in_epilepsy_care=True,
-    # ).exists():
-    #     # this organisation trust already exists as an active site for this registration
-    #     # update that record, update this to show
-
-    #     site = Site.objects.filter(
-    #         case=assessment.registration.case,
-    #         organisation=new_organisation,
-    #         site_is_actively_involved_in_epilepsy_care=True,
-    #     ).get()
-    #     site.site_is_general_paediatric_centre = True
-    #     site.updated_at = (timezone.now(),)
-    #     site.updated_by = request.user
-    #     site.save()
-
-    #     # update the old site to become historical
-    #     old_site = Site.objects.get(pk=site_id)
-    #     old_site.site_is_general_paediatric_centre = False
-    #     old_site.save()
-
-    # else:
-    #     # this change is a new organisation
-    #     Site.objects.filter(pk=site_id).update(
-    #         organisation=new_organisation,
-    #         site_is_general_paediatric_centre=True,
-    #         site_is_actively_involved_in_epilepsy_care=True,
-    #         updated_at=timezone.now(),
-    #         updated_by=request.user,
-    #     )
     update_site_model(
         centre_role="general_paediatric_centre",
         selected_organisation=general_paediatric_centre,
@@ -658,22 +599,9 @@ def paediatric_neurologist_referral_made(request, assessment_id):
         # get new instance of Assessment
         assessment = Assessment.objects.get(pk=assessment_id)
 
-        #     # if any allocated sites make them historical
-        #     if Site.objects.filter(
-        #         case=assessment.registration.case,
-        #         site_is_paediatric_neurology_centre=True,
-        #     ).exists():
-        #         Site.objects.filter(
-        #             case=assessment.registration.case,
-        #             site_is_paediatric_neurology_centre=True,
-        #         ).update(site_is_actively_involved_in_epilepsy_care=False)
-        # if any allocated sites remove them
         if Site.objects.filter(
             case=assessment.registration.case, site_is_paediatric_neurology_centre=True
         ).exists():
-            # loop through these and delete any site where the organisation
-            # is not used elsewhere for this child actively for any other attribute (surgery or neurology)
-            # or is not a historical or active lead site. If it is, set site_is_paediatric_neurology_centre to False
             updated_neurology_status_sites = Site.objects.filter(
                 case=assessment.registration.case,
                 site_is_paediatric_neurology_centre=True,
@@ -851,31 +779,6 @@ def paediatric_neurology_centre(request, assessment_id):
     )
     assessment = Assessment.objects.get(pk=assessment_id)
 
-    # if this registration already has a record in sites
-    #  associated with this organisation,
-    # update it include paediatric neurology, else create a new record
-    # if Site.objects.filter(
-    #     case=assessment.registration.case, organisation=paediatric_neurology_centre
-    # ).exists():
-    #     Site.objects.filter(
-    #         case=assessment.registration.case, organisation=paediatric_neurology_centre
-    #     ).update(
-    #         site_is_actively_involved_in_epilepsy_care=True,
-    #         site_is_paediatric_neurology_centre=True,
-    #         updated_at=timezone.now(),
-    #         updated_by=request.user,
-    #     )
-    # else:
-    #     site = Site.objects.create(
-    #         case=assessment.registration.case,
-    #         organisation=paediatric_neurology_centre,
-    #         site_is_primary_centre_of_epilepsy_care=False,
-    #         site_is_childrens_epilepsy_surgery_centre=False,
-    #         site_is_actively_involved_in_epilepsy_care=True,
-    #         site_is_paediatric_neurology_centre=True,
-    #         site_is_general_paediatric_centre=False,
-    #     )
-    #     site.save()
     update_site_model(
         centre_role="paediatric_neurology_centre",
         selected_organisation=paediatric_neurology_centre,
@@ -923,32 +826,6 @@ def edit_paediatric_neurology_centre(request, assessment_id, site_id):
 
     assessment = Assessment.objects.get(pk=assessment_id)
 
-    # if Site.objects.filter(
-    #     case=assessment.registration.case,
-    #     organisation=paediatric_neurology_centre,
-    #     site_is_actively_involved_in_epilepsy_care=True,
-    # ).exists():
-    #     # this organisation trust already exists for this registration
-    #     # update that record, delete this
-
-    #     site = Site.objects.filter(
-    #         case=assessment.registration.case,
-    #         organisation=paediatric_neurology_centre,
-    #         site_is_actively_involved_in_epilepsy_care=True,
-    #     ).get()
-    #     site.site_is_paediatric_neurology_centre = True
-    #     site.save()
-    #     Site.objects.get(pk=site_id).delete()
-
-    # else:
-    #     # this change is a new organisation
-    #     Site.objects.filter(pk=site_id).update(
-    #         organisation=paediatric_neurology_centre,
-    #         site_is_paediatric_neurology_centre=True,
-    #         site_is_actively_involved_in_epilepsy_care=True,
-    #         updated_at=timezone.now(),
-    #         updated_by=request.user,
-    #     )
     update_site_model(
         centre_role="paediatric_neurology_centre",
         selected_organisation=paediatric_neurology_centre,
@@ -1178,15 +1055,6 @@ def childrens_epilepsy_surgical_service_referral_made(request, assessment_id):
         # get new instance of Assessment
         assessment = Assessment.objects.get(pk=assessment_id)
 
-        # # if any allocated sites deallocate surgery
-        # if Site.objects.filter(
-        #     case=assessment.registration.case,
-        #     site_is_childrens_epilepsy_surgery_centre=True,
-        # ).exists():
-        #     Site.objects.filter(
-        #         case=assessment.registration.case,
-        #         site_is_childrens_epilepsy_surgery_centre=True,
-        #     ).update(site_is_actively_involved_in_epilepsy_care=False)
         if Site.objects.filter(
             case=assessment.registration.case,
             site_is_childrens_epilepsy_surgery_centre=True,
@@ -1428,31 +1296,6 @@ def epilepsy_surgery_centre(request, assessment_id):
     )
     assessment = Assessment.objects.get(pk=assessment_id)
 
-    # if this registration already has a record in sites
-    #  associated with this organisation,
-    # update it to include epilepsy surgery, else create a new record
-    # if Site.objects.filter(
-    #     case=assessment.registration.case, organisation=epilepsy_surgery_centre
-    # ).exists():
-    #     Site.objects.filter(
-    #         case=assessment.registration.case, organisation=epilepsy_surgery_centre
-    #     ).update(
-    #         site_is_actively_involved_in_epilepsy_care=True,
-    #         site_is_childrens_epilepsy_surgery_centre=True,
-    #         updated_at=timezone.now(),
-    #         updated_by=request.user,
-    #     )
-    # else:
-    #     site = Site.objects.create(
-    #         case=assessment.registration.case,
-    #         organisation=epilepsy_surgery_centre,
-    #         site_is_primary_centre_of_epilepsy_care=False,
-    #         site_is_childrens_epilepsy_surgery_centre=True,
-    #         site_is_actively_involved_in_epilepsy_care=True,
-    #         site_is_paediatric_neurology_centre=False,
-    #         site_is_general_paediatric_centre=False,
-    #     )
-    #     site.save()
     update_site_model(
         centre_role="epilepsy_surgery_centre",
         selected_organisation=epilepsy_surgery_centre,
@@ -1505,32 +1348,6 @@ def edit_epilepsy_surgery_centre(request, assessment_id, site_id):
 
     assessment = Assessment.objects.get(pk=assessment_id)
 
-    # if Site.objects.filter(
-    #     case=assessment.registration.case,
-    #     organisation=new_organisation,
-    #     site_is_actively_involved_in_epilepsy_care=True,
-    # ).exists():
-    #     # this organisation trust already exists for this registration
-    #     # update that record, delete this
-
-    #     site = Site.objects.filter(
-    #         case=assessment.registration.case,
-    #         organisation=new_organisation,
-    #         site_is_actively_involved_in_epilepsy_care=True,
-    #     ).get()
-    #     site.site_is_childrens_epilepsy_surgery_centre = True
-    #     site.save()
-    #     Site.objects.get(pk=site_id).delete()
-
-    # else:
-    #     # this change is a new organisation
-    #     Site.objects.filter(pk=site_id).update(
-    #         organisation=new_organisation,
-    #         site_is_childrens_epilepsy_surgery_centre=True,
-    #         site_is_actively_involved_in_epilepsy_care=True,
-    #         updated_at=timezone.now(),
-    #         updated_by=request.user,
-    #     )
     update_site_model(
         centre_role="epilepsy_surgery_centre",
         selected_organisation=epilepsy_surgery_centre,

--- a/epilepsy12/views/case_views.py
+++ b/epilepsy12/views/case_views.py
@@ -382,71 +382,74 @@ def transfer_response(request, organisation_id, case_id, organisation_response):
     Updates associated Site instance and redirects back to case table
     """
 
+    target_organisation = Organisation.objects.get(pk=organisation_id)
     case = Case.objects.get(pk=case_id)
     site = Site.objects.get(
-        case=case, active_transfer=True, site_is_primary_centre_of_epilepsy_care=True
+        case=case,
+        active_transfer=True,
+        site_is_primary_centre_of_epilepsy_care=True,
+        organisation=target_organisation,
     )
+
     # prepare email response to requesting organisation clinical lead
     email = construct_transfer_epilepsy12_site_outcome_email(
         request=request,
-        target_organisation=Organisation.objects.get(pk=organisation_id),
+        target_organisation=target_organisation,
         outcome=f"{organisation_response}ed",
     )
     origin_organisation = site.transfer_origin_organisation
     if organisation_response == "reject":
-        # reset the child back to the origin organisation
-        if Site.objects.filter(
-            organisation=origin_organisation,
-            site_is_primary_centre_of_epilepsy_care=True,
-            site_is_actively_involved_in_epilepsy_care=False,
-        ).exists():
-            # old record exist - reactivate
-            old_site = Site.objects.filter(
-                case=case,
-                organisation=origin_organisation,
-                site_is_primary_centre_of_epilepsy_care=True,
-                site_is_actively_involved_in_epilepsy_care=False,
-            ).get()
-            old_site.site_is_actively_involved_in_epilepsy_care = True
-            old_site.save(update_fields=["site_is_actively_involved_in_epilepsy_care"])
-            # if the old site had other responsibilities that were retained, need to reallocate them back
-            # and delete any records that stored them
-            if Site.objects.filter(
-                (
-                    Q(site_is_childrens_epilepsy_surgery_centre=True)
-                    | Q(site_is_paediatric_neurology_centre=True)
-                    | Q(site_is_general_paediatric_centre=True)
-                ),
-                case=case,
-                organisation=origin_organisation,
-                active_transfer=True,
+        # Any additional responsibilities that were previously maintained before
+        # transfer by the target organisation must be handed back by creating new record
+        if (
+            site.site_is_childrens_epilepsy_surgery_centre
+            or site.site_is_paediatric_neurology_centre
+            or site.site_is_general_paediatric_centre
+        ):
+            Site.objects.create(
+                site_is_childrens_epilepsy_surgery_centre=site.site_is_childrens_epilepsy_surgery_centre,
+                site_is_paediatric_neurology_centre=site.site_is_paediatric_neurology_centre,
+                site_is_general_paediatric_centre=site.site_is_general_paediatric_centre,
                 site_is_primary_centre_of_epilepsy_care=False,
                 site_is_actively_involved_in_epilepsy_care=True,
-            ).exists():
-                old_site_additional_responsibilities = Site.objects.filter(
-                    (
-                        Q(site_is_childrens_epilepsy_surgery_centre=True)
-                        | Q(site_is_paediatric_neurology_centre=True)
-                        | Q(site_is_general_paediatric_centre=True)
-                    ),
-                    case=case,
-                    organisation=origin_organisation,
-                    active_transfer=True,
-                    site_is_primary_centre_of_epilepsy_care=False,
-                    site_is_actively_involved_in_epilepsy_care=True,
-                ).first()
-                old_site_additional_responsibilities.delete()
-            # delete this record
-            site.delete()
-        else:
-            # no previous record to reanimate
-            # continue with this record
-            # no longer in active transfer
-            site.active_transfer = False
-            site.organisation = site.transfer_origin_organisation
-            site.transfer_origin_organisation = None
-            site.transfer_request_date = None
-            site.save()
+                case=case,
+                organisation=target_organisation,
+            )
+        # Reset the site back to original organisation
+        site.site_is_childrens_epilepsy_surgery_centre = False
+        site.site_is_paediatric_neurology_centre = False
+        site.site_is_general_paediatric_centre = False
+        site.active_transfer = False
+        site.organisation = site.transfer_origin_organisation
+        site.transfer_origin_organisation = None
+        site.transfer_request_date = None
+        site.site_is_primary_centre_of_epilepsy_care = True
+        site.site_is_actively_involved_in_epilepsy_care = True
+
+        site.save(
+            update_fields=[
+                "site_is_childrens_epilepsy_surgery_centre",
+                "site_is_paediatric_neurology_centre",
+                "site_is_general_paediatric_centre",
+                "active_transfer",
+                "organisation",
+                "transfer_origin_organisation",
+                "transfer_request_date",
+                "site_is_primary_centre_of_epilepsy_care",
+                "site_is_actively_involved_in_epilepsy_care",
+            ]
+        )
+
+        # if the origin lead site had other responsibilities prior to transfer, a new record
+        # would have been created in the transfer process to hold these. This record
+        # now needs deleting
+
+        Site.objects.filter(
+            case=case,
+            organisation=site.organisation,  # this is the origin organisation
+            site_is_actively_involved_in_epilepsy_care=False,
+        ).delete()
+
     elif organisation_response == "accept":
         site.active_transfer = False
         site.transfer_origin_organisation = None

--- a/epilepsy12/views/case_views.py
+++ b/epilepsy12/views/case_views.py
@@ -408,7 +408,7 @@ def transfer_response(request, organisation_id, case_id, organisation_response):
                 site_is_actively_involved_in_epilepsy_care=False,
             ).get()
             old_site.site_is_actively_involved_in_epilepsy_care = True
-            old_site.save()
+            old_site.save(update_fields=["site_is_actively_involved_in_epilepsy_care"])
             # if the old site had other responsibilities that were retained, need to reallocate them back
             # and delete any records that stored them
             if Site.objects.filter(

--- a/epilepsy12/views/registration_views.py
+++ b/epilepsy12/views/registration_views.py
@@ -410,8 +410,6 @@ def update_lead_site(request, registration_id, site_id, update):
             recipients = [settings.SITE_CONTACT_EMAIL]
             subject = "Epilepsy12 Lead Site Transfer - NO LEAD CLINICIAN"
 
-        print(recipients)
-
         email = construct_transfer_epilepsy12_site_email(
             request=request,
             target_organisation=new_organisation,

--- a/epilepsy12/views/registration_views.py
+++ b/epilepsy12/views/registration_views.py
@@ -402,7 +402,6 @@ def update_lead_site(request, registration_id, site_id, update):
                         & Q(is_active=True)
                         & Q(role=1)  # Audit Centre Lead Clinician
                     )
-                    | (Q(is_active=True) & Q(is_rcpch_audit_team_member=True))
                 ).values_list("email", flat=True)
             )
             subject = "Epilepsy12 Lead Site Transfer"
@@ -410,6 +409,8 @@ def update_lead_site(request, registration_id, site_id, update):
             # there is no allocated clinical lead. Send to SITE_CONTACT_EMAIL
             recipients = [settings.SITE_CONTACT_EMAIL]
             subject = "Epilepsy12 Lead Site Transfer - NO LEAD CLINICIAN"
+
+        print(recipients)
 
         email = construct_transfer_epilepsy12_site_email(
             request=request,

--- a/epilepsy12/views/registration_views.py
+++ b/epilepsy12/views/registration_views.py
@@ -266,7 +266,12 @@ def transfer_lead_site(request, registration_id, site_id):
     registration = Registration.objects.get(pk=registration_id)
     site = Site.objects.get(pk=site_id)
 
-    organisation_list = Organisation.objects.order_by("name").all()
+    organisation_list = (
+        Organisation.objects.all()
+        .exclude(pk__in=site.organisation.pk)
+        .order_by("name")
+        .all()
+    )
 
     context = {
         "organisation_list": organisation_list,

--- a/epilepsy12/views/registration_views.py
+++ b/epilepsy12/views/registration_views.py
@@ -416,7 +416,6 @@ def update_lead_site(request, registration_id, site_id, update):
                 site_is_childrens_epilepsy_surgery_centre=previous_lead_site.site_is_childrens_epilepsy_surgery_centre,
                 site_is_paediatric_neurology_centre=previous_lead_site.site_is_paediatric_neurology_centre,
                 site_is_general_paediatric_centre=previous_lead_site.site_is_general_paediatric_centre,
-                active_transfer=True,  # this flag will be set to false if transfer accepted or used to delete record if transfer ultimately refused
             )
 
         # update current site record to show nolonger actively involved in care as primary centre

--- a/epilepsy12/views/registration_views.py
+++ b/epilepsy12/views/registration_views.py
@@ -266,9 +266,11 @@ def transfer_lead_site(request, registration_id, site_id):
     registration = Registration.objects.get(pk=registration_id)
     site = Site.objects.get(pk=site_id)
 
+    # remove the currently selected organisation from the list - should not be able to
+    # transfer to the current organisation
     organisation_list = (
-        Organisation.objects.all()
-        .exclude(pk__in=site.organisation.pk)
+        Organisation.objects.filter()
+        .exclude(pk=site.organisation.pk)
         .order_by("name")
         .all()
     )

--- a/epilepsy12/views/user_management_views.py
+++ b/epilepsy12/views/user_management_views.py
@@ -141,10 +141,14 @@ def epilepsy12_user_list(request, organisation_id):
             # filters all primary Trust level centres, irrespective of if active or inactive
             if organisation.country.boundary_identifier == "W92000004":
                 parent_trust = organisation.local_health_board.name
+                basic_filter = Q(
+                    organisation_employer__local_health_board__name__contains=parent_trust
+                )
             else:
                 parent_trust = organisation.trust.name
-
-            basic_filter = Q(organisation_employer__trust__name__contains=parent_trust)
+                basic_filter = Q(
+                    organisation_employer__trust__name__contains=parent_trust
+                )
 
         elif request.user.view_preference == 0:
             # filters all primary centres at organisation level, irrespective of if active or inactive

--- a/templates/epilepsy12/forms/case_form.html
+++ b/templates/epilepsy12/forms/case_form.html
@@ -65,15 +65,12 @@
 
   </div>
 
-  
-  {% if request.user|has_group:"trust_audit_team_full_access, trust_audit_team_edit_access, epilepsy12_audit_team_edit_access, epilepsy12_audit_team_full_access" %}
   <div class="field">
     <label>NHS Number</label>
     {{form.nhs_number}} {% if form.nhs_number.errors %}
     <div class="ui pointing red basic label">{{form.nhs_number.errors}}</div>
     {% endif %}
   </div>
-  {% endif %}
 
   <div class="field">
     <label>Ethnicity</label>

--- a/templates/epilepsy12/forms/case_form.html
+++ b/templates/epilepsy12/forms/case_form.html
@@ -133,7 +133,11 @@
         Cancel
       </a>
       {% if perms.epilepsy12.change_case or perms.epilepsy12.add_case %}
-        <button type="submit" class="ui rcpch_primary button" name="update">
+        <button 
+        type="submit" 
+        class="ui rcpch_primary button" 
+        name="update" 
+        _="on click toggle .disabled on me">
           Save
         </button>
     

--- a/templates/epilepsy12/forms/case_form.html
+++ b/templates/epilepsy12/forms/case_form.html
@@ -115,7 +115,7 @@
         <div class="header">Organisation</div>
         <p>
           <b>{% if organisation.trust %}
-              {{organisation.name}}({{organisation.trust.name}}) ({{form.id}})
+              {{organisation.name}}({{organisation.trust.name}})
               {% else %}
               {{organisation.name}}({{organisation.local_health_board.name}})
               {% endif %}

--- a/templates/epilepsy12/partials/case_table.html
+++ b/templates/epilepsy12/partials/case_table.html
@@ -243,7 +243,7 @@
                               showCancelButton: true,
                               confirmButtonColor: '#11a7f2',
                               cancelButtonColor: '#e60700',
-                              confirmButtonText: 'I accept'
+                              confirmButtonText: 'I confirm'
                             })
                           if result.isConfirmed issueRequest()"
                     >
@@ -268,7 +268,7 @@
                               showCancelButton: true,
                               confirmButtonColor: '#11a7f2',
                               cancelButtonColor: '#e60700',
-                              confirmButtonText: 'I accept'
+                              confirmButtonText: 'I confirm'
                             })
                           if result.isConfirmed issueRequest()"
                     >


### PR DESCRIPTION
### Overview

This fixes 4 things to do with the workflow for transferring children between centres.
1. remove E12 users from the email cc when the transfer request is sent
2. if the transfer is refused and the child is returned to the original trust, fix the bug that the original sending organisation is added to list of historical trusts.
3. change the reject/accept modal to read 'I confirm' rather than the more ambiguous 'I accept'
4. Remove the current organisation from the dropdown which appears when the transfer button is pressed. This prevents the user from transferring a child into the organisation where they already are.

### Code changes

Changes are made in 3 files
case_views.py - this deletes the new site object created if the transfer is rejected, and reanimates the previous record.

registration_views: removes members of the RCPCH audit team from the cc in tranfer requests email. removes current organisation from transfer organisation list

case_table: change the wording in the modal button

### Documentation changes (done or required as a result of this PR)

Bug fix, so no implications for documentation

### Related Issues

#538

### Mentions

@mentions of the person or team responsible for reviewing proposed changes.
@anchit_chandran @pacharanero
