### PR TITLE
Add cause - Megalencephalic leukoencephalopathy with subcortical cysts

### DIFF
--- a/epilepsy12/migrations/0006_seed_epilepsy_causes.py
+++ b/epilepsy12/migrations/0006_seed_epilepsy_causes.py
@@ -59,6 +59,7 @@ def seed_epilepsy_causes(apps, schema_editor):
     # Cornelia de Lange Syndrome (CdLS) - 40354009
     # Anoxic encephalopathy - 389098007
     # Congenital Melanocytic Naevus – 398696001
+    # Megalencephalic leukoencephalopathy with subcortical cysts - 703536004
     extra_concept_ids = [
         764946008,
         52767006,
@@ -70,6 +71,7 @@ def seed_epilepsy_causes(apps, schema_editor):
         40354009,
         389098007,
         398696001,
+        703536004,
     ]
     add_epilepsy_cause_list_by_sctid(extra_concept_ids=extra_concept_ids)
 


### PR DESCRIPTION
Fixes #792

### Overview

Add 703536004, Megalencephalic leukoencephalopathy with subcortical cysts (disorder) to migrations for future seeding. Independently added to the VPS

### Code changes

update to 0006 migration

### Documentation changes (done or required as a result of this PR)

no implications

### Related Issues

closes #792
