### PR TITLE
Defend against missing national aggregation entries

### DIFF
--- a/epilepsy12/common_view_functions/aggregate_by.py
+++ b/epilepsy12/common_view_functions/aggregate_by.py
@@ -782,6 +782,33 @@ def ___delete_and_recreate_all_kpi_aggregation_models():
 
     _seed_all_aggregation_models()
 
+def create_kpi_report_row(key, measure, kpi, aggregation_row):
+    ret = {
+        "Measure": measure,
+        "Percentage": 0,
+        "Numerator": 0,
+        "Denominator": 0
+    }
+
+    if aggregation_row:
+        numerator = aggregation_row[f"{kpi}_passed"]
+        denominator = aggregation_row[f"{kpi}_total_eligible"]
+
+        if numerator is None:
+            logger.info(f"Missing numerator for {key} {measure} {kpi}")
+        
+        if denominator is None:
+            logger.info(f"Missing denominator for {key} {measure} {kpi}")
+        
+        ret["Numerator"] = numerator
+        ret["Denominator"] = denominator
+
+        # Make sure we don't divide by zero
+        if denominator != 0:
+            ret["Percentage"] = (numerator / denominator) * 100
+    
+    return ret
+
 def create_KPI_aggregation_dataframe(KPI_model1, constants_list1, cohort, measures, measures_titles, KPI_model2=None, constants_list2=None, is_regional=False):
         '''
         INPUTS:
@@ -849,38 +876,11 @@ def create_KPI_aggregation_dataframe(KPI_model1, constants_list1, cohort, measur
             for key in objects:
                 object = objects[key]
                 for index, kpi in enumerate(measures):
-                    # Catch empty entries
-                    if object == None:
-                        item = {
-                            title: key,
-                            "Measure": measures_titles[index],
-                            "Percentage": 0,
-                            "Numerator": 0,
-                            "Denominator": 0,
-                        }
-                    # Catch Zero Division Errors
-                    elif object[f"{kpi}_total_eligible"] == 0:
-                        item = {
-                            title: key,
-                            "Measure": measures_titles[index],
-                            "Percentage": 0,
-                            "Numerator": object[f"{kpi}_passed"],
-                            "Denominator": object[f"{kpi}_total_eligible"],
-                        }
-                    else:
-                        item = {
-                            title: key,
-                            "Measure": measures_titles[index],
-                            "Percentage": object[f"{kpi}_passed"]
-                            / object[f"{kpi}_total_eligible"]
-                            * 100,
-                            "Numerator": object[f"{kpi}_passed"],
-                            "Denominator": object[f"{kpi}_total_eligible"],
-                        }
+                    item = create_kpi_report_row(key, measures_titles[index], kpi, object)
+                    item[title] = key
                     final_list.append(item)  
         
         # Group organisation body by KPI, then add to dataframe - collect all values relating to KPI 1 across all organisation bodies, add to dataframe, repeat for next KPI
-
         else:
             for index, kpi in enumerate(measures):
                 if is_regional:
@@ -908,71 +908,19 @@ def create_KPI_aggregation_dataframe(KPI_model1, constants_list1, cohort, measur
                     final_list.append(item)
                 for key in objects:
                     object = objects[key]
+                    measure_title = measures_titles[index]
+
                     if ((constants_list1 == INTEGRATED_CARE_BOARDS) or 
                         (constants_list1 == NHS_ENGLAND_REGIONS) or 
                         (constants_list1 == OPEN_UK_NETWORKS) or 
                         (constants_list1 == TRUSTS)):
-                        # Catch empty entries
-                        if object == None:
-                            item = {
-                                title + "Measure": key + measures_titles[index],
-                                title: key,
-                                "Measure": measures_titles[index],
-                                "Percentage": 0,
-                                "Numerator": 0,
-                                "Denominator": 0,
-                            }
-                        # Catch zero division errors
-                        elif object[f"{kpi}_total_eligible"] == 0:
-                            item = {
-                                title + "Measure": key + measures_titles[index],
-                                title: key,
-                                "Measure": measures_titles[index],
-                                "Percentage": 0,
-                                "Numerator": object[f"{kpi}_passed"],
-                                "Denominator": object[f"{kpi}_total_eligible"],
-                            }
-                        else:
-                            item = {
-                                title + "Measure": key + measures_titles[index],
-                                title: key,
-                                "Measure": measures_titles[index],
-                                "Percentage": object[f"{kpi}_passed"]
-                                / object[f"{kpi}_total_eligible"]
-                                * 100,
-                                "Numerator": object[f"{kpi}_passed"],
-                                "Denominator": object[f"{kpi}_total_eligible"],
-                            }
+                        item = create_kpi_report_row(key, measure_title, kpi, object)
+                        item[f"{title}Measure"] = f"{key}{measure_title}"
+                        item[title] = key
                         final_list.append(item) 
                     else:
-                        # Catch empty entries
-                        if object == None:
-                            item = {
-                                title: key,
-                                "Measure": measures_titles[index],
-                                "Percentage": 0,
-                                "Numerator": 0,
-                                "Denominator": 0,
-                            }
-                        # Catch zero division errors
-                        elif object[f"{kpi}_total_eligible"] == 0:
-                            item = {
-                                title: key,
-                                "Measure": measures_titles[index],
-                                "Percentage": 0,
-                                "Numerator": object[f"{kpi}_passed"],
-                                "Denominator": object[f"{kpi}_total_eligible"],
-                            }
-                        else:
-                            item = {
-                                title: key,
-                                "Measure": measures_titles[index],
-                                "Percentage": object[f"{kpi}_passed"]
-                                / object[f"{kpi}_total_eligible"]
-                                * 100,
-                                "Numerator": object[f"{kpi}_passed"],
-                                "Denominator": object[f"{kpi}_total_eligible"],
-                            }
+                        item = create_kpi_report_row(key, measure_title, kpi, object)
+                        item[title] = key
                         final_list.append(item) 
 
         

--- a/epilepsy12/common_view_functions/aggregate_by.py
+++ b/epilepsy12/common_view_functions/aggregate_by.py
@@ -884,27 +884,10 @@ def create_KPI_aggregation_dataframe(KPI_model1, constants_list1, cohort, measur
         else:
             for index, kpi in enumerate(measures):
                 if is_regional:
-                    # Catch Zero Division Errors
-                    if wales_region_object[f"{kpi}_total_eligible"] == 0:
-                        item = {
-                        "NHSregionMeasure": "Health Boards" + measures_titles[index],
-                        title: "Health Boards",
-                        "Measure": measures_titles[index],
-                        "Percentage": 0,
-                        "Numerator": wales_region_object[f"{kpi}_passed"],
-                        "Denominator": wales_region_object[f"{kpi}_total_eligible"],
-                        }
-                    else:
-                        item = {
-                            "NHSregionMeasure": "Health Boards" + measures_titles[index],
-                            title: "Health Boards",
-                            "Measure": measures_titles[index],
-                            "Percentage": wales_region_object[f"{kpi}_passed"]
-                            / wales_region_object[f"{kpi}_total_eligible"]
-                            * 100,
-                            "Numerator": wales_region_object[f"{kpi}_passed"],
-                            "Denominator": wales_region_object[f"{kpi}_total_eligible"],
-                        }
+                    measure_title = measures_titles[index]
+                    item = create_kpi_report_row("wales", measure_title, kpi, wales_region_object)
+                    item["NHSregionMeasure"]: f"Health Boards{measure_title}"
+                    item[title] = "Health Boards"
                     final_list.append(item)
                 for key in objects:
                     object = objects[key]

--- a/epilepsy12/kpi.py
+++ b/epilepsy12/kpi.py
@@ -6,8 +6,8 @@ import pandas as pd
 
 # E12 Imports
 from epilepsy12.constants import EnumAbstractionLevel, TRUSTS, LOCAL_HEALTH_BOARDS, INTEGRATED_CARE_BOARDS, NHS_ENGLAND_REGIONS, OPEN_UK_NETWORKS, OPEN_UK_NETWORKS_TRUSTS, INTEGRATED_CARE_BOARDS_LOCAL_AUTHORITIES
-from epilepsy12.common_view_functions.aggregate_by import create_KPI_aggregation_dataframe, create_reference_dataframe
-
+from epilepsy12.common_view_functions.aggregate_by import create_KPI_aggregation_dataframe, create_reference_dataframe, create_kpi_report_row
+    
 def download_kpi_summary_as_csv(cohort):
     """
     Asynchronous task to pull data from KPIAggregation tables and store as dataframe for export as CSV
@@ -123,16 +123,10 @@ def download_kpi_summary_as_csv(cohort):
 
     final_list = []
     for index, kpi in enumerate(measures):
-        item = {
-            "ukMeasure": "England and Wales" + measures_titles[index],
-            "uk": "England and Wales",
-            "Measure": measures_titles[index],
-            "Percentage": national_kpi_aggregation[f"{kpi}_passed"]
-            / national_kpi_aggregation[f"{kpi}_total_eligible"]
-            * 100,
-            "Numerator": national_kpi_aggregation[f"{kpi}_passed"],
-            "Denominator": national_kpi_aggregation[f"{kpi}_total_eligible"],
-        }
+        measure_title = measures_titles[index]
+        item = create_kpi_report_row("national", measure_title, kpi, national_kpi_aggregation)
+        item["ukMeasure"] = f"England and Wales{measure_title}"
+        item["uk"]: "England and Wales"
         final_list.append(item)
 
     national_df = pd.DataFrame.from_dict(final_list)


### PR DESCRIPTION
Fixes #900 and adds logging to investigate #899 

Move the copy pasted percentage calculation code into a function which we then call at all levels. Log if either the numerator or denominator are missing from an aggregation row (#899)