### PR TITLE
Pin all our direct dependencies

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,62 +1,52 @@
 # Python standard library imports
-python-dateutil
-requests
+python-dateutil==2.9.0.post0
+requests==2.31.0
 
 # third party imports
 ## django and misc
-dj_database_url
-django
-django-auto-logout
-django-filter
-django-htmx
-django-semantic-admin
-django-simple-captcha
-django-simple-history
-django-two-factor-auth
-django-widget-tweaks
-djangorestframework
-docutils
-pandas
-phonenumbers # though not currently using phonenumbers, this is a dependency of dj-2fa
-psycopg2-binary
-whitenoise
+dj_database_url==2.1.0
+django==5.0.3
+django-auto-logout==0.5.1
+django-filter==23.5
+django-htmx==1.17.3
+django-semantic-admin==0.4.1
+django-simple-captcha==0.6.0
+django-simple-history==3.5.0
+django-two-factor-auth==1.16.0
+django-widget-tweaks==1.5.0
+djangorestframework==3.14.0
+docutils==0.20.1
+pandas==2.2.1
+# We don't use this but django-two-factor-auth requires it
+# They are working to make it optional https://github.com/jazzband/django-two-factor-auth/issues/469
+phonenumbers==8.13.31
+psycopg2-binary==2.9.9
+whitenoise==6.6.0
 
 ## graphing
-plotly
+plotly==5.19.0
 
 # NHS number
-nhs-number
+nhs-number==1.3.4
 
 # live application server
-gunicorn
+gunicorn==21.2.0
 
 # code linting and formatting
-autopep8
-black
+autopep8==2.0.4
+black==24.2.0
 
 # testing and code analysis
-coverage
-pytest-django
-pytest-factoryboy
-rapidfuzz
+coverage==7.4.3
+pytest-django==4.8.0
+pytest-factoryboy==2.7.0
+rapidfuzz==3.6.2
 
-# versioning
-bump2version
-
-# DOCUMENTATION - MATERIAL FOR MKDOCS INSIDERS
-# IMPORTANT: This project uses Material for MkDocs **INSIDERS** Edition.
-# To install this you will need a GitHub token which is available (for RCPCH team only)
-# in our .env files
-
-# git+https://${MATERIAL_FOR_MKDOCS_INSIDERS_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
-
-# Further information is at https://squidfunk.github.io/mkdocs-material/insiders/getting-started/
-
-mkdocs-material
-mkdocs-git-committers-plugin-2 # displays authors at the bottom of the page
-mkdocs-git-revision-date-localized-plugin # displays last edit date at the bottom of the page
-mkdocs-macros-plugin # enables 'foldable' admonition text (used for large code blocks)
-mkdocs-with-pdf # PDF export feature
+mkdocs-material==9.5.13
+mkdocs-git-committers-plugin-2==2.3.0 # displays authors at the bottom of the page
+mkdocs-git-revision-date-localized-plugin==1.2.4 # displays last edit date at the bottom of the page
+mkdocs-macros-plugin==1.0.5 # enables 'foldable' admonition text (used for large code blocks)
+mkdocs-with-pdf==0.9.3 # PDF export feature
 
 # for colored logs
-colorlog
+colorlog==6.8.2


### PR DESCRIPTION
Fixes #833 

We had an issue where our unpinned dependencies brought in a new Django major version automatically, causing the logout button to break (https://github.com/rcpch/rcpch-audit-engine/issues/837).

This PR pins all our direct dependencies to try and avoid this happening in the future. This naturally puts the emphasis on us to monitor and upgrade our dependencies as quickly as we can, in collaboration with our good friend Dependabot :)

I've deliberately chosen not to copy paste in the result of `pip freeze` as that would lock all of our transitive dependencies too and make it difficult to simply bump versions in the future without "unfreezing" and freezing again.

I wanted to double check this approach hadn't brought across anything too scary transitively, especially our dependencies themselves having unpinned dependencies. I ran [pipdeptree](https://pypi.org/project/pipdeptree/) to get the full dependency tree and searched for `Any`.

There were some documentation transitive dependencies (`PyYAML`, `GitPython`) but I'm not worried - if they upgrade and cause issues we can easily split off the documentation to a separate build to get the app deployable again.

For the main app these are the unpinned transitive dependencies. For each one I've added a little bit of context as to why I think it's ok not to worry right now:

| Library           | Dependency Path                                                                                       | Notes                                                                                                                                                                                                                                                                                                                                                                                                    |
|-------------------|-------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Django            | `django-simple-captcha > django-ranged-response`                                                      | We'll always have Django as a pinned main dependency. There has not been a release of django-ranged-response since 2017 but django-simple-captcha is well maintained so would likely address any breakage across major versions for us.                                                                                                                                                                  |
| pypng             | `django-two-factor-auth > django-formtools > qrcode`                                                  | No release since 2022 but there is activity in their source (https://gitlab.com/drj11/pypng). They specifically do not follow semantic versioning https://gitlab.com/drj11/pypng/-/commit/81809f032cdc334bab9893e4982470f9246efe14#5b84fdee5cb197a7299f979e9e9908e925ac4d0f_17_27. Again, breakage would likely be handled by django-formtools which had two releases last year so is fairly maintained. |
| typing_extensions | `django-two-factor-auth > django-formtools > qrcode`                                                  | This package exists purely to adopt typing in older Python versions and essentially does nothing on 3.11 (our version). They are hesitent to break backwards compat https://typing-extensions.readthedocs.io/en/latest/#versioning-and-backwards-compatibility                                                                                                                                           |
| packaging         | `black` `gunicorn` `plotly` `pytest-django > pytest` `pytest-factoryboy` `pytest-factoryboy > pytest` | Very widely adopted. Only one breaking change in the entire release notes and it was a technicality: https://github.com/pypa/packaging/pull/734.                                                                                                                                                                                                                                                         |
| iniconfig         | `pytest-django > pytest` `pytest-factoryboy > pytest`                                                 | One breaking change from Jan last year, otherwise no releases since Oct 20. Seems to follow at least major version semantic versioning?                                                                                                                                                                                                                                                                  |
| pytz              | `djangorestframework`                                                                                 | Project is in maintenance mode, apparently core Python >= 3.9 has enough functionality not to need this package (https://pypi.org/project/pytz/). Eventually djangorestframework will update to a newer base Python version and not need this any more As the project is in maintenance mode they are unlikely to introduce breaking changes.                                                            |
| inflection        | `pytest-factoryboy`                                                                                   | No release since 2020 although there were some commits last year. Just a testing dependency though so at worst we would comment out the tests until fixed.                                                                                                                                                                                                                                               |
