### PR TITLE
Updates message for empty search

### DIFF
--- a/templates/epilepsy12/partials/case_table.html
+++ b/templates/epilepsy12/partials/case_table.html
@@ -329,7 +329,7 @@
   {% else %}
   <div class='ui container'>
     <div class='padded_container'>
-      <div class='ui rcpch_info fluid message'>There are no children registered yet</div>
+      <div class='ui rcpch_info fluid message'>No children found.</div>
     </div>
   </div>
   {% endif %}


### PR DESCRIPTION
### Overview

Simple change to the message for when a search for children comes back as empty

### Code changes

case_table.html - replace search message with "No children found"

### Related Issues

Closes #784

