### PR TITLE
Extend timeout in debug mode to reduce re logging in

### DIFF
--- a/.github/workflows/run-docker-compose-test-on-pr.yml
+++ b/.github/workflows/run-docker-compose-test-on-pr.yml
@@ -25,10 +25,6 @@ jobs:
           echo -e "${{ secrets.ENVIRONMENT }}" | base64 -d > envs/.env
           cat envs/.env
 
-      - name: Creates git_hash.txt file current commit hash
-        id: hash
-        run: echo "GIT_BRANCH=$(echo ${GITHUB_REF#refs/heads/}),GIT_HASH=$(git rev-parse --short "$GITHUB_SHA")" > git_hash.txt
-
       - name: Install Docker Compose
         run: |
           sudo apt-get update

--- a/.github/workflows/run-docker-compose-test-on-pr.yml
+++ b/.github/workflows/run-docker-compose-test-on-pr.yml
@@ -35,6 +35,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y docker-compose
 
+      - name: Show Docker environment info
+        run: |
+          docker compose config
+
       - name: Build Docker images and run containers with compose
         run: |
           docker compose up -d

--- a/.github/workflows/run-docker-compose-test-on-pr.yml
+++ b/.github/workflows/run-docker-compose-test-on-pr.yml
@@ -22,7 +22,6 @@ jobs:
 
       - name: Create .env file from repo secrets
         run: |
-          touch envs/.env
           echo -e "${{ secrets.ENVIRONMENT }}" > envs/.env
           cat envs/.env
 

--- a/.github/workflows/run-docker-compose-test-on-pr.yml
+++ b/.github/workflows/run-docker-compose-test-on-pr.yml
@@ -17,8 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - name: Checkout full code repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # to allow git_context_processor.py to still work
 
       - name: Create .env file from repo secrets
         run: |

--- a/.github/workflows/run-docker-compose-test-on-pr.yml
+++ b/.github/workflows/run-docker-compose-test-on-pr.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Create .env file from repo secrets
         run: |
           touch envs/.env
-          echo ${{ secrets.ENVIRONMENT }} >> envs/.env
+          echo "${{ secrets.ENVIRONMENT }}" > envs/.env
           cat envs/.env
 
       - name: Creates git_hash.txt file current commit hash

--- a/.github/workflows/run-docker-compose-test-on-pr.yml
+++ b/.github/workflows/run-docker-compose-test-on-pr.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Create .env file from repo secrets
         run: |
-          echo -e "${{ secrets.ENVIRONMENT }}" > envs/.env
+          echo -e "${{ secrets.ENVIRONMENT }}" | base64 -d > envs/.env
           cat envs/.env
 
       - name: Creates git_hash.txt file current commit hash

--- a/.github/workflows/run-docker-compose-test-on-pr.yml
+++ b/.github/workflows/run-docker-compose-test-on-pr.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Create .env file from repo secrets
         run: |
           touch envs/.env
-          echo  secrets.ENVIRONMENT >> envs/.env
+          echo ${{ secrets.ENVIRONMENT }} >> envs/.env
           cat envs/.env
 
       - name: Creates git_hash.txt file current commit hash

--- a/.github/workflows/run-docker-compose-test-on-pr.yml
+++ b/.github/workflows/run-docker-compose-test-on-pr.yml
@@ -23,47 +23,7 @@ jobs:
       - name: Create .env file from repo secrets
         run: |
           touch envs/.env
