### PR TITLE
Speed up seeding data for local development

### DIFF
--- a/epilepsy12/management/commands/create_e12_records.py
+++ b/epilepsy12/management/commands/create_e12_records.py
@@ -1,5 +1,5 @@
 # python dependencies
-from random import randint, getrandbits, choice
+from random import randint, getrandbits, choice, choices
 from dateutil.relativedelta import relativedelta
 from datetime import date
 
@@ -265,18 +265,8 @@ def create_multiaxial_diagnosis(registration_instance, verbose=True):
         )
 
     if multiaxial_diagnosis.epilepsy_cause_known:
-        ecl = "<< 363235000"
-        epilepsy_causes = fetch_ecl(ecl)
-        random_cause = EpilepsyCause.objects.filter(
-            conceptId=epilepsy_causes[randint(0, len(epilepsy_causes) - 1)]["conceptId"]
-        ).first()
-
-        multiaxial_diagnosis.epilepsy_cause = random_cause
-        choices = []
-        for item in range(0, randint(1, 3)):
-            chosen_cause = choice(EPILEPSY_CAUSES)
-            choices.append(chosen_cause[0])
-        multiaxial_diagnosis.epilepsy_cause_categories = choices
+        multiaxial_diagnosis.epilepsy_cause = choice(EpilepsyCause.objects.all())
+        multiaxial_diagnosis.epilepsy_cause_categories = choices(EPILEPSY_CAUSES, k = randint(1, 3))
 
     if multiaxial_diagnosis.mental_health_issue_identified:
         multiaxial_diagnosis.mental_health_issues = [choice(NEUROPSYCHIATRIC)[0]]

--- a/epilepsy12/management/commands/create_e12_records.py
+++ b/epilepsy12/management/commands/create_e12_records.py
@@ -54,8 +54,6 @@ from ...constants import (
 )
 from ...general_functions import (
     random_date,
-    fetch_ecl,
-    fetch_paediatric_neurodisability_outpatient_diagnosis_simple_reference_set,
 )
 from ...common_view_functions import update_audit_progress, calculate_kpis
 
@@ -274,14 +272,7 @@ def create_multiaxial_diagnosis(registration_instance, verbose=True):
     if multiaxial_diagnosis.relevant_impairments_behavioural_educational:
         # add upto 5 comorbidities
         for count_item in range(1, randint(2, 5)):
