### PR TITLE
fixes E12_SECRET_KEY to DJANGO_SECRET_KEY

### DIFF
--- a/envs/env-template
+++ b/envs/env-template
@@ -27,7 +27,7 @@ DJANGO_ALLOWED_HOSTS="${SITE_DOMAIN}"
 DJANGO_CSRF_TRUSTED_ORIGINS="https://${SITE_DOMAIN}"
 DJANGO_STARTUP_COMMAND="python manage.py runserver 0.0.0.0:8000" # for local development with auto-reload
 # DJANGO_STARTUP_COMMAND="gunicorn --bind=0.0.0.0:8000 --timeout 600 rcpch-audit-engine.wsgi" # for live deployment
-E12_SECRET_KEY= # secret key for Django
+DJANGO_SECRET_KEY= # secret key for Django
 SITE_CONTACT_EMAIL="sitecontactemail@example.com" # email address for site contact
 
 # DJANGO LOGGING


### PR DESCRIPTION
this change needs to be replicated out into all the untracked envs/.env files in local development, GH Actions, and the deployment environments in order to work
