### PR TITLE
Fixes the redirect to Signin Page problem

### DIFF
--- a/epilepsy12/views/redirects.py
+++ b/epilepsy12/views/redirects.py
@@ -22,9 +22,21 @@ def rcpch_403(request, exception):
     # the 403 template would be inserted into the target. This way the HttpReponseClientRedirect
     # from django-htmx middleware forces a redirect to the two-factor sign-in page
     if request.htmx:
-        return HttpResponseClientRedirect('two_factor:login', status=403)
+        if request.user.is_authenticated:
+            redirect_url = reverse_lazy("redirect_403")
+            return HttpResponseClientRedirect(redirect_url, status=403)
+        else: 
+            return HttpResponseClientRedirect('two_factor:login', status=403)
     else:
-        return redirect('two_factor:login')
+        if request.user.is_authenticated:
+            return render(
+            request,
+            template_name="epilepsy12/error_pages/rcpch_403.html",
+            context={},
+            status=403,
+        )
+        else:
+            return redirect('two_factor:login')
 
 
 def redirect_403(request):

--- a/epilepsy12/views/redirects.py
+++ b/epilepsy12/views/redirects.py
@@ -20,17 +20,11 @@ def rcpch_403(request, exception):
     # it is called on raise PermissionDenied()
     # If a 403 template were to be returned at this point as in standard django,
     # the 403 template would be inserted into the target. This way the HttpReponseClientRedirect
-    # from django-htmx middleware forces a redirect. Neat.
+    # from django-htmx middleware forces a redirect to the two-factor sign-in page
     if request.htmx:
-        redirect = reverse_lazy("redirect_403")
-        return HttpResponseClientRedirect(redirect, status=403)
+        return HttpResponseClientRedirect('two_factor:login', status=403)
     else:
-        return render(
-            request,
-            template_name="epilepsy12/error_pages/rcpch_403.html",
-            context={},
-            status=403,
-        )
+        return redirect('two_factor:login')
 
 
 def redirect_403(request):

--- a/rcpch-audit-engine/settings.py
+++ b/rcpch-audit-engine/settings.py
@@ -142,7 +142,7 @@ AUTO_LOGOUT = {
 # LOGIN_URL = "/registration/login/"
 LOGIN_URL = "two_factor:login"  # change LOGIN_URL to the 2fa one
 LOGIN_REDIRECT_URL = "two_factor:profile"
-LOGOUT_REDIRECT_URL = "/"
+LOGOUT_REDIRECT_URL = "two_factor:login"
 
 # REDIS / Celery
 CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL")


### PR DESCRIPTION
### Code changes

Instead of redirecting the user to the 'additional privileges' template upon a 403 being raised, it redirects the user straight to the Sign In page. This has been tested by changing the AUTO_LOGOUT IDLE_TIME parameter to 1 minute and watching the Sign In page load in. Additionally, the 'You have been automatically logged out as there was no activity for 30 minutes' message pops up when this happens.

Now if the user is authenticated, then the 403 template is rendered, which has inbuilt conditionals depending on whether the user has been 2fa-verified or not, and deals with those situations. 

OR, if the user is not authenticated, and tries to access something they don't have permissions for, say a different organisation, then they face the 'additional privileges' page. Alternatively, upon session timeout, they are redirected to the login page

### Documentation changes (done or required as a result of this PR)

None

### Related Issues

Fixes #748 
