### PR TITLE
'Other' option in Cause - multiaxial diagnosis

### DIFF
--- a/documentation/docs/development/dropdowns.md
+++ b/documentation/docs/development/dropdowns.md
@@ -1,0 +1,26 @@
+---
+title: Dropdowns
+reviewers: Dr Simon Chapman
+---
+
+## Lists
+
+Lists that feed either the toggle buttons or the select dropdowns are either found in the `constants` folder, or are seeded to the database in the `migrations`.
+
+Organisation lists are seeded from `constants` as are the levels of abstraction associated with them (trust, ICB etc.) The Epilepsy causes and comorbidities, by contrast are a SNOMED refset seeded from the RCPCH SNOMED server in migration 0006 and 0009 into EpilepsyCause and ComorbidityList resp. Syndromes and medications are from lists in the `constants` folder.
+
+Since go-live, E12 have wished on the basis of user feedback, wanted to add new items to these lists. The process for adding new items should be:
+
+### EpilepsyCause
+
+1. Epilepsy12 team to supply the SNOMED CT ID (SCTID) of the concept
+2. The development team add the SCTID to the list `extra_concept_ids` in migration 0006 for future seeding from scratch, mostly for development reasons
+3. In the python shell to run the seed function:
+
+```console
+python manage.py --mode=add_new_epilepsy_causes -sctids 764946008 52767006
+```
+
+Note that the function expects a list, even if only one item is supplied.
+
+<!-- There will need to be further documentation added here for new organisations and trust, as well as new comorbidities, and possibly medications and so on. For now, this is the workflow for EpilepsyCauses -->

--- a/documentation/docs/development/dropdowns.md
+++ b/documentation/docs/development/dropdowns.md
@@ -7,9 +7,19 @@ reviewers: Dr Simon Chapman
 
 Lists that feed either the toggle buttons or the select dropdowns are either found in the `constants` folder, or are seeded to the database in the `migrations`.
 
-Organisation lists are seeded from `constants` as are the levels of abstraction associated with them (trust, ICB etc.) The Epilepsy causes and comorbidities, by contrast are a SNOMED refset seeded from the RCPCH SNOMED server in migration 0006 and 0009 into EpilepsyCause and ComorbidityList resp. Syndromes and medications are from lists in the `constants` folder.
+**Organisation** lists are seeded from `constants` as are the levels of abstraction associated with them (trust, ICB etc.) 
 
