### PR TITLE
Tidies user verification logging error

### DIFF
--- a/epilepsy12/decorator.py
+++ b/epilepsy12/decorator.py
@@ -372,7 +372,9 @@ def login_and_otp_required():
 
             # Prevent unverified users
             if not user.is_verified():
-                logger.info("User %s is unverified. Tried accessing %s", user, view)
+                user_list = user.__dict__
+                epilepsy12_user = user_list['_wrapped']
+                logger.info("User %s is unverified. Tried accessing %s", epilepsy12_user , view.__qualname__)
                 raise PermissionDenied()
 
             return view(request, *args, **kwargs)

--- a/epilepsy12/decorator.py
+++ b/epilepsy12/decorator.py
@@ -372,7 +372,7 @@ def login_and_otp_required():
 
             # Prevent unverified users
             if not user.is_verified():
-                logger.info("User %s is unverified. Tried accessing", view)
+                logger.info("User %s is unverified. Tried accessing %s", user, view)
                 raise PermissionDenied()
 
             return view(request, *args, **kwargs)


### PR DESCRIPTION
### Overview

Logs to the console the user's name and which view they have tried to accessed while being unverified (ie not having setup 2FA).

The output no longer displays the Python object, but instead the user's first and last name. Also the name of the view accessed is tidier:

User Mr user user is unverified. Tried accessing user_may_view_this_organisation.<locals>.decorator.<locals>.wrapper

### Code changes

Changes to the login_and_otp_required() decorator inside decorator.py

### Related Issues

Closes issue #742

### Mentions

@anchit-chandran @mbarton
