### PR TITLE
Error saving general paediatric centre

### DIFF
--- a/templates/epilepsy12/partials/page_elements/organisations_select.html
+++ b/templates/epilepsy12/partials/page_elements/organisations_select.html
@@ -32,11 +32,14 @@ hx_confirm: if present, the text to confirm continue
             hx-trigger="{{hx_trigger}}"
             name='{{hx_name}}'
             value="{{test_positive}}"
-            _="init js $('.ui.rcpch_light_blue.search.selection.dropdown').dropdown(); end"
+            _="init js $('.ui.rcpch_light_blue.search.selection.dropdown').dropdown(); end
+            on change remove .disabled from #{{hx_name}}_button"
         >
         
         <div class="default text">{{hx_default_text}}</div>
-            <div class="menu" >
+            <div 
+                class="menu"
+            >
                 {% for item in organisation_list %}
                     {% if item.trust %}
                         <div class="item" data-value="{{item.pk}}" >{{item.name}} ({{item.trust.name}})</div>
@@ -50,8 +53,9 @@ hx_confirm: if present, the text to confirm continue
 
 
         <div class='ui buttons'>
-            <button 
-                class="ui rcpch_primary button"
+            <button
+                id="{{hx_name}}_button"
+                class="ui rcpch_primary disabled button"
                 hx-post="{{hx_post}}"
                 hx-target="{{hx_target}}"
                 hx-swap="innerHTML"


### PR DESCRIPTION
Fixes #841 - disable save centre button if not dirty

### Overview

Production logs were showing an error where the organisation id was not in the post request to the `general_paediatric_centre` end point. This was because the update button was not disabled if no organisation was selected in the dropdown. If a user clicked the update button when no organisation was selected in the drop down, this would trigger the post request without the organisation id leading to a silent error.

This repair adds a fix to the template.

### Code changes

The organisations select partial has an id added to identify it in the DOM, and some hyperscript to the hidden input which removes the disabled class from the submit button when dirty.

### Documentation changes (done or required as a result of this PR)

Documentation here covers it

### Related Issues

closes #841

### Mentions

Thanks to @mbarton for identifying this.