-Since go-live, E12 have wished on the basis of user feedback, wanted to add new items to these lists. The process for adding new items should be:
+The **Epilepsy causes** and **comorbidities**, by contrast are a SNOMED refset seeded from the RCPCH SNOMED server in migration 0006 and 0009 into EpilepsyCause and ComorbidityList respectively.
+
+**Syndromes** are from lists in the `constants` folder.
+
+**Epilepsy medicines** (both rescue and not) are found in the `constants` folder but look up the full SNOMED concept from the RCPCH SNOMED server before saving in the Medicine table.
+
+**Semiology Keywords**, used to categorize words in the free text descriptions of a seizure event, are taken from a list in the `constants` folder.
+
+The tables that supply the dropdowns are seeded in the migrations which is a recommended way in the [Django documentation](https://docs.djangoproject.com/en/5.0/topics/migrations/#data-migrations) to add data, known as data migrations.
+
+Since go-live, E12 have wished on the basis of user feedback, from time to time to add new items to these lists. The process for adding new items should be:
 
 ### EpilepsyCause
 
@@ -24,3 +34,27 @@ python manage.py --mode=add_new_epilepsy_causes -sctids 764946008 52767006
 Note that the function expects a list, even if only one item is supplied.
 
 <!-- There will need to be further documentation added here for new organisations and trust, as well as new comorbidities, and possibly medications and so on. For now, this is the workflow for EpilepsyCauses -->
+
+### Organisations
+
+Just updating the `RCPCH_ORGANISATIONS` constant will not in itself update the database, but is a necessary step in the process. The workflow needs to be:
+
+#### Deleting an organisation
+
+1. check there are no children associated with this organisation. If there are, it must not be deleted
+2. Delete the organisation in the admin. This will delete any relationships it also has with associated trusts/health boards etc as well KPIAggregation models
+
+#### Updating an organisation
+
+This can be done reasonably straightforwardly in the admin. Note that the ODS Code is a unique identifier and if the update includes an update to this, you are in effect creating a new organisation, rather than editing an existing one. Better therefore to create a new organisation and delete the old. This becomes more complicated if there are children associated with this organisation.
+
+#### Adding a new organisation
+
+This can be done in the admin. The ODS Code must be unique. The name and ODS code should ideally be mandatory fields but are not currently prescribed as such in the model. Note that you must also allocate the Trust/Health Board, ICB, NHS England Region, London Borough and Country.
+Add the same details to the `RCPCH_ORGANISATIONS` constant. This is necessary later when seeding the KPI Aggregation models
+in the shell:
+
+```console
+from epilepsy12.common_view_functions import _seed_all_aggregation_models
+_seed_all_aggregation_models()
+```

--- a/documentation/docs/development/dropdowns.md
+++ b/documentation/docs/development/dropdowns.md
@@ -7,7 +7,7 @@ reviewers: Dr Simon Chapman
 
 Lists that feed either the toggle buttons or the select dropdowns are either found in the `constants` folder, or are seeded to the database in the `migrations`.
 
-**Organisation** lists are seeded from `constants` as are the levels of abstraction associated with them (trust, ICB etc.) 
+**Organisation** lists are seeded from `constants` as are the levels of abstraction associated with them (trust, ICB etc.)
 
 The **Epilepsy causes** and **comorbidities**, by contrast are a SNOMED refset seeded from the RCPCH SNOMED server in migration 0006 and 0009 into EpilepsyCause and ComorbidityList respectively.
 
@@ -28,7 +28,7 @@ Since go-live, E12 have wished on the basis of user feedback, from time to time 
 3. In the python shell to run the seed function:
 
 ```console
-python manage.py --mode=add_new_epilepsy_causes -sctids 764946008 52767006
+docker compose exec django python manage.py seed --mode=add_new_epilepsy_causes -sctids 764946008 52767006 ...
 ```
 
 Note that the function expects a list, even if only one item is supplied.

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -169,6 +169,7 @@ nav:
       - Overall structure: 'development/application-structure.md'
       - Design Rationale: 'development/design-decisions.md'
       - Database: 'development/database.md'
+      - Dropdown Lists: 'development/dropdowns.md'
       - Audit Forms: 'development/audit-forms.md'
       - Form Scoring: 'development/form-scoring.md'
       - KPIs: 'development/key-performance-indicators.md'

--- a/epilepsy12/general_functions/fetch_snomed.py
+++ b/epilepsy12/general_functions/fetch_snomed.py
@@ -1,12 +1,13 @@
 # standard imports
 import logging
 import requests
+from pprint import pprint
 
 # third party imports
 from django.conf import settings
 
 # RCPCH imports
-from ..constants import BENZODIAZEPINE_TYPES, ANTIEPILEPSY_MEDICINE_TYPES
+from django.apps import apps
 
 # Logging setup
 logger = logging.getLogger(__name__)
@@ -32,7 +33,7 @@ def fetch_concept(concept_id):
     """
     Returns a SNOMED concept from the RPCH Hermes API against a concept id
     """
-    search_url = f"{settings.RCPCH_HERMES_SERVER_URL}/concepts/{concept_id}/extended"
+    search_url = f"{settings.RCPCH_HERMES_SERVER_URL}/expand?ecl={concept_id}"
 
     response = requests.get(search_url)
 
@@ -62,3 +63,63 @@ def fetch_paediatric_neurodisability_outpatient_diagnosis_simple_reference_set()
     ]
 
     return response_no_asd
