### PR TITLE
disable_save_postcode_unknown

### DIFF
--- a/templates/epilepsy12/cases/postcode_options.html
+++ b/templates/epilepsy12/cases/postcode_options.html
@@ -22,6 +22,7 @@
               set id_postcode.value to '' then
               hide #postcode_field then 
               hide #no_postcode then 
+              add .disabled to #create_update_case_button then
               show #unknown_postcode then 
               show #add_postcode"
           >No postcode</button>
@@ -33,6 +34,7 @@
           _="on click 
             halt the event then 
             set id_postcode.value to '' then
+            remove .disabled from #create_update_case_button then
             show #postcode_field then 
             hide #unknown_postcode then 
             show #no_postcode then hide me"

--- a/templates/epilepsy12/cases/unknown_postcode.html
+++ b/templates/epilepsy12/cases/unknown_postcode.html
@@ -9,6 +9,8 @@
     name="unknown_postcode"
     hidden
     {% if test_positive %}
-        _="on load set id_postcode.value to '{{test_positive}}'"
+        _="on load set id_postcode.value to '{{test_positive}}' then
+        remove .disabled from #create_update_case_button
+        "
     {% endif %}
 />

--- a/templates/epilepsy12/forms/case_form.html
+++ b/templates/epilepsy12/forms/case_form.html
@@ -134,6 +134,7 @@
       </a>
       {% if perms.epilepsy12.change_case or perms.epilepsy12.add_case %}
         <button 
+        id="create_update_case_button"
         type="submit" 
         class="ui rcpch_primary button" 
         name="update" 


### PR DESCRIPTION
### Overview

If postcode is not known but none of the three-way toggles are selected, the postcode_id input field has no focus and no value, throwing an error. This PR disables the save button when 'no postcode' has been selected but none of the 3 options have been chosen either. Once an option has been chosen, the save button is enabled.

### Code changes

Multiple small changes to the hyperscript in 3 template files:
1. the `case_form` adds an id to the save button to identify it in the DOM
2. the `postcode_options` template either adds or removes the `.disabled` class from the save button on click of th add postcode/no postcode buttons
3. The `unknown_postcode` template which holds the threeway toggle resets the save button to enabled once an option is selected.


### Documentation changes (done or required as a result of this PR)

This is a bug fix

### Related Issues

fixes and closes #825
