### PR TITLE
Remove Celery, Redis and Flower

### DIFF
--- a/envs/env-template
+++ b/envs/env-template
@@ -27,7 +27,7 @@ DJANGO_ALLOWED_HOSTS="${SITE_DOMAIN}"
 DJANGO_CSRF_TRUSTED_ORIGINS="https://${SITE_DOMAIN}"
 DJANGO_STARTUP_COMMAND="python manage.py runserver 0.0.0.0:8000" # for local development with auto-reload
 # DJANGO_STARTUP_COMMAND="gunicorn --bind=0.0.0.0:8000 --timeout 600 rcpch-audit-engine.wsgi" # for live deployment
-E12_SECRET_KEY= # secret key for Django
+DJANGO_SECRET_KEY= # secret key for Django
 SITE_CONTACT_EMAIL="sitecontactemail@example.com" # email address for site contact
 
 # DJANGO LOGGING

--- a/epilepsy12/management/commands/seed.py
+++ b/epilepsy12/management/commands/seed.py
@@ -25,8 +25,6 @@ from .create_e12_records import create_epilepsy12_record, create_registrations
 from epilepsy12.tests.factories import E12CaseFactory
 from epilepsy12.tasks import (
     insert_old_pt_data,
-    async_insert_old_pt_data,
-    async_insert_user_data,
 )
 from epilepsy12.management.commands.user_scripts import insert_user_data
 
@@ -81,15 +79,9 @@ class Command(BaseCommand):
         elif options["mode"] == "upload_old_patient_data":
             self.stdout.write("Uploading old patient data.")
             insert_old_pt_data()
-        elif options["mode"] == "async_upload_old_patient_data":
-            self.stdout.write("CELERY: uploading old patient data.")
-            async_insert_old_pt_data.delay()
         elif options["mode"] == "upload_user_data":
             self.stdout.write("Uploading user data.")
             insert_user_data()
-        elif options["mode"] == "async_upload_user_data":
-            self.stdout.write("CELERY: uploading user data.")
-            async_insert_user_data.delay()
         elif options["mode"] == "add_new_epilepsy_causes":
             extra_concept_ids = options["snomedctids"]
             if not isinstance(extra_concept_ids, list):

--- a/epilepsy12/tasks.py
+++ b/epilepsy12/tasks.py
@@ -22,26 +22,7 @@ from epilepsy12.management.commands.user_scripts import insert_user_data
 logger = logging.getLogger(__name__)
 
 @shared_task