+
+
+def add_cause_by_sctid_to_database(sct_id: int):
+    """
+    Function that accepts an SCTID (sanctioned by the E12 team), uses this to get the SNOMED concept
+    and persist this in the database.
+    """
+    EpilepsyCause = apps.get_model("epilepsy12", "EpilepsyCause")
+    error_message = None
+    try:
+        snomed_concept = fetch_concept(concept_id=sct_id)[0]
+    except Exception as error:
+        error_message = error
+        return {"success": False, "concept": None, "error": error_message}
+
+    if EpilepsyCause.objects.filter(conceptId=snomed_concept["conceptId"]).exists():
+        # duplicate conceptId
+        return {
+            "success": False,
+            "concept": snomed_concept["conceptId"],
+            "error": "Duplicate. Item not saved.",
+        }
+    else:
+        new_cause = EpilepsyCause(
+            conceptId=snomed_concept["conceptId"],
+            term=snomed_concept["term"],
+            preferredTerm=snomed_concept["preferredTerm"],
+        )
+        try:
+            new_cause.save()
+        except Exception as e:
+            logger.info(
+                f"Epilepsy cause {snomed_concept['preferredTerm']} not added. {e}"
+            )
+            return {"success": False, "concept": None, "error": e}
+    logger.info(f"{snomed_concept['preferredTerm']} added")
+    return {"success": True, "concept": snomed_concept, "error": None}
+
+
+def add_epilepsy_cause_list_by_sctid(extra_concept_ids: list):
+    """
+    Adds a new list of epilepsy causes
+    Duplicates will be ignored
+    Accepts a list of SCT IDs
+    **Note the SCT ID should be added to the extra_concept_ids list in migration 0006**
+    """
+    index = 0
+
+    for sct_id in extra_concept_ids:
+        response = add_cause_by_sctid_to_database(sct_id=sct_id)
+        if response["success"]:
+            index += 1
+        else:
+            logger.error(response["error"])
+    if len(extra_concept_ids) == index:
+        info_string = f"{index} extra concepts added."
+        logger.info(info_string)
+    else:
+        warning_string = f"Only {index} extra concepts from an expected total {len(extra_concept_ids)} added. Check logs for errors."
+        logger.warning(warning_string)

--- a/epilepsy12/migrations/0006_seed_epilepsy_causes.py
+++ b/epilepsy12/migrations/0006_seed_epilepsy_causes.py
@@ -3,7 +3,7 @@ import logging
 
 from django.db import migrations
 
-from ..general_functions import fetch_ecl
+from ..general_functions import fetch_ecl, add_epilepsy_cause_list_by_sctid
 
 # Logging setup
 logger = logging.getLogger(__name__)
@@ -42,6 +42,34 @@ def seed_epilepsy_causes(apps, schema_editor):
             except Exception as e:
                 logger.info(f"Epilepsy cause {cause['preferredTerm']} not added. {e}")
     logger.info(f"{index} epilepsy causes added")
+
+    """
+    These are additional causes added after go live
+    Added here now so that any development work where the database has been reseeded
+    remains in sync with what is live
+    """
+
+    # Constitutional mismatch repair deficiency syndrome (CMMRD) - 764946008
+    # Neonatal hypoglycaemia - 52767006
+    # Hypoxic ischaemic encephalopathy - 703300001
+    # Perinatal arterial ischaemic stroke - 722929005
+    # Non-accidental injury to child - 158094009
+    # Periventricular leukomalacia - 230769007
+    # Neonatal cerebral haemorrhage - 261808007
+    # Cornelia de Lange Syndrome (CdLS) - 40354009
+    # Anoxic encephalopathy - 389098007
+    extra_concept_ids = [
+        764946008,
+        52767006,
+        703300001,
+        722929005,
+        158094009,
+        230769007,
+        261808007,
+        40354009,
+        389098007,
+    ]
+    add_epilepsy_cause_list_by_sctid(extra_concept_ids=extra_concept_ids)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Fixes #723

### Overview

This adds a work flow largely from the command prompt as a `manage.py` command to update the database with new epilepsy causes. This could be done simply in the django admin, but epilepsy causes we normally pull from our snomed server, so this PR contains a new function(s) to accept a list of snomedct ids, fetch the concepts from our server and store the relevant fields (term and preferredTerm) in the tables.

### Code changes
`migration_0006`: this is where epilepsy causes are seeded. Any new causes are stored here so that any new instances of E12 are run (such as in development) to ensure the causes in live match what is in the new instance

`general_functions/fetch_snomed.py`: 2 functions to make the API call with the SCTID and persist the result. The second accepts a list of sctids and iteratively calls the first. Errors and success are returned as an object and this is used to log to the console.

`management/commands/seed.py`: adds a new mode and parameter. Example: `python manage.py --mode=add_new_epilepsy_causes -sctids 76496008 52767006`
Note accepts a list minimum length of 1. Duplicates are skipped but logged to the console.

### Documentation changes (done or required as a result of this PR)
I have added a new documentation file to describe the workflow to the docs. I realise now that I forgot to add this to the yml also, so will not show but the text is there.

### Related Issues

#723

### Mentions

@mentions of the person or team responsible for reviewing proposed changes.
