### PR TITLE
fix back button in otp workflow

### DIFF
--- a/templates/two_factor/core/otp_required.html
+++ b/templates/two_factor/core/otp_required.html
@@ -12,7 +12,7 @@
     account. Enable two-factor authentication for enhanced account
     security.{% endblocktrans %}</p>
   <p>
-    <a href="javascript:history.go(-1)"
+    <a href="{% url 'two_factor:setup' %}"
        class="float-right btn btn-link">{% trans "Go back" %}</a>
     <a href="{% url 'two_factor:setup' %}" class="btn btn-primary">
     {% trans "Enable Two-Factor Authentication" %}</a>


### PR DESCRIPTION
### Overview

Back button in OTP `/account/two_factor/setup/` not working

### Code changes

Change in `otp_required` template to redirect to previous screen

### Documentation changes (done or required as a result of this PR)

No implications

### Related Issues

closes #814

### Mentions

Thanks to @mbarton for this pickup
