### PR TITLE
Sets autoescape to on for password reset page

### DIFF
--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -1,6 +1,6 @@
 {% load epilepsy12_template_tags %}
 {% load static %}
-{% autoescape off %}
+{% autoescape on %}
 <div class="indent" style="display: relative; width: 80%; margin: auto;">
   <div class="centered" style="width: 50%; margin: auto;">
     <img alt="RCPCH Epilepsy12 Logo" src='{{ protocol}}://{{ domain }}{% static "images/epilepsy12-logo-1.png" %}'>


### PR DESCRIPTION
### Overview

Provides a fix to the password reset field being broken in local development.

This change fixes the breaking, but also provides an extra layer of security against XSS attacks by autoescaping any html characters.

### Code changes

Changes password_reset_email.html, sets autoescape to on.


### Related Issues

Closes #767 

### Mentions

@mbarton