### PR TITLE
853 add text in new user emails

### DIFF
--- a/templates/registration/admin_reset_password.html
+++ b/templates/registration/admin_reset_password.html
@@ -15,7 +15,9 @@
     </a>
   </p>
   <p style="font-family: 'Montserrat', sans-serif;">
-    This link can only be used once.
+    This link can only be used once, and expires in 72 hours. To request a new link, get in touch with your Epilepsy12 local admin
+    or get in touch with
+    <a href="mailto:epilepsy12@rcpch.ac.uk">The Epilepsy12 Team</a>
   </p>
   <br />
   <p style="font-family: 'Montserrat', sans-serif;">

--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -19,6 +19,15 @@
   <p style="font-family: 'Montserrat', sans-serif;">If you did not make this request, please
     <a href="mailto:{% site_contact_email %}">contact the RCPCH Epilepsy12 team.</a>
   </p>
+  <p style="font-family: 'Montserrat', sans-serif;">Please note that this link will expire in 72 hours</p>
+  <p>
+    To request a new link, go to 
+    <a href="{{ protocol }}://{{ domain }}{% url 'password_reset'%}">
+      {{ protocol }}://{{ domain }}{% url 'password_reset'%}
+    </a>
+    or get in touch with 
+    <a href="mailto:epilepsy12@rcpch.ac.uk">The Epilepsy12 Team</a>
+  </p>
   <br />
   <p style="font-family: 'Montserrat', sans-serif;">The RCPCH Epilepsy12 team</p>
 </div>


### PR DESCRIPTION
### Overview

Adds extra text to email for password reset and first password set email.

Adds in a link back to the password reset page should the user's link expire, and also a mailto to the epilepsy12 team for additional support

### Code changes

admin_password_reset.html: adds info and mailto

password_reset.html: adds info, link to reset page and mailto

### Related Issues

Closes #853 

