### PR TITLE
Organisation-id-mismatch-on-create-user-handling

### DIFF
--- a/epilepsy12/forms_folder/epilepsy12_user_form.py
+++ b/epilepsy12/forms_folder/epilepsy12_user_form.py
@@ -20,6 +20,7 @@ from ..models import Epilepsy12User, Organisation, VisitActivity
 # Logging setup
 logger = logging.getLogger(__name__)
 
+
 class Epilepsy12UserUpdatePasswordForm(SetPasswordForm):
     # form show when setting or resetting password
     # password validation occurs here and updates the password_last_set field

--- a/epilepsy12/tests/view_tests/permissions_tests/test_permissions_create.py
+++ b/epilepsy12/tests/view_tests/permissions_tests/test_permissions_create.py
@@ -110,7 +110,9 @@ from epilepsy12.models import (
     Organisation,
     Case,
 )
-from epilepsy12.tests.view_tests.permissions_tests.perm_tests_utils import twofactor_signin
+from epilepsy12.tests.view_tests.permissions_tests.perm_tests_utils import (
+    twofactor_signin,
+)
 
 
 @pytest.mark.django_db
@@ -149,10 +151,8 @@ def test_user_create_same_org_success(
         ), f"Incorrect number of users selected. Requested {len(selected_users)} but queryset contains {len(users)}: {users}"
 
     for test_user in users:
-        
-        
         client.force_login(test_user)
-        
+
         # OTP ENABLE
         twofactor_signin(client, test_user)
 
@@ -178,7 +178,7 @@ def test_user_create_same_org_success(
             "organisation_employer": TEST_USER_ORGANISATION.id,
             "first_name": TEMP_CREATED_USER_FIRST_NAME,
             "surname": "User",
-            "is_rcpch_audit_team_member": True,
+            "is_rcpch_audit_team_member": False,
             "is_rcpch_staff": False,
             "email_confirmed": True,
         }
