### PR TITLE
Eatyourpeas/deprivation_update_postcode_unknown

### DIFF
--- a/epilepsy12/tests/model_tests/test_case.py
+++ b/epilepsy12/tests/model_tests/test_case.py
@@ -54,6 +54,17 @@ def test_case_save_unknown_postcode(e12_case_factory):
 
 
 @pytest.mark.django_db
+def test_case_save_unknown_postcode_when_imd_not_none(e12_case_factory):
+    # Tests that the save method works as expected using one of the 'unknown' postcodes
+    e12Case = e12_case_factory(
+        postcode="WC1X 8SH", index_of_multiple_deprivation_quintile=4
+    )
+    e12Case.postcode = "ZZ99 3CZ"
+    e12Case.save()
+    assert e12Case.index_of_multiple_deprivation_quintile is None
+
+
+@pytest.mark.django_db
 def test_case_save_postcode_obtain_imdq(e12_case_factory):
     # Tests that the save method works as expected using a known postcode IMD
     e12Case = e12_case_factory(index_of_multiple_deprivation_quintile=None)
@@ -70,6 +81,7 @@ def test_case_save_invalid_postcode(e12_case_factory):
     e12Case.save()
     assert e12Case.postcode == "GARBAGE"
     assert e12Case.index_of_multiple_deprivation_quintile is None
+
 
 @pytest.mark.django_db
 def test_case_dont_overwrite_index_of_multiple_deprivation_quintile(e12_case_factory):


### PR DESCRIPTION
### Overview

When a new Case is saved, `index_of_multiple_deprivation_quintile` is set if postcode is supplied. If postcode is unknown, `index_of_multiple_deprivation_quintile` is set to None. If a previously set postcode is subsequently updated to unknown, the `index_of_multiple_deprivation_quintile` was not reset to None

This PR fixes this edge case and adds a test

### Code changes

A new conditional is added to the `save` method in Case in `case.py`
A test is added to `test_case.py` that creates a new case with a known postcode and IMD quintile, then updates it to unknown and tests that IMD quintile is None


### Documentation changes (done or required as a result of this PR)

No implications for documentation

### Related Issues

closes #824
