### PR TITLE
Dc2007git/issue748

### DIFF
--- a/static/styles/buttons.css
+++ b/static/styles/buttons.css
@@ -94,6 +94,7 @@
 
   .ui.rcpch_light_blue.button.re_sign_in {
     width: 200px;
+    margin-top: 40px;
   }
 
   .centered_button_container {

--- a/static/styles/buttons.css
+++ b/static/styles/buttons.css
@@ -91,6 +91,16 @@
     font-family: var(--rcpch_standard_font) !important;
   }
   
+
+  .ui.rcpch_light_blue.button.re_sign_in {
+    width: 200px;
+  }
+
+  .centered_button_container {
+    display: flex;
+    justify-content: center;
+  }
+  
   /* individual buttons */
   
   .ui.rcpch_primary.button {

--- a/templates/epilepsy12/error_pages/rcpch_403.html
+++ b/templates/epilepsy12/error_pages/rcpch_403.html
@@ -37,18 +37,25 @@
         <div class="ui centered grid">
             <div class="column">
                 <div class="ui sizer vertical segment">
-                    <h2 class="ui left aligned header">You need additional privileges in order to go any further</h2>
+                    <h2 class="ui left aligned header">You may need to sign in again to go further</h2>
                     <h5 class="ui subheader">
                         You are seeing this message because you are trying to access a page where you are not logged in or you don't have the right permissions.
                         If this persists, please contact your local Epilepsy12 administrator or the RCPCH at
                         {% include 'epilepsy12/partials/contact_email.html' %}
                         .
                     </h5>
-                    <img class="ui fluid image"
-                         src="{% static 'styles/images/RCPCH_Epilepsy12_2018_Illustrations_R522.png' %}" />
                 </div>
             </div>
+        </div> 
+        <div class='centered_button_container'>
+            <a class="ui rcpch_light_blue button re_sign_in" href="{% url 'login' %}">
+                Sign In Again
+            </a>
         </div>
+        <div>
+            <img class="ui fluid image"
+                    src="{% static 'styles/images/RCPCH_Epilepsy12_2018_Illustrations_R522.png' %}" />
+        </div> 
     {% endif %}
-</div>
-{% endblock %}
+    {% endblock %}
+    


### PR DESCRIPTION
Fixes #748

### Overview

Adds a redirect button to the login timeout/ inappropriate permissions page. Changes the header text as below:

![image](https://github.com/rcpch/rcpch-audit-engine/assets/65614251/dcc6880d-ff1d-4f53-8b13-2d08e9d26640)


### Code changes

Added a button, changed header text, created 2 new css classes specific for this problem

(this is where Tailwind would be really useful! Instead of having to come up with new classes with semantic meaning for simple code such as display:flex and justify-content: center, tailwind would make those styles clear in the html, and save time looking for named CSS classes!)