-          echo "SITE_DOMAIN=${{ secrets.SITE_DOMAIN }}" >> envs/.env
-          echo "LETSENCRYPT_EMAIL_ADDRESS=${{ secrets.LETSENCRYPT_EMAIL_ADDRESS }}" >> envs/.env
-          echo "LETSENCRYPT_ENDPOINT=${{ secrets.LETSENCRYPT_ENDPOINT }}" >> envs/.env
-          echo "TLS_SOURCE=${{ secrets.TLS_SOURCE }}" >> envs/.env
-          echo "CELERY_BROKER_URL=${{ secrets.CELERY_BROKER_URL }}" >> envs/.env
-          echo "CELERY_RESULT_BACKEND=${{ secrets.CELERY_RESULT_BACKEND }}" >> envs/.env
-          echo "RCPCH_CENSUS_PLATFORM_TOKEN=${{ secrets.RCPCH_CENSUS_PLATFORM_TOKEN }}" >> envs/.env
-          echo "RCPCH_CENSUS_PLATFORM_URL=${{ secrets.RCPCH_CENSUS_PLATFORM_URL }}" >> envs/.env
-          echo "DEBUG=${{ secrets.DEBUG }}" >> envs/.env
-          echo "DJANGO_ALLOWED_HOSTS=${{ secrets.DJANGO_ALLOWED_HOSTS }}" >> envs/.env
-          echo "DJANGO_CSRF_TRUSTED_ORIGINS=${{ secrets.DJANGO_CSRF_TRUSTED_ORIGINS }}" >> envs/.env
-          echo "DJANGO_STARTUP_COMMAND=${{ secrets.DJANGO_STARTUP_COMMAND }}" >> envs/.env
-          echo "CONSOLE_DJANGO_LOG_LEVEL=${{ secrets.CONSOLE_DJANGO_LOG_LEVEL }}" >> envs/.env
-          echo "CONSOLE_LOG_LEVEL=${{ secrets.CONSOLE_LOG_LEVEL }}" >> envs/.env
-          echo "FILE_LOG_LEVEL=${{ secrets.FILE_LOG_LEVEL }}" >> envs/.env
-          echo "E12_SECRET_KEY=${{ secrets.E12_SECRET_KEY }}" >> envs/.env
-          echo "SITE_CONTACT_EMAIL=${{ secrets.SITE_CONTACT_EMAIL }}" >> envs/.env
-          echo "E12_POSTGRES_DB_HOST=${{ secrets.E12_POSTGRES_DB_HOST }}" >> envs/.env
-          echo "E12_POSTGRES_DB_NAME=${{ secrets.E12_POSTGRES_DB_NAME }}" >> envs/.env
-          echo "E12_POSTGRES_DB_PASSWORD=${{ secrets.E12_POSTGRES_DB_PASSWORD }}" >> envs/.env
-          echo "E12_POSTGRES_DB_PORT=${{ secrets.E12_POSTGRES_DB_PORT }}" >> envs/.env
-          echo "E12_POSTGRES_DB_USER=${{ secrets.E12_POSTGRES_DB_USER }}" >> envs/.env
-          echo "EMAIL_DEFAULT_FROM_EMAIL=${{ secrets.EMAIL_DEFAULT_FROM_EMAIL }}" >> envs/.env
-          echo "EMAIL_HOST_PASSWORD=${{ secrets.EMAIL_HOST_PASSWORD }}" >> envs/.env
-          echo "EMAIL_HOST_PORT=${{ secrets.EMAIL_HOST_PORT }}" >> envs/.env
-          echo "EMAIL_HOST_SERVER=${{ secrets.EMAIL_HOST_SERVER }}" >> envs/.env
-          echo "EMAIL_HOST_USER=${{ secrets.EMAIL_HOST_USER }}" >> envs/.env
-          echo "SMTP_EMAIL_ENABLED=${{ secrets.SMTP_EMAIL_ENABLED }}" >> envs/.env
-          echo "FLOWER_PASSWORD=${{ secrets.FLOWER_PASSWORD }}" >> envs/.env
-          echo "FLOWER_PORT=${{ secrets.FLOWER_PORT }}" >> envs/.env
-          echo "FLOWER_USER=${{ secrets.FLOWER_USER }}" >> envs/.env
-          echo "RCPCH_HERMES_SERVER_URL=${{ secrets.RCPCH_HERMES_SERVER_URL }}" >> envs/.env
-          echo "ENABLE_GIT_COMMITTERS=${{ secrets.ENABLE_GIT_COMMITTERS }}" >> envs/.env
-          echo "ENABLE_PDF_EXPORT=${{ secrets.ENABLE_PDF_EXPORT }}" >> envs/.env
-          echo "DOCS_URL=${{ secrets.DOCS_URL }}" >> envs/.env
-          echo "NHS_ODS_API_URL=${{ secrets.NHS_ODS_API_URL }}" >> envs/.env
-          echo "POSTCODE_API_BASE_URL=${{ secrets.POSTCODE_API_BASE_URL }}" >> envs/.env
-          echo "POSTGRES_DB=${{ secrets.POSTGRES_DB }}" >> envs/.env
-          echo "POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}" >> envs/.env
-          echo "POSTGRES_USER=${{ secrets.POSTGRES_USER }}" >> envs/.env
-          echo "TZ=${{ secrets.TZ }}" >> envs/.env
+          echo  secrets.ENVIRONMENT >> envs/.env
           cat envs/.env
 
       - name: Creates git_hash.txt file current commit hash