@@ -229,7 +229,7 @@ def test_user_create_diff_org_success(
 
     for test_user in users:
         client.force_login(test_user)
-        
+
         # OTP ENABLE
         twofactor_signin(client, test_user)
 
@@ -302,7 +302,7 @@ def test_user_creation_forbidden(
 
     for test_user in users:
         client.force_login(test_user)
-        
+
         # OTP ENABLE
         twofactor_signin(client, test_user)
 
@@ -388,7 +388,7 @@ def test_patient_create_success(
 
     for test_user in users:
         client.force_login(test_user)
-        
+
         # OTP ENABLE
         twofactor_signin(client, test_user)
 
@@ -508,7 +508,7 @@ def test_patient_creation_forbidden(
 
     for test_user in users:
         client.force_login(test_user)
-        
+
         # OTP ENABLE
         twofactor_signin(client, test_user)
 
@@ -600,7 +600,7 @@ def test_add_episode_comorbidity_syndrome_aem_success(client):
 
     for test_user in users:
         client.force_login(test_user)
-        
+
         # OTP ENABLE
         twofactor_signin(client, test_user)
 

--- a/epilepsy12/views/user_management_views.py
+++ b/epilepsy12/views/user_management_views.py
@@ -335,16 +335,23 @@ def create_epilepsy12_user(request, organisation_id, user_type, epilepsy12_user_
         )
 
         if form.is_valid():
-            # decorator cannot keep out users that change the organisation at this point.
-            if new_user.organisation_employer != request.user.organisation_employer:
+            # decorator cannot keep out bad actors that change the organisation at this point.
+            if form.cleaned_data.get(
+                "organisation_employer"
+            ) != request.user.organisation_employer and not (
+                request.user.is_rcpch_audit_team_member or request.user.is_superuser
+            ):
                 raise PermissionDenied()
-            # decorator cannot keep out bad actors that change the is_rcpch_audit_team_member flag
-            if new_user.is_rcpch_audit_team_member and not (
+            # decorator cannot keep out bad actors that change the is_rcpch_audit_team_member or is_superuser flag in post request
+            if (
+                form.cleaned_data.get("is_rcpch_audit_team_member")
+                or form.cleaned_data.get("is_superuser")
+            ) and not (
                 request.user.is_rcpch_audit_team_member or request.user.is_superuser
             ):
                 raise PermissionDenied()
 
-            # save new user and add to gropup - return to user list with success message
+            # save new user and add to group - return to user list with success message
             # send sign up email asynchronously
             # If signup unsuccessful, user not saved return to list with error message. Email not sent.
             new_user = form.save(commit=False)
@@ -487,6 +494,21 @@ def edit_epilepsy12_user(request, organisation_id, epilepsy12_user_id):
 
         else:
             if form.is_valid():
+                # decorator cannot keep out bad actors that change the organisation at this point.
+                if form.cleaned_data.get(
+                    "organisation_employer"
+                ) != request.user.organisation_employer and not (
+                    request.user.is_rcpch_audit_team_member or request.user.is_superuser
+                ):
+                    raise PermissionDenied()
+                # decorator cannot keep out bad actors that change the is_rcpch_audit_team_member or is_superuser flag in post request
+                if (
+                    form.cleaned_data.get("is_rcpch_audit_team_member")
+                    or form.cleaned_data.get("is_superuser")
+                ) and not (
+                    request.user.is_rcpch_audit_team_member or request.user.is_superuser
+                ):
+                    raise PermissionDenied()
                 # this will not include the password which will be empty
                 new_user = form.save()
 

--- a/epilepsy12/views/user_management_views.py
+++ b/epilepsy12/views/user_management_views.py
@@ -335,6 +335,15 @@ def create_epilepsy12_user(request, organisation_id, user_type, epilepsy12_user_
         )
 
         if form.is_valid():
+            # decorator cannot keep out users that change the organisation at this point.
+            if new_user.organisation_employer != request.user.organisation_employer:
+                raise PermissionDenied()
+            # decorator cannot keep out bad actors that change the is_rcpch_audit_team_member flag
+            if new_user.is_rcpch_audit_team_member and not (
+                request.user.is_rcpch_audit_team_member or request.user.is_superuser
+            ):
+                raise PermissionDenied()
+
             # save new user and add to gropup - return to user list with success message
             # send sign up email asynchronously
             # If signup unsuccessful, user not saved return to list with error message. Email not sent.

--- a/templates/registration/admin_create_user.html
+++ b/templates/registration/admin_create_user.html
@@ -18,9 +18,9 @@
         </div>
         
         <form 
-          class='ui rcpch form' 
+          class='ui rcpch form'
+          id="rcpch_edit_user_form"
           method="POST" 
-          action=""
           name='create_epilepsy12_user_form'>
           {% csrf_token %}
 
@@ -141,11 +141,14 @@
                 name="delete"
                 id="delete"
                 value="Delete"
-                _= "on click
+                hx-post="{% url 'delete_epilepsy12_user' organisation_id=organisation_id epilepsy12_user_id=form.instance.pk %}"
+                hx-trigger='click'
+                hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                _= "on htmx:confirm(issueRequest)
                   halt the event
                   call Swal.fire({
                     title: 'Confirmation Required',
-                    text: 'This will irreversibly remove {{epilepsy12_user}} and related dated from Epilepsy12.',
+                    text: 'This will irreversibly remove {{form.first_name.value}} {{form.surname.value}} and related dated from Epilepsy12.',
                     icon: 'warning',
                     iconColor: '#e00087',
                     showCancelButton: true,
@@ -153,15 +156,7 @@
                     cancelButtonColor: '#e60700',
                     confirmButtonText: 'Remove user from Epilepsy12'
                   })
-                  if result.isConfirmed then 
-                  fetch {% url 'edit_epilepsy12_user' organisation_id user.pk %} 
-                  { 
-                    method: 'POST', 
-                    headers: { 'X-CSRToken':{{csrf_token}} }, 
-                    mode:'same-origin' 
-                  }
-                  end
-                  "
+                  if result.isConfirmed issueRequest()"
               />
             
             {% endif %}

--- a/templates/registration/admin_create_user.html
+++ b/templates/registration/admin_create_user.html
@@ -20,7 +20,7 @@
         <form 
           class='ui rcpch form' 
           method="POST" 
-          action="" 
+          action=""
           name='create_epilepsy12_user_form'>
           {% csrf_token %}
 
@@ -141,7 +141,7 @@
                 name="delete"
                 id="delete"
                 value="Delete"
-                  _= "on click
+                _= "on click
                   halt the event
                   call Swal.fire({
                     title: 'Confirmation Required',
@@ -153,14 +153,12 @@
                     cancelButtonColor: '#e60700',
                     confirmButtonText: 'Remove user from Epilepsy12'
                   })
-                  if result.isConfirmed then fetch {% url 'edit_epilepsy12_user' organisation_id user.pk %}
-                  {
-                    method: 'post',
-                    headers: {
-                      'X-CSRFToken': {{csrf_token}},
-                      'Accept': 'network/json',
-                      'Content-Type': 'network/json',
-                    }
+                  if result.isConfirmed then 
+                  fetch {% url 'edit_epilepsy12_user' organisation_id user.pk %} 
+                  { 
+                    method: 'POST', 
+                    headers: { 'X-CSRToken':{{csrf_token}} }, 
+                    mode:'same-origin' 
                   }
                   end
                   "
@@ -194,7 +192,6 @@
   </div>
 
 </div>
-
 {% endblock %}
 
 


### PR DESCRIPTION
### Overview

This fixes an important issue in the forms which create users and edit users. This PR fixes the problem and fixes the failing test. It does not address the wider problem of tests in this area not quite testing what was intended.
Pushing now to see if pen testers can confirm this fixes main issue

### Code changes
`epilepsy_user_form` changes in the create and edit functions to raise permissiondenied redirects. 
`test_permissions` changes the new user in the post request to not have is_rcpch_audit_team_member as True. Only audit team members and superusers can alter this flag
`admin_create_user` has an inicidental finding in the hyperscript script to present the confirmation modal and redirect to the table.

### Documentation changes (done or required as a result of this PR)
None

**Note that need to raise a separate issue to review tests relating to user management particularly**