### PR TITLE
add causes except genetics to migration__0006

### DIFF
--- a/epilepsy12/constants/causes.py
+++ b/epilepsy12/constants/causes.py
@@ -34,7 +34,7 @@ EPILEPSY_GENETIC_CAUSE_TYPES = (
 
 EPILEPSY_GENE_DEFECTS = (
     ("UBE", "UBE3A"),    # 722056009
-    ("GLU", "GLUT1"),
+    ("GLU", "GLUT1"),   # 445252005
     ("SLC", "SLC2A1"),  # 782911008
     ("MEC", "MECP2"),   # 702816000
     ("SCN", "SCN1A"),   # 230437002
@@ -42,13 +42,15 @@ EPILEPSY_GENE_DEFECTS = (
     ("CDK", "CDKL5"),   # 773230003
     ("KCN", "KCNQ2"),   # 778001003
     ("SCN", "SCN2A"),   # 778002005
-    ("KCN", "KCNT1"),
+    ("KCN", "KCNT1"),   # no code
     ("ARX", "ARX"),     # 725163002
     ("FOX", "FOXG1"),   # 702450004
-    ("PCD", "PCDH19"),
+    ("PCD", "PCDH19"),  # 888801000000105
     ("GRI", "GRIN2A"),  # 770431001
     ("Oth", "Other")
 )
+
+
 
 METABOLIC_CAUSES = (
     # 240096000

--- a/epilepsy12/migrations/0006_seed_epilepsy_causes.py
+++ b/epilepsy12/migrations/0006_seed_epilepsy_causes.py
@@ -69,6 +69,21 @@ def seed_epilepsy_causes(apps, schema_editor):
     # Angelman syndrome (disorder)	76880004
     # Rett's disorder (disorder)	68618008
     # Neuronal ceroid lipofuscinosis (disorder)	42012007
+    # UBE3A 722056009
+    # GLUT1 445252005
+    # SLC2A1 782911008
+    # MECP2 702816000
+    # SCN1A 230437002
+    # STXBP1 768666006
+    # CDKL5 773230003
+    # KCNQ2 778001003
+    # SCN2A 778002005
+    # KCNT1 no code - NOTE THIS NEEDS ADDING TO THE DATABASE MANUALLY
+    # ARX 725163002
+    # FOXG1 702450004
+    # PCDH19 888801000000105
+    # GRIN2A 770431001
+    # Dysembryoplastic neuroepithelial neoplasm of brain (disorder) 1196837008 - NOTE THIS DOES NOT EXIST IN CURRENT SNOMED TERMINOLOGY SERVER: ADD MANUALLY
     extra_concept_ids = [
         764946008,
         52767006,
@@ -89,7 +104,20 @@ def seed_epilepsy_causes(apps, schema_editor):
         127295002,
         76880004,
         68618008,
-        42012007
+        42012007,
+        722056009,
+        445252005,
+        782911008,
+        702816000,
+        230437002,
+        768666006,
+        773230003,
+        778001003,
+        778002005,
+        725163002,
+        702450004,
+        888801000000105,
+        770431001
     ]
     add_epilepsy_cause_list_by_sctid(extra_concept_ids=extra_concept_ids)
 

--- a/epilepsy12/migrations/0006_seed_epilepsy_causes.py
+++ b/epilepsy12/migrations/0006_seed_epilepsy_causes.py
@@ -63,6 +63,12 @@ def seed_epilepsy_causes(apps, schema_editor):
     # Cerebral ischemic stroke due to global hypoperfusion with watershed infarct - 788882003
     # Schizencephaly (disorder) - 253159001
     # Tetrasomy 12p syndrome (disorder) - 9527009
+    # Klinefelter syndrome (disorder)	22053006
+    # Hypothalamic neuronal hamartoma (disorder)	230791000
+    # Traumatic brain injury (disorder)	127295002
+    # Angelman syndrome (disorder)	76880004
+    # Rett's disorder (disorder)	68618008
+    # Neuronal ceroid lipofuscinosis (disorder)	42012007
     extra_concept_ids = [
         764946008,
         52767006,
@@ -78,6 +84,12 @@ def seed_epilepsy_causes(apps, schema_editor):
         788882003,
         253159001,
         9527009,
+        22053006,
+        230791000,
+        127295002,
+        76880004,
+        68618008,
+        42012007
     ]
     add_epilepsy_cause_list_by_sctid(extra_concept_ids=extra_concept_ids)
 


### PR DESCRIPTION
### Overview

Adding causes as per #854

Klinefelter syndrome (disorder)	22053006
Hypothalamic neuronal hamartoma (disorder)	230791000
Traumatic brain injury (disorder)	127295002
Angelman syndrome (disorder)	76880004
Rett's disorder (disorder)	68618008
Neuronal ceroid lipofuscinosis (disorder)	42012007

### Code changes

Added already to databases in staging and live. 
Adding here to the migrations for future seeding

### Related Issues

#854 - does not close as outstanding question.

### Mentions

@coldunk @AmaniKrayemRCPCH