### PR TITLE
case pagination not working if filter applied

### DIFF
--- a/epilepsy12/templatetags/epilepsy12_template_tags.py
+++ b/epilepsy12/templatetags/epilepsy12_template_tags.py
@@ -479,13 +479,24 @@ def no_eligible_cases(aggregation_model, kpi_name: str):
 # the list of which can be found in 'capitalised_words' below
 @register.filter
 def capitalise_org_names(organisation_name):
-    capitalised_words = ['Ii', 'Rbh', 'Nhs', 'Cdc', '(Hq)', '(Epma)', '(Epact)', 'Gstt', 'Qmc', 'Ctr']
+    capitalised_words = [
+        "Ii",
+        "Rbh",
+        "Nhs",
+        "Cdc",
+        "(Hq)",
+        "(Epma)",
+        "(Epact)",
+        "Gstt",
+        "Qmc",
+        "Ctr",
+    ]
     organisation_name = organisation_name.split()
     organisation_name = [
         name.upper() if name in capitalised_words else name
         for name in organisation_name
     ]
-    organisation_name = ' '.join(organisation_name)
+    organisation_name = " ".join(organisation_name)
     return mark_safe(organisation_name)
 
 

--- a/epilepsy12/views/case_views.py
+++ b/epilepsy12/views/case_views.py
@@ -35,6 +35,7 @@ from ..tasks import asynchronously_send_email_to_recipients
 # Logging setup
 logger = logging.getLogger(__name__)
 
+
 @login_and_otp_required()
 @user_may_view_this_organisation()
 def case_list(request, organisation_id):
@@ -320,6 +321,7 @@ def case_list(request, organisation_id):
         "rcpch_choices": rcpch_choices,
         "organisation_id": organisation_id,
         "cases_in_transfer": cases_in_transfer,
+        "filtered_case_list": filter_term,
     }
     if request.htmx:
         return render(

--- a/templates/epilepsy12/cases/cases.html
+++ b/templates/epilepsy12/cases/cases.html
@@ -43,7 +43,7 @@
       </div>
 
       <div id="case_table">
-        {% include '../partials/case_table.html' with case_list=case_list paginated=paginated organisation=organisation %}
+        {% include '../partials/case_table.html' with case_list=case_list paginated=paginated organisation=organisation filtered_case_list=filter_case_list %}
       </div>
 
       

--- a/templates/epilepsy12/partials/case_table.html
+++ b/templates/epilepsy12/partials/case_table.html
@@ -299,18 +299,22 @@
     <tfoot>
       <tr>
         <th colspan="10" class="right aligned">
-          {% if case_list %}
-            <label>page {{case_list.number}} of {{case_list.paginator.num_pages}}</label>
-          {% endif %}
           {% if case_list.has_previous %}
           <div class="ui rcpch_primary button" hx-target="#case_table"
-            hx-get="{% url 'cases' organisation_id=organisation.pk %}?page={{case_list.previous_page_number}}&filtered_case_list={{filtered_case_list}}&sort_flag={{sort_flag}}"
-            hx-swap="innerHTML">Previous 10</div>
+          hx-get="{% url 'cases' organisation_id=organisation.pk %}?page={{case_list.previous_page_number}}&filtered_case_list={{filtered_case_list}}&sort_flag={{sort_flag}}"
+          hx-swap="innerHTML">Previous 10</div>
           {% endif %}
           {% if case_list.has_next %}
           <div class="ui rcpch_primary button" name="next_button" hx-target="#case_table"
-            hx-get="{% url 'cases' organisation_id=organisation.pk  %}?page={{ case_list.next_page_number }}&filtered_case_list={{filtered_case_list}}&sort_flag={{sort_flag}}"
-            hx-swap="innerHTML">Next 10</div>
+          hx-get="{% url 'cases' organisation_id=organisation.pk  %}?page={{ case_list.next_page_number }}&filtered_case_list={{filtered_case_list}}&sort_flag={{sort_flag}}"
+          hx-swap="innerHTML">Next 10</div>
+          {% endif %}
+        </th>
+      </tr>
+      <tr>
+        <th colspan="12" class="right aligned">
+          {% if case_list %}
+            <label>Page {{case_list.number}} of {{case_list.paginator.num_pages}}</label>
           {% endif %}
         </th>
       </tr>

--- a/templates/epilepsy12/partials/case_table.html
+++ b/templates/epilepsy12/partials/case_table.html
@@ -299,14 +299,17 @@
     <tfoot>
       <tr>
         <th colspan="10" class="right aligned">
+          {% if case_list %}
+            <label>page {{case_list.number}} of {{case_list.paginator.num_pages}}</label>
+          {% endif %}
           {% if case_list.has_previous %}
           <div class="ui rcpch_primary button" hx-target="#case_table"
-            hx-get="{% url 'cases' organisation_id=organisation.pk %}?page={{case_list.previous_page_number}}&sort_flag={{sort_flag}}"
+            hx-get="{% url 'cases' organisation_id=organisation.pk %}?page={{case_list.previous_page_number}}&filtered_case_list={{filtered_case_list}}&sort_flag={{sort_flag}}"
             hx-swap="innerHTML">Previous 10</div>
           {% endif %}
           {% if case_list.has_next %}
           <div class="ui rcpch_primary button" name="next_button" hx-target="#case_table"
-            hx-get="{% url 'cases' organisation_id=organisation.pk  %}?page={{case_list.next_page_number}}&sort_flag={{sort_flag}}"
+            hx-get="{% url 'cases' organisation_id=organisation.pk  %}?page={{ case_list.next_page_number }}&filtered_case_list={{filtered_case_list}}&sort_flag={{sort_flag}}"
             hx-swap="innerHTML">Next 10</div>
           {% endif %}
         </th>


### PR DESCRIPTION
also adds pagination counter
Fixes #766

### Overview

A bug noticed by E12 that on filtering cases using the search box, the filter term is lost on clicking on the next and previous page buttons.

The reason for this is that the filter term was not added to the URL and therefore the filtering was lost on table refresh.

### Code changes

The filter term passed to `case_list` (via `cases`) on keyup from the search box is passed back to that template in the context. This allows the template to add it to the URL on clicking the next and previous page buttons.

For clarity, an extra label has been added to the footer of the cases table to notify the user how many pages are viewable, and the number of the current page.

### Documentation changes (done or required as a result of this PR)

No implications for documentation

### Related Issues

Fixes #766
