### PR TITLE
Community

### DIFF
--- a/epilepsy12/views/case_views.py
+++ b/epilepsy12/views/case_views.py
@@ -75,7 +75,7 @@ def case_list(request, organisation_id):
             # user has requested organisation level view
             all_cases = (
                 Case.objects.filter(
-                    Q(site__organisation__name__contains=organisation.name)
+                    Q(site__organisation=organisation)
                     & Q(site__site_is_primary_centre_of_epilepsy_care=True)
                     & Q(site__site_is_actively_involved_in_epilepsy_care=True)
                     & (
@@ -92,13 +92,11 @@ def case_list(request, organisation_id):
             if organisation.country.boundary_identifier == "W92000004":
                 # in Wales filter by health board
                 trust_filter = Q(
-                    site__organisation__local_health_board__ods_code__contains=organisation.local_health_board.ods_code
+                    site__organisation__local_health_board=organisation.local_health_board
                 )
             else:
                 # England filter by Trust
-                trust_filter = Q(
-                    site__organisation__trust__ods_code__contains=organisation.trust.ods_code
-                )
+                trust_filter = Q(site__organisation__trust=organisation.trust)
 
             all_cases = (
                 Case.objects.filter(
@@ -145,14 +143,14 @@ def case_list(request, organisation_id):
             if organisation.country.boundary_identifier == "W92000004":
                 # welsh - select health boards
                 filtered_cases = Case.objects.filter(
-                    organisations__local_health_board__name__contains=parent_trust.name,
+                    organisations__local_health_board=parent_trust,
                     site__site_is_primary_centre_of_epilepsy_care=True,
                     site__site_is_actively_involved_in_epilepsy_care=True,
                 )
             else:
                 # England - select trusts
                 filtered_cases = Case.objects.filter(
-                    organisations__trust__name__contains=parent_trust.name,
+                    organisations__trust=parent_trust,
                     site__site_is_primary_centre_of_epilepsy_care=True,
                     site__site_is_actively_involved_in_epilepsy_care=True,
                 )
@@ -160,7 +158,7 @@ def case_list(request, organisation_id):
         else:
             # filters all primary centres at organisation level, irrespective of if active or inactive
             filtered_cases = Case.objects.filter(
-                organisations__name__contains=organisation.name,
+                organisations__name=organisation,
                 site__site_is_primary_centre_of_epilepsy_care=True,
                 site__site_is_actively_involved_in_epilepsy_care=True,
             )

--- a/epilepsy12/views/user_management_views.py
+++ b/epilepsy12/views/user_management_views.py
@@ -83,14 +83,14 @@ def epilepsy12_user_list(request, organisation_id):
         # filter_term is called if filtering by search box
         if request.user.view_preference == 0:
             # user has requested organisation level view
-            basic_filter = Q(organisation_employer__name__icontains=organisation.name)
+            basic_filter = Q(organisation_employer=organisation.name)
         elif request.user.view_preference == 1:
             # user has requested trust level view
             if organisation.country.boundary_identifier == "W92000004":
                 parent_trust = organisation.organisation.local_health_board.name
             else:
                 parent_trust = organisation.organisation.trust.name
-            basic_filter = Q(organisation_employer__name__icontains=parent_trust)
+            basic_filter = Q(organisation_employer=parent_trust)
         elif request.user.view_preference == 2:
             # user has requested national level view
             basic_filter = None
@@ -140,19 +140,15 @@ def epilepsy12_user_list(request, organisation_id):
         elif request.user.view_preference == 1:
             # filters all primary Trust level centres, irrespective of if active or inactive
             if organisation.country.boundary_identifier == "W92000004":
-                parent_trust = organisation.local_health_board.name
-                basic_filter = Q(
-                    organisation_employer__local_health_board__name__contains=parent_trust
-                )
+                parent_trust = organisation.local_health_board
+                basic_filter = Q(organisation_employer__local_health_board=parent_trust)
             else:
-                parent_trust = organisation.trust.name
-                basic_filter = Q(
-                    organisation_employer__trust__name__contains=parent_trust
-                )
+                parent_trust = organisation.trust
+                basic_filter = Q(organisation_employer__trust__name=parent_trust)
 
         elif request.user.view_preference == 0:
             # filters all primary centres at organisation level, irrespective of if active or inactive
-            basic_filter = Q(organisation_employer__name__contains=organisation.name)
+            basic_filter = Q(organisation_employer=organisation)
         else:
             raise Exception("No View Preference supplied")
 
@@ -250,9 +246,9 @@ def epilepsy12_user_list(request, organisation_id):
             epilepsy12_user_list = filtered_epilepsy12_users.order_by("surname").all()
 
     if organisation.country.boundary_identifier == "W92000004":
-        parent_trust = organisation.local_health_board.name
+        parent_trust = organisation.local_health_board
     else:
-        parent_trust = organisation.trust.name
+        parent_trust = organisation.trust
 
     if (
         request.user.is_rcpch_audit_team_member


### PR DESCRIPTION
### Overview

fix for #794

@amanikrayem identified a vulnerability where lead clinicians for community organisations could view (but not edit) users and children in other community organisations.

This was because the `icontains` filter was finding a match for organisations which contained community in their names. This was been altered to a match by relationship (organisation id), not name

### Code changes

`case_views` and `user_management_views` - remove the icontains filter based on name.

### Documentation changes (done or required as a result of this PR)

no  implications

### Related Issues

closes #794
