### PR TITLE
Add organisation - Midland Metropolitan University Hospital

### DIFF
--- a/epilepsy12/constants/rcpch_organisations.py
+++ b/epilepsy12/constants/rcpch_organisations.py
@@ -8402,9 +8402,40 @@ RCPCH_ORGANISATIONS = [
         "Fax": "",
         "LocalAuthority": "E06000043",
     },  # 01/04/2021, QNX NHS SUSSEX INTEGRATED CARE BOARD, SOUTH EAST, SOUTH EAST THAMES EPILEPSY GROUP
+    {
+        "OrganisationID": "",
+        "OrganisationCode": "I3W1A",
+        "OrganisationType": "",
+        "SubType": "",
+        "Sector": "",
+        "OrganisationStatus": "",
+        "IsPimsManaged": "",
+        "OrganisationName": "MIDLAND METROPOLITAN UNIVERSITY HOSPITAL",
+        "Address1": "GROVE LANE",
+        "Address2": "",
+        "Address3": "",
+        "City": "SMETHWICK",
+        "County": "WEST MIDLANDS",
+        "Postcode": "B66 2QT",
+        "Latitude": "52.491258",
+        "Longitude": "-1.949846",
+        "ParentODSCode": "RXK",
+        "ParentName": "SANDWELL AND WEST BIRMINGHAM HOSPITALS NHS TRUST",
+        "Phone": "",
+        "Email": "",
+        "Website": "",
+        "Fax": "",
+        "LocalAuthority": "E08000028",
+    },  # 01/04/2023 QHL NHS BIRMINGHAM AND SOLIHULL INTEGRATED CARE BOARD, MIDLANDS, Birmingham Regional Paediatric Neurology Forum
 ]
 
 """
+Steps to update organisation in the console once created in the admin
+from django.contrib.gis.geos import Point
+point = Point(x=longitude,y=latitude)
+o = Organisation.objects.get(ods_code="####")
+o.geocode_coordinates=point
+o.save()
 from epilepsy12.common_view_functions import _seed_all_aggregation_models
 _seed_all_aggregation_models()
 """


### PR DESCRIPTION
Fixes #810

### Overview

Atomic change. Adds a new organisation to the seeding migration for future builds

### Code changes

Adds the details for Midland Metropolitan University Hospital, est 1/4/2023 to `rcpch_organisations`.

Note that seeding will allocate the correct associated models (Trust, OPENUKRegion etc) but will not store the date of inception and the geocode as a Point. This can be done as a separate step in the console. The methods for this are in the comments in `rcpch_organisations`

### Documentation changes (done or required as a result of this PR)

No implications

### Related Issues

closes #810

### Mentions

@mentions of the person or team responsible for reviewing proposed changes.
