### PR TITLE
Reduce docker overall memory footprint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: "3.10"
 x-global-environment: &global
   env_file:
     - envs/.env # env file - NOT committed to Git
+  volumes:
+    - .:/app/
 
 services:
   # Caddy reverse proxy - web-facing SSL server
@@ -26,11 +28,10 @@ services:
   django: &django
     <<: *global # this will inherit all the envs from x-global-environment
     build: .
+    image: e12-django:built # build image and save for use by other containers
     depends_on:
       - postgis
       - redis
-    volumes:
-      - .:/app/
     command: >
       sh -c "python manage.py collectstatic --noinput &&
         python manage.py migrate &&
@@ -41,7 +42,7 @@ services:
 
   # PostgreSQL with PostGIS extension
   postgis:
-    <<: *global # this will inherit all the envs from x-global-environment
+    <<: *global # this will inherit config from x-global-environment
     image: postgis/postgis:15-3.3
     volumes:
       - postgis-data:/var/lib/postgresql/data
@@ -56,13 +57,15 @@ services:
 
   # Celery worker
   celeryworker:
-    <<: *django # this will inherit all the settings from the django service
+    <<: *global # this will inherit config from x-global-environment
+    image: e12-django:built
     command: celery -A rcpch-audit-engine worker -l info
     restart: always
 
   # Flower UI for Celery tasks
   flower:
-    <<: *django # this will inherit all the settings from the django service
+    <<: *global # this will inherit config from x-global-environment
+    image: e12-django:built
     ports:
       - 8888:8888
     volumes:
@@ -72,12 +75,14 @@ services:
 
   # Celery scheduled tasks/cron
   celerybeat:
-    <<: *django # this will inherit all the settings from the django service
+    <<: *global # this will inherit config from x-global-environment
+    image: e12-django:built
     command: celery -A rcpch-audit-engine beat -l info
     restart: always
 
   mkdocs:
-    <<: *django # this will inherit all the settings from the django service
+    <<: *global # this will inherit config from x-global-environment
+    image: e12-django:built
     ports:
       - 8001:8001
     command: >


### PR DESCRIPTION
### Overview

Docker Compose when running in GitHub Actions is failing due to high memory usage. We have two options here:

1) be more efficient in how Docker images are built and how they are used as containers. Our Django image is 2Gb in size, but we are reusing it for all the other Python related service (celery, celerybeat, mkdocs, flower) so it is very heavy on memory. This is the preferred option since it makes us use resources more carefully and mindfully.

2) switch to a self-hosted Actions runner - we supply a VPS of any size we want, and install GH agent on it (easy to do) , then specify `runs-on: self-hosted` in the GitHub Action workflow file. We might be able to reuse the Development VPS for this, possibly...

3) pay for GitHub Enterprise and use GitHub-hosted larger runners - costs are per-minute and so might well be cheaper to pay GH than to host our own VPS (which we would have to pay for all the time rather than per-minute)

### Documentation changes (done or required as a result of this PR)

Please describe any changes to documentation here.

### Related Issues

List any issues related to this PR here.

### Mentions

@mentions of the person or team responsible for reviewing proposed changes.
