### PR TITLE
updates password reset email with expiry time variable

### DIFF
--- a/envs/env-template
+++ b/envs/env-template
@@ -46,6 +46,9 @@ EMAIL_HOST_SERVER= # hostname of SMTP service
 EMAIL_HOST_USER= # username for SMTP service
 # To output emails to console, set SMTP_EMAIL_ENABLED=False
 SMTP_EMAIL_ENABLED=True # To output emails to console, set SMTP_EMAIL_ENABLED=False
+# Password reset link expires after (in seconds)
+PASSWORD_RESET_TIMEOUT=259200
+
 
 # HERMES (SNOMED CT)
 RCPCH_HERMES_SERVER_URL= # SNOMED server API URL

--- a/epilepsy12/views/user_management_views.py
+++ b/epilepsy12/views/user_management_views.py
@@ -565,7 +565,7 @@ class ResetPasswordView(SuccessMessageMixin, PasswordResetView):
         "please make sure you've entered the address you registered with, and check your spam folder."
     )
     extra_email_context= { 
-                          "reset_password_link_expires_at": datetime.now() + timedelta(seconds=settings.PASSWORD_RESET_TIMEOUT) }
+                          "reset_password_link_expires_at": datetime.now() + timedelta(seconds=int(settings.PASSWORD_RESET_TIMEOUT)) }
     success_url = reverse_lazy("index")
 
     # extend form_valid to set user.password_last_set

--- a/epilepsy12/views/user_management_views.py
+++ b/epilepsy12/views/user_management_views.py
@@ -22,6 +22,7 @@ from django_htmx.http import HttpResponseClientRedirect
 # Other dependencies
 from two_factor.views import LoginView as TwoFactorLoginView
 import pandas as pd
+from datetime import datetime, timedelta
 
 # epilepsy12
 from ..models import Epilepsy12User, Organisation, VisitActivity, Site
@@ -563,6 +564,8 @@ class ResetPasswordView(SuccessMessageMixin, PasswordResetView):
         " If you don't receive an email, "
         "please make sure you've entered the address you registered with, and check your spam folder."
     )
+    extra_email_context= { 
+                          "reset_password_link_expires_at": datetime.now() + timedelta(seconds=settings.PASSWORD_RESET_TIMEOUT) }
     success_url = reverse_lazy("index")
 
     # extend form_valid to set user.password_last_set

--- a/rcpch-audit-engine/settings.py
+++ b/rcpch-audit-engine/settings.py
@@ -84,6 +84,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.admindocs",
+    "django.contrib.humanize",
     "rest_framework",
     "whitenoise.runserver_nostatic",
     "django.contrib.staticfiles",
@@ -239,7 +240,7 @@ else:
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 logger.info("EMAIL_BACKEND: %s", EMAIL_BACKEND)
 
-PASSWORD_RESET_TIMEOUT = 259200  # Default: 259200 (3 days, in seconds)
+PASSWORD_RESET_TIMEOUT = os.environ.get("PASSWORD_RESET_TIMEOUT", 259200)  # Default: 259200 (3 days, in seconds)
 
 SITE_CONTACT_EMAIL = os.environ.get("SITE_CONTACT_EMAIL")
 

--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -1,5 +1,6 @@
 {% load epilepsy12_template_tags %}
 {% load static %}
+{% load humanize %}
 {% autoescape on %}
 <div class="indent" style="display: relative; width: 80%; margin: auto;">
   <div class="centered" style="width: 50%; margin: auto;">
@@ -19,7 +20,7 @@
   <p style="font-family: 'Montserrat', sans-serif;">If you did not make this request, please
     <a href="mailto:{% site_contact_email %}">contact the RCPCH Epilepsy12 team.</a>
   </p>
-  <p style="font-family: 'Montserrat', sans-serif;">Please note that this link will expire in 72 hours</p>
+  <p style="font-family: 'Montserrat', sans-serif;">Please note that this link will expire in <b>{{ reset_password_link_expires_at|naturaltime }}</b></p>
   <p>
     To request a new link, go to 
     <a href="{{ protocol }}://{{ domain }}{% url 'password_reset'%}">


### PR DESCRIPTION
### Overview

Converts hard-coded "72 hours" to use the expiry time defined as env variable.

### Code changes

Updates .env template.
Imports humanize from built-in django template filters. 
In email template, updates "72 hours" to humanized datetime var, expressed as seconds (int). 

### Documentation changes (done or required as a result of this PR)
n/a


### Related Issues
#853 