--- a/.github/workflows/run-docker-compose-test-on-pr.yml
+++ b/.github/workflows/run-docker-compose-test-on-pr.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Create .env file from repo secrets
         run: |
           touch envs/.env
-          echo "${{ secrets.ENVIRONMENT }}" > envs/.env
+          echo -e "${{ secrets.ENVIRONMENT }}" > envs/.env
           cat envs/.env
 
       - name: Creates git_hash.txt file current commit hash

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 ![image](./static/images/epilepsy12-logo-3.png)
 
-All documentation for this project is at https://epilepsy12docs.rcpch.tech/
+All documentation for this project is at <https://e12.rcpch.ac.uk/docs>

--- a/envs/env-template
+++ b/envs/env-template
@@ -21,7 +21,7 @@ RCPCH_CENSUS_PLATFORM_TOKEN= # API key for RCPCH Census Platform (Deprivation sc
 RCPCH_CENSUS_PLATFORM_URL="https://api.rcpch.ac.uk/deprivation/v1"
 
 # DJANGO
-AUTO_LOGOUT_DELAY_MINUTES=30 # minutes
+AUTO_LOGOUT_DELAY_MINUTES=30 # default 30 minutes
 DEBUG="True" # Set DEBUG=True for Local dev and Development, not Staging or Live
 DJANGO_ALLOWED_HOSTS="${SITE_DOMAIN}"
 DJANGO_CSRF_TRUSTED_ORIGINS="https://${SITE_DOMAIN}"

--- a/envs/env-template
+++ b/envs/env-template
@@ -21,6 +21,7 @@ RCPCH_CENSUS_PLATFORM_TOKEN= # API key for RCPCH Census Platform (Deprivation sc
 RCPCH_CENSUS_PLATFORM_URL="https://api.rcpch.ac.uk/deprivation/v1"
 
 # DJANGO
+AUTO_LOGOUT_DELAY_MINUTES=30 # minutes
 DEBUG="True" # Set DEBUG=True for Local dev and Development, not Staging or Live
 DJANGO_ALLOWED_HOSTS="${SITE_DOMAIN}"
 DJANGO_CSRF_TRUSTED_ORIGINS="https://${SITE_DOMAIN}"
@@ -28,6 +29,11 @@ DJANGO_STARTUP_COMMAND="python manage.py runserver 0.0.0.0:8000" # for local dev
 # DJANGO_STARTUP_COMMAND="gunicorn --bind=0.0.0.0:8000 --timeout 600 rcpch-audit-engine.wsgi" # for live deployment
 E12_SECRET_KEY= # secret key for Django
 SITE_CONTACT_EMAIL="sitecontactemail@example.com" # email address for site contact
+
+# DJANGO LOGGING
+CONSOLE_DJANGO_LOG_LEVEL="WARNING" # default Django-specific console logs [DEBUG, INFO, WARNING, ERROR, CRITICAL]
+CONSOLE_LOG_LEVEL="DEBUG" # Epilepsy12 App console logs [DEBUG, INFO, WARNING, ERROR, CRITICAL]
+FILE_LOG_LEVEL="DEBUG" # All logs, but to file [DEBUG, INFO, WARNING, ERROR, CRITICAL]
 
 # DJANGO POSTGRES DATABASE CONNECTION
 E12_POSTGRES_DB_HOST="postgis"

