### PR TITLE
add Schizencephaly (disorder) - 253159001, Tetrasomy 12p syndrome (disorder) - 9527009 to migration_006

### DIFF
--- a/epilepsy12/migrations/0006_seed_epilepsy_causes.py
+++ b/epilepsy12/migrations/0006_seed_epilepsy_causes.py
@@ -61,6 +61,8 @@ def seed_epilepsy_causes(apps, schema_editor):
     # Congenital Melanocytic Naevus – 398696001
     # Megalencephalic leukoencephalopathy with subcortical cysts - 703536004
     # Cerebral ischemic stroke due to global hypoperfusion with watershed infarct - 788882003
+    # Schizencephaly (disorder) - 253159001
+    # Tetrasomy 12p syndrome (disorder) - 9527009
     extra_concept_ids = [
         764946008,
         52767006,
@@ -74,6 +76,8 @@ def seed_epilepsy_causes(apps, schema_editor):
         398696001,
         703536004,
         788882003,
+        253159001,
+        9527009,
     ]
     add_epilepsy_cause_list_by_sctid(extra_concept_ids=extra_concept_ids)
 


### PR DESCRIPTION
### Overview

Request from E12 team to add Schizencephaly and Tetrasomy 12p syndrome to epilepsy causes

This has been done in the console of all 3 VPS instances using: `python manage.py seed --mode=add_new_epilepsy_causes -sctids 9527009 253159001`

Updating seed functions here to maintain single 'source of truth'

### Code changes

Update to migration0006

### Documentation changes (done or required as a result of this PR)

No implications

### Related Issues

closes #809