### PR TITLE
Eatyourpeas/issue813

### DIFF
--- a/epilepsy12/tests/view_tests/permissions_tests/test_permissions_delete.py
+++ b/epilepsy12/tests/view_tests/permissions_tests/test_permissions_delete.py
@@ -104,7 +104,9 @@ from epilepsy12.models import (
     Medicine,
     ComorbidityList,
 )
-from epilepsy12.tests.view_tests.permissions_tests.perm_tests_utils import twofactor_signin
+from epilepsy12.tests.view_tests.permissions_tests.perm_tests_utils import (
+    twofactor_signin,
+)
 
 
 @pytest.mark.django_db
@@ -171,35 +173,6 @@ def test_user_delete_success(
         assert (
             response.status_code == HTTPStatus.OK
         ), f"{test_user.first_name} (from {test_user.organisation_employer}) requested `{url}` for User from {TEST_USER_ORGANISATION}. Has groups: {test_user.groups.all()}. Expected 200 response status code, received {response.status_code}"
-
-        # Additional test for deleting users outside of own Trust
-        if test_user.first_name in [
-            test_user_clinicial_audit_team_data.role_str,
-            test_user_rcpch_audit_team_data.role_str,
-        ]:
-            # Seed a temp User to be deleted
-            temp_user_same_org = E12UserFactory(
-                first_name="temp_user",
-                email=f"temp_{test_user.first_name}@temp.com",
-                role=test_user.role,
-                is_active=1,
-                organisation_employer=DIFF_TRUST_DIFF_ORGANISATION,
-                groups=[test_user_audit_centre_administrator_data.group_name],
-            )
-
-            url = reverse(
-                "delete_epilepsy12_user",
-                kwargs={
-                    "organisation_id": DIFF_TRUST_DIFF_ORGANISATION.id,
-                    "epilepsy12_user_id": temp_user_same_org.id,
-                },
-            )
-
-            response = client.get(url)
-
-            assert (
-                response.status_code == HTTPStatus.OK
-            ), f"{test_user.first_name} (from {test_user.organisation_employer}) requested `{url}` for User from {DIFF_TRUST_DIFF_ORGANISATION}. Has groups: {test_user.groups.all()}. Expected 200 response status code, received {response.status_code}"
 
 
 @pytest.mark.django_db

--- a/epilepsy12/tests/view_tests/permissions_tests/test_permissions_delete.py
+++ b/epilepsy12/tests/view_tests/permissions_tests/test_permissions_delete.py
@@ -170,9 +170,19 @@ def test_user_deactivate_success(
 
         response = client.get(url)
 
+        # test 200 response that user correctly deactivates temp_user_same_org
         assert (
             response.status_code == HTTPStatus.OK
         ), f"{test_user.first_name} (from {test_user.organisation_employer}) requested `{url}` for User from {TEST_USER_ORGANISATION}. Has groups: {test_user.groups.all()}. Expected 200 response status code, received {response.status_code}"
+
+        # requery temp_user_same_org is_active status
+        updated_user_active_status = Epilepsy12User.objects.get(
+            pk=temp_user_same_org.pk
+        )
+        # test database reflects that user correctly deactivates temp_user_same_org
+        assert (
+            updated_user_active_status.is_active == 0
+        ), f"{updated_user_active_status.first_name} (from {updated_user_active_status.organisation_employer}) weas deactivated by User from {TEST_USER_ORGANISATION}. Has groups: {test_user.groups.all()}. Expected {temp_user_same_org.first_name}'s is_active status to be False. Received {updated_user_active_status.is_active}"
 
 
 @pytest.mark.django_db
@@ -249,6 +259,15 @@ def test_user_deactivate_forbidden(
                 response.status_code == HTTPStatus.FORBIDDEN
             ), f"{test_user.first_name} (from {test_user.organisation_employer}) requested `{url}` for User from {DIFF_TRUST_DIFF_ORGANISATION}. Has groups: {test_user.groups.all()}. Expected {HTTPStatus.FORBIDDEN} response status code, received {response.status_code}"
 
+            # requery temp_user_same_org is_active status
+            updated_user_active_status = Epilepsy12User.objects.get(
+                pk=temp_user_same_org.pk
+            )
+            # test database reflects that user fails to deactivate temp_user_same_org
+            assert (
+                updated_user_active_status.is_active == 1
+            ), f"{updated_user_active_status.first_name} (from {updated_user_active_status.organisation_employer}) was NOT deactivated by User from {TEST_USER_ORGANISATION}. Has groups: {test_user.groups.all()}. Expected {temp_user_same_org.first_name}'s is_active status to be True. Received {updated_user_active_status.is_active}"
+
         else:
             url = reverse(
                 "delete_epilepsy12_user",
@@ -263,6 +282,15 @@ def test_user_deactivate_forbidden(
             assert (
                 response.status_code == HTTPStatus.FORBIDDEN
             ), f"{test_user.first_name} (from {test_user.organisation_employer}) requested `{url}` for User from {TEST_USER_ORGANISATION}. Has groups: {test_user.groups.all()}. Expected {HTTPStatus.FORBIDDEN} response status code, received {response.status_code}"
+
+            # requery temp_user_same_org is_active status
+            updated_user_active_status = Epilepsy12User.objects.get(
+                pk=temp_user_same_org.pk
+            )
+            # test database reflects that user fails to deactivate temp_user_same_org
+            assert (
+                updated_user_active_status.is_active == 1
+            ), f"{updated_user_active_status.first_name} (from {updated_user_active_status.organisation_employer}) was NOT deactivated by User from {TEST_USER_ORGANISATION}. Has groups: {test_user.groups.all()}. Expected {temp_user_same_org.first_name}'s is_active status to be True. Received {updated_user_active_status.is_active}"
 
 
 @pytest.mark.django_db

--- a/epilepsy12/tests/view_tests/permissions_tests/test_permissions_delete.py
+++ b/epilepsy12/tests/view_tests/permissions_tests/test_permissions_delete.py
@@ -1,27 +1,27 @@
 """
 ## Delete Tests
 
-    [x] Assert an Audit Centre Lead Clinician can delete users inside own Trust - HTTPStatus.OK
-    [x] Assert RCPCH Audit Team can delete users inside own Trust - HTTPStatus.OK
-    [x] Assert RCPCH Audit Team can delete users outside own Trust - HTTPStatus.OK
-    [x] Assert Clinical Audit Team can delete users inside own Trust - HTTPStatus.OK
-    [x] Assert Clinical Audit Team can delete users outside own Trust - HTTPStatus.OK
+    [x] Assert an Audit Centre Lead Clinician can deactivate users inside own Trust - HTTPStatus.OK
+    [x] Assert RCPCH Audit Team can deactivate users inside own Trust - HTTPStatus.OK
+    [x] Assert RCPCH Audit Team can deactivate users outside own Trust - HTTPStatus.OK
+    [x] Assert Clinical Audit Team can deactivate users inside own Trust - HTTPStatus.OK
+    [x] Assert Clinical Audit Team can deactivate users outside own Trust - HTTPStatus.OK
 
-    [x] Assert an Audit Centre Administrator CANNOT delete users - HTTPStatus.FORBIDDEN
-    [x] Assert an audit centre clinician CANNOT delete users - HTTPStatus.FORBIDDEN
-    [x] Assert an Audit Centre Lead Clinician CANNOT delete users outside own Trust - HTTPStatus.FORBIDDEN
+    [x] Assert an Audit Centre Administrator CANNOT deactivate users - HTTPStatus.FORBIDDEN
+    [x] Assert an audit centre clinician CANNOT deactivate users - HTTPStatus.FORBIDDEN
+    [x] Assert an Audit Centre Lead Clinician CANNOT deactivate users outside own Trust - HTTPStatus.FORBIDDEN
     
     
 
-    [x] Assert an Audit Centre Lead Clinician can delete patients inside own Trust - HTTPStatus.OK
-    [x] Assert RCPCH Audit Team can delete patients inside own Trust - HTTPStatus.OK
-    [x] Assert RCPCH Audit Team can delete patients outside own Trust - HTTPStatus.OK
-    [x] Assert Clinical Audit Team can delete patients inside own Trust - HTTPStatus.OK
-    [x] Assert Clinical Audit Team can delete patients outside own Trust - HTTPStatus.OK
+    [x] Assert an Audit Centre Lead Clinician can deactivate patients inside own Trust - HTTPStatus.OK
+    [x] Assert RCPCH Audit Team can deactivate patients inside own Trust - HTTPStatus.OK
+    [x] Assert RCPCH Audit Team can deactivate patients outside own Trust - HTTPStatus.OK
+    [x] Assert Clinical Audit Team can deactivate patients inside own Trust - HTTPStatus.OK
+    [x] Assert Clinical Audit Team can deactivate patients outside own Trust - HTTPStatus.OK
     
-    [x] Assert an Audit Centre Administrator CANNOT delete patients - HTTPStatus.FORBIDDEN
-    [x] Assert an audit centre clinician CANNOT delete patients outside own Trust - HTTPStatus.FORBIDDEN
-    [x] Assert an Audit Centre Lead Clinician CANNOT delete patients outside own Trust - HTTPStatus.FORBIDDEN
+    [x] Assert an Audit Centre Administrator CANNOT deactivate patients - HTTPStatus.FORBIDDEN
+    [x] Assert an audit centre clinician CANNOT deactivate patients outside own Trust - HTTPStatus.FORBIDDEN
+    [x] Assert an Audit Centre Lead Clinician CANNOT deactivate patients outside own Trust - HTTPStatus.FORBIDDEN
 
 
 # Episode
@@ -110,15 +110,15 @@ from epilepsy12.tests.view_tests.permissions_tests.perm_tests_utils import (
 
 
 @pytest.mark.django_db
-def test_user_delete_success(
+def test_user_deactivate_success(
     client,
     seed_groups_fixture,
     seed_users_fixture,
     seed_cases_fixture,
 ):
-    """Simulating different E12 users with different roles attempting to delete Users inside own trust.
+    """Simulating different E12 users with different roles attempting to deactivate inside own trust.
 
-    Additionally, RCPCH Audit Team and Clinical Audit Team roles should be able to delete user in different trust.
+    Additionally, RCPCH Audit Team and Clinical Audit Team roles should be able to deactivate user in different trust.
     """
 
     # set up constants
@@ -176,10 +176,10 @@ def test_user_delete_success(
 
 
 @pytest.mark.django_db
-def test_user_delete_forbidden(
+def test_user_deactivate_forbidden(
     client,
 ):
-    """Simulating different E12 users with different roles attempting to delete Users inside own trust.
+    """Simulating different E12 users with different roles attempting to deactivate Users inside own trust.
 
     Audit Centre Lead Clinician role CANNOT delete user in different trust.
     """
@@ -207,7 +207,7 @@ def test_user_delete_forbidden(
         user_first_names_for_test
     ), f"Incorrect queryset of test users. Requested {len(user_first_names_for_test)} users, queryset includes {len(users)}: {users}"
 
-    # Seed a temp User for attempt to delete
+    # Seed a temp User for attempt to deactivate
     temp_user_same_org = E12UserFactory(
         first_name="temp_user",
         email=f"temp_user_same_org@temp.com",
@@ -216,7 +216,7 @@ def test_user_delete_forbidden(
         organisation_employer=TEST_USER_ORGANISATION,
         groups=[test_user_audit_centre_administrator_data.group_name],
     )
-    # Seed a temp User to be deleted
+    # Seed a temp User to be deactivated
     temp_user_same_org = E12UserFactory(
         first_name="temp_user",
         email=f"temp_user_diff_org@temp.com",

--- a/epilepsy12/views/user_management_views.py
+++ b/epilepsy12/views/user_management_views.py
@@ -438,7 +438,11 @@ def edit_epilepsy12_user(request, organisation_id, epilepsy12_user_id):
 
     if request.method == "POST":
         if "delete" in request.POST:
-            epilepsy12_user_to_edit.delete()
+            # This call back from the user form, not the table.
+            # Rather than delete user, instead set is_active to False as prevents cascade delete error for any cases/registrations
+            # updated by this user (see issue #813)
+            epilepsy12_user_to_edit.is_active = False
+            epilepsy12_user_to_edit.save(update_fields=["is_active"])
             messages.success(
                 request, f"{epilepsy12_user_to_edit.email} Deleted successfully."
             )
@@ -527,7 +531,12 @@ def edit_epilepsy12_user(request, organisation_id, epilepsy12_user_id):
 @user_can_access_user()
 @permission_required("epilepsy12.delete_epilepsy12user", raise_exception=True)
 def delete_epilepsy12_user(request, organisation_id, epilepsy12_user_id):
+    """
+    HTMX callback from epilepsy12user table
+    Sets user is_active flag to False
+    """
     try:
+        # This call back from the table, not the form
         # rather than delete user, instead set is_active to False as prevents cascade delete error for any cases/registrations
         # updated by this user (see issue #813)
         Epilepsy12User.objects.filter(pk=epilepsy12_user_id).update(is_active=False)

--- a/epilepsy12/views/user_management_views.py
+++ b/epilepsy12/views/user_management_views.py
@@ -528,7 +528,9 @@ def edit_epilepsy12_user(request, organisation_id, epilepsy12_user_id):
 @permission_required("epilepsy12.delete_epilepsy12user", raise_exception=True)
 def delete_epilepsy12_user(request, organisation_id, epilepsy12_user_id):
     try:
-        Epilepsy12User.objects.get(pk=epilepsy12_user_id).delete()
+        # rather than delete user, instead set is_active to False as prevents cascade delete error for any cases/registrations
+        # updated by this user (see issue #813)
+        Epilepsy12User.objects.filter(pk=epilepsy12_user_id).update(is_active=False)
     except ValueError as error:
         messages.error(request, f"Delete User Unsuccessful: {error}")
 

--- a/templates/registration/admin_create_user.html
+++ b/templates/registration/admin_create_user.html
@@ -140,7 +140,7 @@
                 {% endif %}
                 name="delete"
                 id="delete"
-                value="Delete"
+                value="Deactivate"
                 hx-post="{% url 'delete_epilepsy12_user' organisation_id=organisation_id epilepsy12_user_id=form.instance.pk %}"
                 hx-trigger='click'
                 hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
@@ -148,13 +148,13 @@
                   halt the event
                   call Swal.fire({
                     title: 'Confirmation Required',
-                    text: 'This will irreversibly remove {{form.first_name.value}} {{form.surname.value}} and related dated from Epilepsy12.',
+                    text: 'This will deactivate the account for {{form.first_name.value}} {{form.surname.value}}.',
                     icon: 'warning',
                     iconColor: '#e00087',
                     showCancelButton: true,
                     confirmButtonColor: '#11a7f2',
                     cancelButtonColor: '#e60700',
-                    confirmButtonText: 'Remove user from Epilepsy12'
+                    confirmButtonText: 'Deactivate Epilepsy12 user account.'
                   })
                   if result.isConfirmed issueRequest()"
               />

--- a/templates/registration/user_management/epilepsy12_user_table.html
+++ b/templates/registration/user_management/epilepsy12_user_table.html
@@ -234,7 +234,7 @@
                     </button>
                     
                     <button 
-                        data-tooltip='Delete {{epilepsy12_user}}.' 
+                        data-tooltip='Deactivate {{epilepsy12_user}}.' 
                         {% if perms.epilepsy12.delete_epilepsy12user and epilepsy12_user.email != user.email %}
                             class="ui rcpch_danger icon button" 
                         {% else %}
@@ -248,13 +248,13 @@
                             halt the event
                             call Swal.fire({
                                 title: 'Confirmation Required',
-                                text: 'Are you sure you want to delete {{epilepsy12_user}}? This is an irreversible step.',
+                                text: 'Are you sure you want to deactivate {{epilepsy12_user}}?',
                                 icon: 'warning',
                                 iconColor: '#e00087',
                                 showCancelButton: true,
                                 confirmButtonColor: '#11a7f2',
                                 cancelButtonColor: '#e60700',
-                                confirmButtonText: 'Delete {{epilepsy12_user}}'
+                                confirmButtonText: 'Deactivate {{epilepsy12_user}}'
                             })
                             if result.isConfirmed issueRequest()"
                     >

--- a/templates/registration/user_management/epilepsy12_user_table.html
+++ b/templates/registration/user_management/epilepsy12_user_table.html
@@ -234,7 +234,7 @@
                     </button>
                     
                     <button 
-                        data-tooltip='Delete {{epilepsy12_user}}. This is irreversible.' 
+                        data-tooltip='Delete {{epilepsy12_user}}.' 
                         {% if perms.epilepsy12.delete_epilepsy12user and epilepsy12_user.email != user.email %}
                             class="ui rcpch_danger icon button" 
                         {% else %}

--- a/templates/registration/user_management/epilepsy12_user_table.html
+++ b/templates/registration/user_management/epilepsy12_user_table.html
@@ -170,7 +170,7 @@
                 {% elif epilepsy12_user.email_confirmed and not epilepsy12_user.is_active %}
                     <i 
                         class="red close icon"
-                        id="{{epilepsy12_user.id}}_inactive_icon"
+                        id="{{epilepsy12_user.id}}_is_inactive_icon"
                         data-title="User status"
                         data-content="{{epilepsy12_user}} is an inactive user."
                         data-position="top left"

--- a/templates/registration/user_management/epilepsy12_user_table.html
+++ b/templates/registration/user_management/epilepsy12_user_table.html
@@ -222,7 +222,7 @@
                     
                     <button 
                         data-tooltip="Edit {{epilepsy12_user}}'s details."
-                        {% if perms.epilepsy12.change_epilepsy12user %}
+                        {% if perms.epilepsy12.change_epilepsy12user and epilepsy12_user.is_active %}
                             class="ui rcpch_primary icon button" 
                         {% else %}
                             class="ui rcpch_primary icon disabled button" 
@@ -235,7 +235,7 @@
                     
                     <button 
                         data-tooltip='Deactivate {{epilepsy12_user}}.' 
-                        {% if perms.epilepsy12.delete_epilepsy12user and epilepsy12_user.email != user.email %}
+                        {% if perms.epilepsy12.delete_epilepsy12user and epilepsy12_user.email != user.email  and epilepsy12_user.is_active %}
                             class="ui rcpch_danger icon button" 
                         {% else %}
                             class="ui rcpch_danger icon disabled button" 
@@ -262,7 +262,7 @@
                     </button>
                     
                     <button
-                        {% if perms.epilepsy12.view_logs %}
+                        {% if perms.epilepsy12.view_logs and epilepsy12_user.is_active %}
                             class='ui rcpch_light_blue icon right floated button'
                         {% else %}
                             class='ui rcpch_light_blue icon right floated disabled button'


### PR DESCRIPTION
### Overview

Bug fix
E12 users identified that deleting a user who had previously scored a child threw a referential integrity error, as the registration for that child contains the foreign key of the user in the `updated_by` field.
Users can therefore only be deleted if they have not yet created any registrations, clearly a problem.
This has been fixed by changing the language around deletion to deactivation, and setting the `is_active` flag in the user model to False.
This shows in the user table as red cross.
This PR also contains a fix in the template for the popup as this was not rendering due to misnaming error of the element id.

### Code changes

changes to 3 files:
`user_management_views`: 2 functions affected, one a callback from the delete button click in the form template (`admin_create_user`, the other an htmx callback from the delete button in the `epilepsy12_user_table`. Both changes set the is_active flag to True and remove the delete.
Refactoring in the templates changes the wording around deletion to deactivation and fixes the popup error.

### Documentation changes (done or required as a result of this PR)
No documentation changes made.

### Related Issues

closes #813