-            comorbidity_choices = (
-                fetch_paediatric_neurodisability_outpatient_diagnosis_simple_reference_set()
-            )
-            random_comorbidities = choice(comorbidity_choices)
-
-            random_comorbidity = ComorbidityList.objects.filter(
-                conceptId=random_comorbidities["conceptId"]
-            ).first()
+            random_comorbidity = choice(ComorbidityList.objects.all())
 
             try:
                 Comorbidity.objects.create(

--- a/epilepsy12/management/commands/seed.py
+++ b/epilepsy12/management/commands/seed.py
@@ -114,6 +114,7 @@ def run_dummy_cases_seed(verbose=True, cases=50):
         cases = 50
 
     different_organisations = [
+        "RJZ01",
         "RGT01",
         "RBS25",
         "RQM01",

--- a/epilepsy12/management/commands/seed.py
+++ b/epilepsy12/management/commands/seed.py
@@ -140,9 +140,7 @@ def run_dummy_cases_seed(verbose=True, cases=50):
         postcode = return_random_postcode(
             country_boundary_identifier=org.country.boundary_identifier
         )
-        postcode = return_random_postcode(
-            country_boundary_identifier=org.country.boundary_identifier
-        )
+        index_of_multiple_deprivation_quintile = randint(1, 5)
 
         E12CaseFactory.create_batch(
             num_cases_to_seed_in_org,
@@ -151,6 +149,7 @@ def run_dummy_cases_seed(verbose=True, cases=50):
             date_of_birth=date_of_birth,
             postcode=postcode,
             ethnicity=ethnicity,
+            index_of_multiple_deprivation_quintile=index_of_multiple_deprivation_quintile,
             organisations__organisation=org,
             **{
                 "seed_male": seed_male,

--- a/epilepsy12/management/commands/seed.py
+++ b/epilepsy12/management/commands/seed.py
@@ -197,7 +197,8 @@ def complete_registrations(verbose=True, cohort=None):
 
     for registration in Registration.objects.all():
         registration.first_paediatric_assessment_date = random_date(
-            start=current_cohort_data["cohort_start_date"], end=date.today()
+            start=current_cohort_data["cohort_start_date"],
+            end=current_cohort_data["cohort_end_date"],
         )
         registration.eligibility_criteria_met = True
         registration.save()

--- a/epilepsy12/models_folder/case.py
+++ b/epilepsy12/models_folder/case.py
@@ -143,7 +143,7 @@ class Case(TimeStampAbstractBaseClass, UserStampAbstractBaseClass, HelpTextMixin
     def save(self, *args, **kwargs) -> None:
         # calculate the index of multiple deprivation quintile if the postcode is present
         # Skips the calculation if the postcode is on the 'unknown' list
-        if self.postcode:
+        if self.postcode and not self.index_of_multiple_deprivation_quintile:
             if str(self.postcode).replace(" ", "") not in UNKNOWN_POSTCODES_NO_SPACES:
                 try:
                     self.index_of_multiple_deprivation_quintile = imd_for_postcode(

--- a/epilepsy12/tests/model_tests/test_case.py
+++ b/epilepsy12/tests/model_tests/test_case.py
@@ -56,7 +56,7 @@ def test_case_save_unknown_postcode(e12_case_factory):
 @pytest.mark.django_db
 def test_case_save_postcode_obtain_imdq(e12_case_factory):
     # Tests that the save method works as expected using a known postcode IMD
-    e12Case = e12_case_factory()
+    e12Case = e12_case_factory(index_of_multiple_deprivation_quintile=None)
     e12Case.postcode = "WC1X 8SH"  # RCPCH address
     e12Case.save()
     assert e12Case.index_of_multiple_deprivation_quintile == 4
@@ -65,8 +65,17 @@ def test_case_save_postcode_obtain_imdq(e12_case_factory):
 @pytest.mark.django_db
 def test_case_save_invalid_postcode(e12_case_factory):
     # Tests that the save method works as expected using an invalid postcode
-    e12Case = e12_case_factory()
+    e12Case = e12_case_factory(index_of_multiple_deprivation_quintile=None)
     e12Case.postcode = "GARBAGE"
     e12Case.save()
     assert e12Case.postcode == "GARBAGE"
     assert e12Case.index_of_multiple_deprivation_quintile is None
+
+@pytest.mark.django_db
+def test_case_dont_overwrite_index_of_multiple_deprivation_quintile(e12_case_factory):
+    e12Case = e12_case_factory(index_of_multiple_deprivation_quintile=5)
+
+    e12Case.postcode = "WC1X 8SH"
+    e12Case.save()
+    assert e12Case.postcode == "WC1X 8SH"
+    assert e12Case.index_of_multiple_deprivation_quintile is 5

--- a/s/psql
+++ b/s/psql
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+docker compose exec postgis psql -U epilepsy12user -d epilepsy12db


### PR DESCRIPTION
4 times faster seeding data by removing API lookups performed per case or registration.

I also added a script to connect to the local db (useful whilst testing this PR).

I also added Kings to the list of seed organisations as that's the one you're sent to when you first log in as a superuser whilst developing. I got confused where my data was until I realised I needed to switch org!

**Before**

```
 Seeding 1000 fictional cases... 
Creating 142 Cases in ADDENBROOKE'S HOSPITAL
Creating 142 Cases in AIREDALE GENERAL HOSPITAL
Creating 142 Cases in ALDER HEY CHILDREN'S HOSPITAL
Creating 142 Cases in BRONGLAIS GENERAL HOSPITAL
Creating 142 Cases in CHELSEA & WESTMINSTER HOSPITAL
Creating 142 Cases in CHEPSTOW COMMUNITY HOSPITAL
Creating 142 Cases in YSBYTY YSTRAD FAWR
docker compose exec django python manage.py seed --mode=seed_registrations --cohort 6 $*
register cases in audit and complete all fields with random answers...
 Registering fictional cases in Epilepsy12... 
 Completing all the Epilepsy12 fields for the fictional cases... 


real    12m21.293s
user    0m0.189s
sys     0m0.064s
```

**After**

```
 Seeding 1000 fictional cases... 
Creating 125 Cases in ADDENBROOKE'S HOSPITAL
Creating 125 Cases in AIREDALE GENERAL HOSPITAL
Creating 125 Cases in ALDER HEY CHILDREN'S HOSPITAL
Creating 125 Cases in BRONGLAIS GENERAL HOSPITAL
Creating 125 Cases in CHELSEA & WESTMINSTER HOSPITAL
Creating 125 Cases in CHEPSTOW COMMUNITY HOSPITAL
Creating 125 Cases in KING'S COLLEGE HOSPITAL (DENMARK HILL)
Creating 125 Cases in YSBYTY YSTRAD FAWR
docker compose exec django python manage.py seed --mode=seed_registrations --cohort 6 $*
register cases in audit and complete all fields with random answers...
 Registering fictional cases in Epilepsy12... 
 Completing all the Epilepsy12 fields for the fictional cases... 


real    3m10.061s
user    0m0.163s
sys     0m0.041s
```

