### PR TITLE
Logout button is broken

### DIFF
--- a/templates/epilepsy12/nav.html
+++ b/templates/epilepsy12/nav.html
@@ -15,7 +15,10 @@
           <div class="rcpch_logged_in">
             <h5><i class="id badge icon"></i>{{ user.get_full_name }}</h5>
           </div>
-          <div class="ui button" onclick="location.href='{% url 'logout' %}'">Log out</div>
+          <form method="POST" action="{% url 'logout' %}">
+            {% csrf_token %}
+            <button class="ui rcpch_light_blue button" type="submit">Log out</button>
+          </form>
           <div class="ui floating dropdown icon button">
           <i class="dropdown icon"></i>
           <div class="menu">


### PR DESCRIPTION
### Overview

Following django 4.2 the logout get request has been changed to a post request, meaning users can nolonger logout from our form

### Code changes

The nav button is now wrapped in a form element which makes a POST request on submit. The csrf token is added to the header as part of this.

### Documentation changes (done or required as a result of this PR)

All documentation relevent in the issue discussion

### Related Issues

Fixes #837

### Mentions

@mbarton