-def asynchronously_aggregate_kpis_and_update_models_for_cohort_and_abstraction_level(
-    cohort: int = None,
-    abstractions: Union[Literal["all"], list[EnumAbstractionLevel]] = "all",
-    open_access=False,
-):
-    """This asynchronous task will run through all Cases for the Cohort, for all abstraction levels, aggregate KPI scores and update each abstraction's KPIAggregation model.
-    `cohort` and `abstractions` parameters are optional.
-    """
-    # If no cohort supplied, automatically get cohort from current datetime
-    if cohort is None:
-        cohort = cohort_number_from_first_paediatric_assessment_date(date.today())
-
-    # By default, this will update all KPIAggregation models for all levels of abstraction
-    update_all_kpi_agg_models(
-        cohort=cohort, abstractions=abstractions, open_access=open_access
-    )
-
-
-@shared_task
-def asynchronously_send_email_to_recipients(
+def send_email_to_recipients(
     recipients: list, subject: str, message: str
 ):
     """
@@ -58,16 +39,6 @@ def asynchronously_send_email_to_recipients(
         )
     except Exception:
         raise BadHeaderError
-
-
-@shared_task
-def async_insert_old_pt_data(csv_path: str = "data.csv"):
-    insert_old_pt_data(csv_path=csv_path)
-
-
-@shared_task
-def async_insert_user_data(csv_path: str = "data.csv"):
-    insert_user_data(csv_path=csv_path)
 
 @shared_task
 def hello():

--- a/epilepsy12/views/case_views.py
+++ b/epilepsy12/views/case_views.py
@@ -30,7 +30,7 @@ from ..decorator import (
 from django.conf import settings
 
 from ..general_functions import construct_transfer_epilepsy12_site_outcome_email
-from ..tasks import asynchronously_send_email_to_recipients
+from ..tasks import send_email_to_recipients
 
 # Logging setup
 logger = logging.getLogger(__name__)
@@ -498,7 +498,7 @@ def transfer_response(request, organisation_id, case_id, organisation_response):
         recipients = [settings.SITE_CONTACT_EMAIL]
         subject = f"Epilepsy12 Lead Site Transfer {outcome}  - NO LEAD CLINICIAN"
 
-    asynchronously_send_email_to_recipients.delay(
+    send_email_to_recipients(
         recipients=recipients, subject=subject, message=email
     )
 

--- a/epilepsy12/views/organisation_views.py
+++ b/epilepsy12/views/organisation_views.py
@@ -29,9 +29,8 @@ from ..general_functions import (
     value_from_key,
     cohorts_and_dates,
 )
-from ..tasks import (
-    asynchronously_aggregate_kpis_and_update_models_for_cohort_and_abstraction_level,
-)
+
+from epilepsy12.common_view_functions.aggregate_by import update_all_kpi_agg_models
 
 
 def selected_organisation_summary_select(request):
@@ -199,7 +198,7 @@ def publish_kpis(request, organisation_id):
     cohort_data = dates_for_cohort(cohort)
 
     # perform aggregations and update all the KPIAggregation models only for clinicians
-    asynchronously_aggregate_kpis_and_update_models_for_cohort_and_abstraction_level.delay(
+    update_all_kpi_agg_models(
         cohort=cohort_data["cohort"], open_access=True
     )
 
@@ -242,7 +241,7 @@ def selected_trust_kpis(request, organisation_id, access):
 
         if access == "private":
             # perform aggregations and update all the KPIAggregation models only for clinicians
-            asynchronously_aggregate_kpis_and_update_models_for_cohort_and_abstraction_level.delay(
+            update_all_kpi_agg_models(
                 cohort=cohort_data["submitting_cohort"], open_access=False
             )
 

--- a/epilepsy12/views/registration_views.py
+++ b/epilepsy12/views/registration_views.py
@@ -33,7 +33,7 @@ from ..general_functions import (
     construct_transfer_epilepsy12_site_email,
     cohorts_and_dates,
 )
-from ..tasks import asynchronously_send_email_to_recipients
+from ..tasks import send_email_to_recipients
 
 
 @login_and_otp_required()
@@ -462,7 +462,7 @@ def update_lead_site(request, registration_id, site_id, update):
             origin_organisation=origin_organisation,
         )
 
-        asynchronously_send_email_to_recipients.delay(
+        send_email_to_recipients(
             recipients=recipients, subject=subject, message=email
         )
 

--- a/epilepsy12/views/user_management_views.py
+++ b/epilepsy12/views/user_management_views.py
@@ -41,7 +41,7 @@ from ..constants import (
     AUDIT_CENTRE_ROLES,
     EPILEPSY12_AUDIT_TEAM_FULL_ACCESS,
 )
-from ..tasks import asynchronously_send_email_to_recipients
+from ..tasks import send_email_to_recipients
 
 
 @login_and_otp_required()
@@ -372,7 +372,7 @@ def create_epilepsy12_user(request, organisation_id, user_type, epilepsy12_user_
             subject = "Password Reset Requested"
             email = construct_confirm_email(request=request, user=new_user)
 
-            asynchronously_send_email_to_recipients.delay(
+            send_email_to_recipients(
                 recipients=[new_user.email], subject=subject, message=email
             )
 
@@ -462,7 +462,7 @@ def edit_epilepsy12_user(request, organisation_id, epilepsy12_user_id):
                 request=request, user=epilepsy12_user_to_edit
             )
 
-            asynchronously_send_email_to_recipients.delay(
+            send_email_to_recipients(
                 recipients=[epilepsy12_user_to_edit.email],
                 subject=subject,
                 message=email,


### PR DESCRIPTION
We have benchmarked our aggregation queries against 10,000 fake cases. Calculating them at all levels only takes 1 second.

As such we've decided to remove the current async task infrastructure. It's acceptable to wait 1 second to refresh the KPIs in the UI. It also allows us to simplify the dev ops setup in the future, potentially moving back to Azure app service as docker compose will no longer be required.

We will need asynchronous tasks or scheduling in the future and we'll review our tech choices again then based on priorities and needs.