### PR TITLE
Post-fix

### DIFF
--- a/epilepsy12/forms_folder/epilepsy12_user_form.py
+++ b/epilepsy12/forms_folder/epilepsy12_user_form.py
@@ -213,9 +213,9 @@ class Epilepsy12UserAdminCreationForm(forms.ModelForm):
             self.cleaned_data["view_preference"] = 0
         return data
 
-    def clean_organisation_employer(self):
-        data = self.cleaned_data["organisation_employer"]
-        return data
+    # def clean_organisation_employer(self):
+    #     data = self.cleaned_data["organisation_employer"]
+    #     return data
 
     def clean(self):
         cleaned_data = super().clean()

--- a/epilepsy12/forms_folder/epilepsy12_user_form.py
+++ b/epilepsy12/forms_folder/epilepsy12_user_form.py
@@ -4,6 +4,7 @@ import logging
 from django import forms
 from django.conf import settings
 from django.core import validators
+from django.core.exceptions import ValidationError
 from django.contrib.auth.forms import AuthenticationForm, SetPasswordForm
 from django.utils.translation import gettext as _
 from django.utils import timezone
@@ -62,8 +63,9 @@ class Epilepsy12UserAdminCreationForm(forms.ModelForm):
     """
 
     rcpch_organisation = ""
+    requesting_user = ""
 
-    def __init__(self, rcpch_organisation, *args, **kwargs):
+    def __init__(self, rcpch_organisation, requesting_user, *args, **kwargs):
         super(Epilepsy12UserAdminCreationForm, self).__init__(*args, **kwargs)
         if rcpch_organisation == "organisation-staff":
             choices = AUDIT_CENTRE_ROLES
@@ -74,6 +76,7 @@ class Epilepsy12UserAdminCreationForm(forms.ModelForm):
                 "No user-type supplied to create user form. Arguments are rcpch-staff or organisation-staff."
             )
 
+        self.requesting_user = requesting_user
         self.rcpch_organisation = rcpch_organisation
         self.fields["role"].choices = choices
 
@@ -216,14 +219,54 @@ class Epilepsy12UserAdminCreationForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
-
         if self.rcpch_organisation == "rcpch-staff":
             # RCPCH staff are not affiliated with any organisation
-            cleaned_data["is_staff"] = False
-            cleaned_data["is_rcpch_staff"] = True
-            cleaned_data["organisation_employer"] = None
-            cleaned_data["is_rcpch_audit_team_member"] = True
-            cleaned_data["view_preference"] = 0
+            if (
+                self.requesting_user.is_rcpch_audit_team_member
+                or self.requesting_user.is_superuser
+            ):
+                cleaned_data["is_staff"] = False
+                cleaned_data["is_rcpch_staff"] = True
+                cleaned_data["organisation_employer"] = None
+                cleaned_data["is_rcpch_audit_team_member"] = True
+                cleaned_data["view_preference"] = 0
+            else:
+                # should not have managed to get here
+                raise ValidationError(
+                    "You do not have permission to create RCPCH staff."
+                )
+        else:
+            # this new user is not RCPCH staff
+            if (
+                self.requesting_user.is_rcpch_audit_team_member
+                or self.requesting_user.is_superuser
+            ):
+                # anything goes
+                return cleaned_data
+            else:
+                if (
+                    self.requesting_user.organisation_employer
+                    != cleaned_data["organisation_employer"]
+                ):
+                    self.add_error(
+                        "organisation_employer",
+                        "You do not have permission to create users in different organisations.",
+                    )
+                if cleaned_data["is_rcpch_audit_team_member"] == True:
+                    self.add_error(
+                        "is_rcpch_audit_team_member",
+                        "You do not have permission to allocate RCPCH audit team member status.",
+                    )
+                if cleaned_data["is_rcpch_staff"] == True:
+                    self.add_error(
+                        "is_rcpch_staff",
+                        "You do not have permission to allocate RCPCH staff member status.",
+                    )
+                if cleaned_data["is_superuser"] == True:
+                    self.add_error(
+                        "is_superuser",
+                        "You do not have permission to allocate superuser status.",
+                    )
 
         return cleaned_data
 

--- a/epilepsy12/tests/misc_py_shell_code.py
+++ b/epilepsy12/tests/misc_py_shell_code.py
@@ -65,3 +65,16 @@ E12UserFactory(
     organisation_employer=TEST_USER_ORGANISATION,
     groups=[test_user_rcpch_audit_team_data.group_name],
 )
+
+# Welsh Lead Clinician
+E12UserFactory(
+    first_name=test_user_audit_centre_lead_clinician_data.role_str,
+    role=test_user_audit_centre_lead_clinician_data.role,
+    surname="WELSH",
+    is_active=False,
+    is_staff=False,
+    is_rcpch_audit_team_member=False,
+    is_rcpch_staff=False,
+    organisation_employer=Organisation.objects.get(pk=333),
+    groups=[test_user_audit_centre_lead_clinician_data.group_name],
+)

--- a/epilepsy12/tests/view_tests/permissions_tests/test_form_create.py
+++ b/epilepsy12/tests/view_tests/permissions_tests/test_form_create.py
@@ -1,0 +1,283 @@
+"""
+A group of tests which have the unusual assumption that a user logged in as a lead clinician
+(probably a paediatric neurologist or paediatrician with expertise in epilepsy) is using his/her credentials
+(since they would have to be logged in) to subvert the audit by
+opening up Postman and firing off a load of unfriendly post requests
+
+These tests test the validations in the clean function in the epilepsy_12_user_form
+
+[x] Assert a Lead Clinician cannot create a user in another trust
+[x] Assert a Lead Clinician cannot create a user in another health board
+[x] Assert a Lead Clinician cannot create a user who is an RCPCH audit team member
+[x] Assert a Lead Clinician cannot create a user who is an RCPCH staff member
+[x] Assert a Lead Clinician cannot create a user who is a superuser
+"""
+
+# python imports
+import pytest
+
+# django imports
+
+# E12 Imports
+from epilepsy12.tests.UserDataClasses import (
+    test_user_audit_centre_administrator_data,
+    test_user_audit_centre_clinician_data,
+    test_user_audit_centre_lead_clinician_data,
+    test_user_clinicial_audit_team_data,
+    test_user_rcpch_audit_team_data,
+)
+from epilepsy12.models import (
+    Epilepsy12User,
+    Organisation,
+)
+from epilepsy12.tests.view_tests.permissions_tests.perm_tests_utils import (
+    twofactor_signin,
+)
+from epilepsy12.forms_folder import Epilepsy12UserAdminCreationForm
+
+
+@pytest.mark.django_db
+def test_lead_clinician_cannot_create_a_user_in_another_trust(client):
+    """ """
+
+    TEMP_CREATED_USER_FIRST_NAME = "TEMP_CREATED_USER_FIRST_NAME"
+
+    test_user = Epilepsy12User.objects.get(
+        first_name=test_user_audit_centre_lead_clinician_data.role_str
+    )
+
+    OTHER_ORGANISATION_OTHER_TRUST = Organisation.objects.get(pk=139)  # King's
+
+    data = {
+        "title": 1,
+        "email": f"{test_user.first_name}@test.com",
+        "role": 1,
+        "organisation_employer": OTHER_ORGANISATION_OTHER_TRUST,
+        "first_name": TEMP_CREATED_USER_FIRST_NAME,
+        "surname": "User",
+        "is_rcpch_audit_team_member": False,
+        "is_rcpch_staff": False,
+        "is_superuser": False,
+        "email_confirmed": False,
+        "is_staff": False,
+        "is_child_or_carer": False,
+    }
+    client.force_login(test_user)
+
+    # OTP ENABLE
+    twofactor_signin(client, test_user)
+
+    form = Epilepsy12UserAdminCreationForm(
+        rcpch_organisation="organisation-staff",
+        requesting_user=test_user,
+        data=data,
+    )
+
+    assert form.is_valid() == False, "Invalid form"
+
+    assert (
+        form.errors["organisation_employer"][0]
+        == f"You do not have permission to create users in different organisations."
+    ), f"Expected {test_user} from {test_user.organisation_employer} NOT to be able to create user in {OTHER_ORGANISATION_OTHER_TRUST} in different Trust"
+
+
+@pytest.mark.django_db
+def test_lead_clinician_cannot_create_a_user_in_another_local_health_board(client):
+    """
+    A group of tests which have the unusual assumption that a user logged in as a lead clinician
+    (probably a paediatric neurologist or paediatrician with expertise in epilepsy) is using his/her credentials
+    (since they would have to be logged in) to subvert the audit by
+    opening up Postman and firing off a load of unfriendly post requests
+    """
+
+    TEMP_CREATED_USER_FIRST_NAME = "TEMP_CREATED_USER_FIRST_NAME"
+
+    OTHER_ORGANISATION_OTHER_LOCAL_HEALTH_BOARD = Organisation.objects.get(pk=334)
+
+    test_user = Epilepsy12User.objects.create(
+        surname="leadclinician",
+        title=1,
+        email=f"welsh.leadclinician@test.com",
+        role=1,
+        organisation_employer=Organisation.objects.get(pk=333),
+        first_name="welsh",
+        is_rcpch_audit_team_member=False,
+        is_rcpch_staff=False,
+        is_superuser=False,
+        email_confirmed=False,
+        is_staff=False,
+        is_patient_or_carer=False,
+    )
+
+    data = {
+        "title": 1,
+        "email": f"{test_user.first_name}@test.com",
+        "role": 1,
+        "organisation_employer": OTHER_ORGANISATION_OTHER_LOCAL_HEALTH_BOARD,
+        "first_name": TEMP_CREATED_USER_FIRST_NAME,
+        "surname": "User",
+        "is_rcpch_audit_team_member": False,
+        "is_rcpch_staff": False,
+        "is_superuser": False,
+        "email_confirmed": False,
+        "is_staff": False,
+        "is_patient_or_carer": False,
+    }
+    client.force_login(test_user)
+
+    # OTP ENABLE
+    twofactor_signin(client, test_user)
+
+    form = Epilepsy12UserAdminCreationForm(
+        rcpch_organisation="organisation-staff",
+        requesting_user=test_user,
+        data=data,
+    )
+
+    assert form.is_valid() == False, "Invalid form"
+
+    assert (
+        form.errors["organisation_employer"][0]
+        == f"You do not have permission to create users in different organisations."
+    ), f"Expected {test_user} from {test_user.organisation_employer} NOT to be able to create user in {OTHER_ORGANISATION_OTHER_LOCAL_HEALTH_BOARD}"
+
+
+@pytest.mark.django_db
+def test_lead_clinician_cannot_create_an_RCPCH_audit_team_member(client):
+    # is rcpch audit team member
+
+    # GOSH
+    TEST_USER_ORGANISATION = Organisation.objects.get(
+        ods_code="RP401",
+        trust__ods_code="RP4",
+    )
+
+    TEMP_CREATED_USER_FIRST_NAME = "TEMP_CREATED_USER_FIRST_NAME"
+
+    test_user = Epilepsy12User.objects.get(
+        first_name=test_user_audit_centre_lead_clinician_data.role_str
+    )
+
+    OTHER_ORGANISATION_OTHER_TRUST = Organisation.objects.get(pk=139)  # King's
+
+    data = {
+        "title": 1,
+        "email": f"{test_user.first_name}@test.com",
+        "role": 1,
+        "organisation_employer": TEST_USER_ORGANISATION,
+        "first_name": TEMP_CREATED_USER_FIRST_NAME,
+        "surname": "User",
+        "is_rcpch_audit_team_member": True,
+        "is_rcpch_staff": False,
+        "is_superuser": False,
+        "email_confirmed": False,
+        "is_staff": False,
+        "is_child_or_carer": False,
+    }
+
+    form = Epilepsy12UserAdminCreationForm(
+        rcpch_organisation="organisation-staff",
+        requesting_user=test_user,
+        data=data,
+    )
+
+    assert form.is_valid() == False, "Invalid form"
+
+    assert (
+        form.errors["is_rcpch_audit_team_member"][0]
+        == f"You do not have permission to allocate RCPCH audit team member status."
+    ), f"Expected {test_user} from {test_user.organisation_employer} may NOT create RCPCH Audit Team Member in {TEST_USER_ORGANISATION}"
+
+
+@pytest.mark.django_db
+def test_lead_clinician_cannot_create_an_RCPCH_staff_member(client):
+    # is rcpch audit team member
+
+    # GOSH
+    TEST_USER_ORGANISATION = Organisation.objects.get(
+        ods_code="RP401",
+        trust__ods_code="RP4",
+    )
+
+    TEMP_CREATED_USER_FIRST_NAME = "TEMP_CREATED_USER_FIRST_NAME"
+
+    test_user = Epilepsy12User.objects.get(
+        first_name=test_user_audit_centre_lead_clinician_data.role_str
+    )
+
+    OTHER_ORGANISATION_OTHER_TRUST = Organisation.objects.get(pk=139)  # King's
+
+    data = {
+        "title": 1,
+        "email": f"{test_user.first_name}@test.com",
+        "role": 1,
+        "organisation_employer": TEST_USER_ORGANISATION,
+        "first_name": TEMP_CREATED_USER_FIRST_NAME,
+        "surname": "User",
+        "is_rcpch_audit_team_member": False,
+        "is_rcpch_staff": True,
+        "is_superuser": False,
+        "email_confirmed": False,
+        "is_staff": False,
+        "is_child_or_carer": False,
+    }
+
+    form = Epilepsy12UserAdminCreationForm(
+        rcpch_organisation="organisation-staff",
+        requesting_user=test_user,
+        data=data,
+    )
+
+    assert form.is_valid() == False, "Invalid form"
+
+    assert (
+        form.errors["is_rcpch_staff"][0]
+        == f"You do not have permission to allocate RCPCH staff member status."
+    ), f"Expected {test_user} from {test_user.organisation_employer} may NOT create RCPCH Staff Member in {TEST_USER_ORGANISATION}"
+
+
+@pytest.mark.django_db
+def test_lead_clinician_cannot_create_a_superuser(client):
+    # is rcpch audit team member
+
+    # GOSH
+    TEST_USER_ORGANISATION = Organisation.objects.get(
+        ods_code="RP401",
+        trust__ods_code="RP4",
+    )
+
+    TEMP_CREATED_USER_FIRST_NAME = "TEMP_CREATED_USER_FIRST_NAME"
+
+    test_user = Epilepsy12User.objects.get(
+        first_name=test_user_audit_centre_lead_clinician_data.role_str
+    )
+
+    OTHER_ORGANISATION_OTHER_TRUST = Organisation.objects.get(pk=139)  # King's
+
+    data = {
+        "title": 1,
+        "email": f"{test_user.first_name}@test.com",
+        "role": 1,
+        "organisation_employer": TEST_USER_ORGANISATION,
+        "first_name": TEMP_CREATED_USER_FIRST_NAME,
+        "surname": "User",
+        "is_rcpch_audit_team_member": False,
+        "is_rcpch_staff": False,
+        "is_superuser": True,
+        "email_confirmed": False,
+        "is_staff": False,
+        "is_child_or_carer": False,
+    }
+
+    form = Epilepsy12UserAdminCreationForm(
+        rcpch_organisation="organisation-staff",
+        requesting_user=test_user,
+        data=data,
+    )
+
+    assert form.is_valid() == False, "Invalid form"
+
+    assert (
+        form.errors["is_superuser"][0]
+        == f"You do not have permission to allocate superuser status."
+    ), f"Expected {test_user} from {test_user.organisation_employer} may NOT create a superuser in {TEST_USER_ORGANISATION}"

--- a/epilepsy12/tests/view_tests/permissions_tests/test_permissions_create.py
+++ b/epilepsy12/tests/view_tests/permissions_tests/test_permissions_create.py
@@ -328,7 +328,7 @@ def test_user_creation_forbidden(
             "organisation_employer": DIFF_TRUST_DIFF_ORGANISATION.id,
             "first_name": TEMP_CREATED_USER_FIRST_NAME,
             "surname": "User",
-            "is_rcpch_audit_team_member": True,
+            "is_rcpch_audit_team_member": False,
             "is_rcpch_staff": False,
             "email_confirmed": True,
         }
@@ -338,7 +338,7 @@ def test_user_creation_forbidden(
         # This is valid form data, should redirect
         assert (
             response.status_code == HTTPStatus.FORBIDDEN
-        ), f"Unpermitted E12User {test_user} attempted to create an E12User. expected status_code {HTTPStatus.FORBIDDEN}, received {response.status_code}"
+        ), f"Unpermitted E12User {test_user} from {test_user.organisation_employer} attempted to create an E12User from {DIFF_TRUST_DIFF_ORGANISATION}. expected status_code {HTTPStatus.FORBIDDEN}, received {response.status_code}"
 
     assert (
         Epilepsy12User.objects.filter(first_name=TEMP_CREATED_USER_FIRST_NAME).count()

--- a/epilepsy12/views/case_views.py
+++ b/epilepsy12/views/case_views.py
@@ -306,10 +306,16 @@ def case_list(request, organisation_id):
                 (2, "National level"),
             )
     else:
-        rcpch_choices = (
-            (0, "Organisation level"),
-            (1, "Trust level"),
-        )
+        if organisation.country.boundary_identifier == "W92000004":
+            rcpch_choices = (
+                (0, "Organisation level"),
+                (1, "Local Health Board level"),
+            )
+        else:
+            rcpch_choices = (
+                (0, "Organisation level"),
+                (1, "Trust level"),
+            )
 
     context = {
         "case_list": case_list,

--- a/epilepsy12/views/user_management_views.py
+++ b/epilepsy12/views/user_management_views.py
@@ -320,37 +320,24 @@ def create_epilepsy12_user(request, organisation_id, user_type, epilepsy12_user_
             "organisation_employer": organisation,
         }
         form = Epilepsy12UserAdminCreationForm(
-            rcpch_organisation=user_type, initial=prepopulated_data
+            rcpch_organisation=user_type,
+            requesting_user=request.user,
+            initial=prepopulated_data,
         )
     elif user_type == "rcpch-staff":
         admin_title = "Add RCPCH Epilepsy12 staff member"
         form = Epilepsy12UserAdminCreationForm(
-            rcpch_organisation=user_type, initial=None
+            rcpch_organisation=user_type, requesting_user=request.user, initial=None
         )
 
     if request.method == "POST":
         form = Epilepsy12UserAdminCreationForm(
             user_type,
+            request.user,
             request.POST or None,
         )
 
         if form.is_valid():
-            # decorator cannot keep out bad actors that change the organisation at this point.
-            if form.cleaned_data.get(
-                "organisation_employer"
-            ) != request.user.organisation_employer and not (
-                request.user.is_rcpch_audit_team_member or request.user.is_superuser
-            ):
-                raise PermissionDenied()
-            # decorator cannot keep out bad actors that change the is_rcpch_audit_team_member or is_superuser flag in post request
-            if (
-                form.cleaned_data.get("is_rcpch_audit_team_member")
-                or form.cleaned_data.get("is_superuser")
-            ) and not (
-                request.user.is_rcpch_audit_team_member or request.user.is_superuser
-            ):
-                raise PermissionDenied()
-
             # save new user and add to group - return to user list with success message
             # send sign up email asynchronously
             # If signup unsuccessful, user not saved return to list with error message. Email not sent.
@@ -445,6 +432,7 @@ def edit_epilepsy12_user(request, organisation_id, epilepsy12_user_id):
             request.POST["email"] = epilepsy12_user_to_edit.email
         form = Epilepsy12UserAdminCreationForm(
             user_type,
+            request.user,
             request.POST or None,
             instance=epilepsy12_user_to_edit,
         )
@@ -494,21 +482,6 @@ def edit_epilepsy12_user(request, organisation_id, epilepsy12_user_id):
 
         else:
             if form.is_valid():
-                # decorator cannot keep out bad actors that change the organisation at this point.
-                if form.cleaned_data.get(
-                    "organisation_employer"
-                ) != request.user.organisation_employer and not (
-                    request.user.is_rcpch_audit_team_member or request.user.is_superuser
-                ):
-                    raise PermissionDenied()
-                # decorator cannot keep out bad actors that change the is_rcpch_audit_team_member or is_superuser flag in post request
-                if (
-                    form.cleaned_data.get("is_rcpch_audit_team_member")
-                    or form.cleaned_data.get("is_superuser")
-                ) and not (
-                    request.user.is_rcpch_audit_team_member or request.user.is_superuser
-                ):
-                    raise PermissionDenied()
                 # this will not include the password which will be empty
                 new_user = form.save()
 

--- a/rcpch-audit-engine/settings.py
+++ b/rcpch-audit-engine/settings.py
@@ -22,7 +22,9 @@ from celery.schedules import crontab
 from django.core.management.utils import get_random_secret_key
 
 # RCPCH imports
-from .logging_settings import LOGGING # no it is not an unused import, it pulls LOGGING into the settings file
+from .logging_settings import (
+    LOGGING,
+)  # no it is not an unused import, it pulls LOGGING into the settings file
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +130,12 @@ SECURE_HSTS_SECONDS = 3600
 SECURE_HSTS_PRELOAD = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 X_FRAME_OPTIONS = "DENY"
-# SESSION_COOKIE_SECURE = True
+
+# Session cookies
+SESSION_COOKIE_SECURE = True  # enforces HTTPS
+CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_HTTPONLY = True  # cannot access session cookie on client-side using JS
+SESSION_EXPIRE_AT_BROWSER_CLOSE = True  # session expires on browser close
 
 ROOT_URLCONF = "rcpch-audit-engine.urls"
 


### PR DESCRIPTION
### Overview

The original fix preventing user creation in different trusts did not work on testing in development. This PR:
1. moves the create and edit case validation code into the form
2. adds a new test suite to test the form
3. adds new session and http settings
4. fixes a newly identified bug that welsh clinicians were able to view children across health boards
5. fixes the button text in case_list not showing Local Health Board 

### Code changes

Largely self explanatory

### Documentation changes (done or required as a result of this PR)

No documentation done

### Related Issues

no issues in issues to close