--- a/rcpch-audit-engine/git_context_processor.py
+++ b/rcpch-audit-engine/git_context_processor.py
@@ -3,36 +3,28 @@ from pathlib import Path
 
 def get_active_branch_and_commit(request):
     """
-    Gets the `GIT_HASH` environment variable, created in GitHub Actions workflow, inserts into all templates.
-    
-    If there is no git_hash.txt, such as in local dev, looks directly in the .git folder.
+    Gets the active branch and latest commit hash from the git repo
     """
+
     # Load the txt file containing hash
+
     try:
-        with open("git_hash.txt", "r") as f:
-            git_branch, git_hash = f.read().split(",")
+        head_dir = Path(".") / ".git" / "HEAD"
+        with head_dir.open("r") as f:
+            head_branch = f.read().splitlines()
+        for line in head_branch:
+            if line[0:4] == "ref:":
+                active_git_branch = line.partition("refs/heads/")[2]
+    except:
+        active_git_branch = "[branch name not found]"
 
-            latest_git_commit = git_hash.replace("GIT_HASH=", "")
-            active_git_branch = git_branch.replace("GIT_BRANCH=", "")
+    try:
+        refs_dir = Path(".") / ".git" / "refs" / "heads" / active_git_branch
+        with refs_dir.open("r") as f:
+            latest_git_commit = f.read().splitlines()[0]
 
-    except FileNotFoundError:
-        try:
-            head_dir = Path(".") / ".git" / "HEAD"
-            with head_dir.open("r") as f:
-                head_branch = f.read().splitlines()
-            for line in head_branch:
-                if line[0:4] == "ref:":
-                    active_git_branch = line.partition("refs/heads/")[2]
-        except:
-            active_git_branch = "[branch name not found]"
-
-        try:
-            refs_dir = Path(".") / ".git" / "refs" / "heads" / active_git_branch
-            with refs_dir.open("r") as f:
-                latest_git_commit = f.read().splitlines()[0]
-
-        except:
-            latest_git_commit = "[latest commit hash not found]"
+    except:
+        latest_git_commit = "[latest commit hash not found]"
 
     admin_data = {
         "latest_git_commit": latest_git_commit,

--- a/rcpch-audit-engine/git_context_processor.py
+++ b/rcpch-audit-engine/git_context_processor.py
@@ -1,34 +1,37 @@
+"""
+This module contains a function to get the active branch and latest commit hash
+from the git repo.
+"""
+
 from pathlib import Path
+import logging
+
+# set up logging
+logger = logging.getLogger(__name__)
 
 
-def get_active_branch_and_commit(request):
+def get_active_branch_and_commit(_request):
     """
     Gets the active branch and latest commit hash from the git repo
     """
 
-    # Load the txt file containing hash
-
-    try:
-        head_dir = Path(".") / ".git" / "HEAD"
-        with head_dir.open("r") as f:
-            head_branch = f.read().splitlines()
-        for line in head_branch:
-            if line[0:4] == "ref:":
-                active_git_branch = line.partition("refs/heads/")[2]
-    except:
-        active_git_branch = "[branch name not found]"
-
-    try:
-        refs_dir = Path(".") / ".git" / "refs" / "heads" / active_git_branch
-        with refs_dir.open("r") as f:
-            latest_git_commit = f.read().splitlines()[0]
-
-    except:
-        latest_git_commit = "[latest commit hash not found]"
-
-    admin_data = {
-        "latest_git_commit": latest_git_commit,
-        "active_git_branch": active_git_branch,
+    # set defaults/fallback for values in git_data dict
+    git_data = {
+        "active_git_branch": "[branch name not found]",
+        "latest_git_commit": "[latest commit hash not found]",
     }
 
-    return admin_data
+    head_dir = Path(".") / ".git" / "HEAD"
+    with head_dir.open("r") as f:
+        head_branch = f.read().splitlines()
+    for line in head_branch:
+        if line[0:4] == "ref:":
+            git_data["active_git_branch"] = line.partition("refs/heads/")[2]
+    logger.info("Active git branch: %s", git_data["active_git_branch"])
+
+    refs_dir = Path(".") / ".git" / "refs" / "heads" / git_data["active_git_branch"]
+    with refs_dir.open("r") as f:
+        git_data["latest_git_commit"] = f.read().splitlines()[0]
+    logger.info("Latest git commit: %s", git_data["latest_git_commit"])
+
+    return git_data

--- a/rcpch-audit-engine/git_context_processor.py
+++ b/rcpch-audit-engine/git_context_processor.py
@@ -10,7 +10,9 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def get_active_branch_and_commit(_request):
+def get_active_branch_and_commit(
+    request,  # pylint: disable=unused-argument
+):
     """
     Gets the active branch and latest commit hash from the git repo
     """
@@ -21,17 +23,20 @@ def get_active_branch_and_commit(_request):
         "latest_git_commit": "[latest commit hash not found]",
     }
 
-    head_dir = Path(".") / ".git" / "HEAD"
-    with head_dir.open("r") as f:
-        head_branch = f.read().splitlines()
-    for line in head_branch:
-        if line[0:4] == "ref:":
-            git_data["active_git_branch"] = line.partition("refs/heads/")[2]
-    logger.info("Active git branch: %s", git_data["active_git_branch"])
+    try:
+        head_dir = Path(".") / ".git" / "HEAD"
+        with head_dir.open("r") as f:
+            head_branch = f.read().splitlines()
+        for line in head_branch:
+            if line[0:4] == "ref:":
+                git_data["active_git_branch"] = line.partition("refs/heads/")[2]
+        logger.info("Active git branch: %s", git_data["active_git_branch"])
 
-    refs_dir = Path(".") / ".git" / "refs" / "heads" / git_data["active_git_branch"]
-    with refs_dir.open("r") as f:
-        git_data["latest_git_commit"] = f.read().splitlines()[0]
-    logger.info("Latest git commit: %s", git_data["latest_git_commit"])
+        refs_dir = Path(".") / ".git" / "refs" / "heads" / git_data["active_git_branch"]
+        with refs_dir.open("r") as f:
+            git_data["latest_git_commit"] = f.read().splitlines()[0]
+        logger.info("Latest git commit: %s", git_data["latest_git_commit"])
+    except:  # pylint: disable=bare-except
+        logger.exception("Error getting git data from repository")
 
     return git_data

--- a/rcpch-audit-engine/settings.py
+++ b/rcpch-audit-engine/settings.py
@@ -22,7 +22,7 @@ from celery.schedules import crontab
 from django.core.management.utils import get_random_secret_key
 
 # RCPCH imports
-from .logging_settings import LOGGING
+from .logging_settings import LOGGING # no it is not an unused import, it pulls LOGGING into the settings file
 
 logger = logging.getLogger(__name__)
 

--- a/rcpch-audit-engine/settings.py
+++ b/rcpch-audit-engine/settings.py
@@ -134,7 +134,7 @@ ROOT_URLCONF = "rcpch-audit-engine.urls"
 
 # AUTO LOGOUT SESSION EXPIRATION
 AUTO_LOGOUT = {
-    "IDLE_TIME": os.getenv("AUTO_LOGOUT_DELAY_MINUTES"),
+    "IDLE_TIME": int(os.getenv("AUTO_LOGOUT_DELAY_MINUTES")),
     "REDIRECT_TO_LOGIN_IMMEDIATELY": True,
     "MESSAGE": "You have been automatically logged out as there was no activity for 30 minutes. Please login again to continue.",
 }

--- a/rcpch-audit-engine/settings.py
+++ b/rcpch-audit-engine/settings.py
@@ -134,7 +134,7 @@ ROOT_URLCONF = "rcpch-audit-engine.urls"
 
 # AUTO LOGOUT SESSION EXPIRATION
 AUTO_LOGOUT = {
-    "IDLE_TIME": datetime.timedelta(minutes=30),
+    "IDLE_TIME": os.getenv("AUTO_LOGOUT_DELAY_MINUTES"),
     "REDIRECT_TO_LOGIN_IMMEDIATELY": True,
     "MESSAGE": "You have been automatically logged out as there was no activity for 30 minutes. Please login again to continue.",
 }


### PR DESCRIPTION
### Overview

1. to reduce the amount of time spent logging in when in local development by moving this setting into an env var
2. to reduce the complexity of adding new env vars to GitHub by making them all handled in a single GitHub secret and piped into a file for docker compose when the test runner starts.
