### PR TITLE
Eatyourpeas/issue901

### DIFF
--- a/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_1.py
+++ b/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_1.py
@@ -16,7 +16,7 @@ def score_kpi_1(registration_instance) -> int:
     Calculation Method
 
     Numerator = Number of children and young people  [diagnosed with epilepsy] at first year AND (who had [input from a paediatrician with expertise in epilepsy] OR a [input from a paediatric neurologist] within 2 weeks of initial referral. (initial referral to mean first paediatric assessment)
-    
+
     Denominator = Number of and young people [diagnosed with epilepsy] at first year
     """
 

--- a/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_10.py
+++ b/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_10.py
@@ -5,15 +5,16 @@
 # E12 imports
 from epilepsy12.constants import KPI_SCORE
 
+
 def score_kpi_10(registration_instance, age_at_first_paediatric_assessment) -> int:
     """10. school_individual_healthcare_plan
-    
+
     Percentage of children and young people with epilepsy aged 5 years and above with evidence of a school individual healthcare plan by 1 year after first paediatric assessment.
-    
+
     Calculation Method
-    
+
     Numerator = Number of children and young people aged 5 years and above diagnosed with epilepsy at first year AND with evidence of EHCP
-    
+
     Denominator =Number of children and young people aged 5 years and above diagnosed with epilepsy at first year
     """
 
@@ -22,6 +23,10 @@ def score_kpi_10(registration_instance, age_at_first_paediatric_assessment) -> i
     # ineligible
     if age_at_first_paediatric_assessment < 5:
         return KPI_SCORE["INELIGIBLE"]
+
+    # unscored measure if plan not in place is still a fail
+    if management.individualised_care_plan_in_place is False:
+        return KPI_SCORE["FAIL"]
 
     # unscored
     if management.individualised_care_plan_includes_ehcp is None:

--- a/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_5.py
+++ b/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_5.py
@@ -15,7 +15,7 @@ def score_kpi_5(registration_instance, age_at_first_paediatric_assessment) -> in
     Calculation Method
 
     Numerator = Number of children and young people diagnosed with epilepsy at first year AND who are NOT JME or JAE or CAE or CECTS/Rolandic OR number of children aged under 2 years at first assessment with a diagnosis of epilepsy at first year AND who had an MRI within 6 weeks of request
-    
+
     Denominator = Number of children and young people diagnosed with epilepsy at first year AND ((who are NOT JME or JAE or CAE or BECTS) OR (number of children aged under  2 years  at first assessment with a diagnosis of epilepsy at first year))
     """
     multiaxial_diagnosis = registration_instance.multiaxialdiagnosis
@@ -53,8 +53,12 @@ def score_kpi_5(registration_instance, age_at_first_paediatric_assessment) -> in
             (investigations.mri_brain_requested_date is None),
             (investigations.mri_brain_reported_date is None),
         ]
-        if any(mri_dates_are_none):
-            return KPI_SCORE["NOT_SCORED"]
+
+        if investigations.mri_indicated is not None:
+            if any(mri_dates_are_none) and investigations.mri_indicated is True:
+                return KPI_SCORE["NOT_SCORED"]
+            elif investigations.mri_indicated is False:
+                return KPI_SCORE["FAIL"]
 
         # eligible for this measure - score kpi
         passing_criteria_met = (

--- a/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_9.py
+++ b/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_9.py
@@ -162,6 +162,18 @@ def score_kpi_9B(registration_instance) -> int:
     ]
 
     # unscored
+    if management.individualised_care_plan_in_place is not None:
+        if management.individualised_care_plan_in_place:
+            if any(fields_not_filled):
+                # there is a care plan in place but not yet known if updated in the last year or evidence of agreement not yet scored
+                return KPI_SCORE["NOT_SCORED"]
+        else:
+            # there is no care plan in place
+            return KPI_SCORE["FAIL"]
+    else:
+        return KPI_SCORE["NOT_SCORED"]
+
+    # unscored
     if any(fields_not_filled):
         return KPI_SCORE["NOT_SCORED"]
 
@@ -209,6 +221,10 @@ def score_kpi_9Bi(registration_instance) -> int:
         (management.individualised_care_plan_parental_prolonged_seizure_care is None),
     ]
 
+    # unscored measure if plan not in place is still a fail
+    if management.individualised_care_plan_in_place is False:
+        return KPI_SCORE["FAIL"]
+
     # unscored
     if any(fields_not_filled):
         return KPI_SCORE["NOT_SCORED"]
@@ -238,6 +254,10 @@ def score_kpi_9Bii(registration_instance) -> int:
 
     management = registration_instance.management
 
+    # unscored measure if plan not in place is still a fail
+    if management.individualised_care_plan_in_place is False:
+        return KPI_SCORE["FAIL"]
+
     # unscored
     if management.individualised_care_plan_addresses_water_safety is None:
         return KPI_SCORE["NOT_SCORED"]
@@ -262,6 +282,10 @@ def score_kpi_9Biii(registration_instance) -> int:
     """
 
     management = registration_instance.management
+
+    # unscored measure if plan not in place is still a fail
+    if management.individualised_care_plan_in_place is False:
+        return KPI_SCORE["FAIL"]
 
     # unscored
     if management.individualised_care_plan_include_first_aid is None:
@@ -288,6 +312,10 @@ def score_kpi_9Biv(registration_instance) -> int:
 
     management = registration_instance.management
 
+    # unscored measure if plan not in place is still a fail
+    if management.individualised_care_plan_in_place is False:
+        return KPI_SCORE["FAIL"]
+
     # unscored
     if management.individualised_care_plan_includes_general_participation_risk is None:
         return KPI_SCORE["NOT_SCORED"]
@@ -313,6 +341,10 @@ def score_kpi_9Bv(registration_instance) -> int:
 
     management = registration_instance.management
 
+    # unscored measure if plan not in place is still a fail
+    if management.individualised_care_plan_in_place is False:
+        return KPI_SCORE["FAIL"]
+
     # unscored
     if management.individualised_care_plan_includes_service_contact_details is None:
         return KPI_SCORE["NOT_SCORED"]
@@ -337,6 +369,10 @@ def score_kpi_9Bvi(registration_instance) -> int:
     """
 
     management = registration_instance.management
+
+    # unscored measure if plan not in place is still a fail
+    if management.individualised_care_plan_in_place is False:
+        return KPI_SCORE["FAIL"]
 
     fields_not_filled = [
         (management.individualised_care_plan_addresses_sudep is None),

--- a/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_9.py
+++ b/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_9.py
@@ -120,6 +120,10 @@ def score_kpi_9Aiii(registration_instance) -> int:
 
     management = registration_instance.management
 
+    # unscored measure if plan not in place is still a fail
+    if management.individualised_care_plan_in_place is False:
+        return KPI_SCORE["FAIL"]
+
     # unscored
     if management.has_individualised_care_plan_been_updated_in_the_last_year is None:
         return KPI_SCORE["NOT_SCORED"]

--- a/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_9.py
+++ b/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_9.py
@@ -24,13 +24,20 @@ def score_kpi_9A(registration_instance) -> int:
     management = registration_instance.management
 
     fields_not_filled = [
-        (management.individualised_care_plan_in_place is None),
         (management.has_individualised_care_plan_been_updated_in_the_last_year is None),
         (management.individualised_care_plan_has_parent_carer_child_agreement is None),
     ]
 
     # unscored
-    if any(fields_not_filled):
+    if management.individualised_care_plan_in_place is not None:
+        if management.individualised_care_plan_in_place:
+            if any(fields_not_filled):
+                # there is a care plan in place but not yet known if updated in the last year or evidence of agreement not yet scored
+                return KPI_SCORE["NOT_SCORED"]
+        else:
+            # there is no care plan in place
+            return KPI_SCORE["FAIL"]
+    else:
         return KPI_SCORE["NOT_SCORED"]
 
     # score kpi

--- a/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_9.py
+++ b/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_9.py
@@ -93,12 +93,16 @@ def score_kpi_9Aii(registration_instance) -> int:
 
     management = registration_instance.management
 
+    # unscored measure if plan not in place is still a fail
+    if management.individualised_care_plan_in_place is False:
+        return KPI_SCORE["FAIL"]
+
     # unscored
     if management.individualised_care_plan_has_parent_carer_child_agreement is None:
         return KPI_SCORE["NOT_SCORED"]
 
     # score kpi
-    if management.individualised_care_plan_has_parent_carer_child_agreement is True:
+    elif management.individualised_care_plan_has_parent_carer_child_agreement is True:
         return KPI_SCORE["PASS"]
     else:
         return KPI_SCORE["FAIL"]

--- a/epilepsy12/common_view_functions/calculate_kpis.py
+++ b/epilepsy12/common_view_functions/calculate_kpis.py
@@ -106,6 +106,8 @@ def calculate_kpis(registration_instance):
     if has_all_attributes(
         registration_instance, ["multiaxialdiagnosis", "investigations"]
     ):
+
+        registration_instance.investigations.mri_indicated = True
         mri = score_kpi_5(registration_instance, age_at_first_paediatric_assessment)
 
     if hasattr(registration_instance, "multiaxialdiagnosis"):

--- a/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_1.py
+++ b/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_1.py
@@ -146,6 +146,7 @@ def test_measure_1_should_fail_not_seen_14_days_after_referral(
         kpi_score == KPI_SCORE["FAIL"]
     ), f"Patient did not see a Paediatrician/Neurologist within 14 days of referral (seen after {INPUT_DATE - REFERRAL_DATE}), but did not fail measure"
 
+
 @pytest.mark.django_db
 def test_measure_1_should_fail_no_doctor_involved(
     e12_case_factory,

--- a/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_9B.py
+++ b/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_9B.py
@@ -79,21 +79,22 @@ from epilepsy12.models import KPI, Registration
 
 
 @pytest.mark.parametrize(
-    "has_rescue_medication_been_prescribed,individualised_care_plan_parental_prolonged_seizure_care,individualised_care_plan_include_first_aid,individualised_care_plan_addresses_water_safety,individualised_care_plan_includes_service_contact_details,individualised_care_plan_includes_general_participation_risk,individualised_care_plan_addresses_sudep, expected_score",
+    "has_rescue_medication_been_prescribed,individualised_care_plan_in_place,individualised_care_plan_parental_prolonged_seizure_care,individualised_care_plan_include_first_aid,individualised_care_plan_addresses_water_safety,individualised_care_plan_includes_service_contact_details,individualised_care_plan_includes_general_participation_risk,individualised_care_plan_addresses_sudep, expected_score",
     [
-        (True, True, True, True, True, True, True, KPI_SCORE["PASS"]),
-        (True, False, True, True, True, True, True, KPI_SCORE["FAIL"]),
-        (True, True, False, True, True, True, True, KPI_SCORE["FAIL"]),
-        (True, True, True, False, True, True, True, KPI_SCORE["FAIL"]),
-        (True, True, True, True, False, True, True, KPI_SCORE["FAIL"]),
-        (True, True, True, True, True, False, True, KPI_SCORE["FAIL"]),
-        (True, True, True, True, True, True, False, KPI_SCORE["FAIL"]),
+        (True, True, True, True, True, True, True, True, KPI_SCORE["PASS"]),
+        (True, True, False, True, True, True, True, True, KPI_SCORE["FAIL"]),
+        (True, True, True, False, True, True, True, True, KPI_SCORE["FAIL"]),
+        (True, True, True, True, False, True, True, True, KPI_SCORE["FAIL"]),
+        (True, True, True, True, True, False, True, True, KPI_SCORE["FAIL"]),
+        (True, True, True, True, True, True, False, True, KPI_SCORE["FAIL"]),
+        (True, True, True, True, True, True, True, False, KPI_SCORE["FAIL"]),
     ],
 )
 @pytest.mark.django_db
 def test_measure_9B_comprehensive_care_planning_content(
     e12_case_factory,
     has_rescue_medication_been_prescribed,
+    individualised_care_plan_in_place,
     individualised_care_plan_parental_prolonged_seizure_care,
     individualised_care_plan_include_first_aid,
     individualised_care_plan_addresses_water_safety,
@@ -112,6 +113,7 @@ def test_measure_9B_comprehensive_care_planning_content(
     # create case
     case = e12_case_factory(
         registration__management__has_rescue_medication_been_prescribed=has_rescue_medication_been_prescribed,
+        registration__management__individualised_care_plan_in_place=individualised_care_plan_in_place,
         registration__management__individualised_care_plan_parental_prolonged_seizure_care=individualised_care_plan_parental_prolonged_seizure_care,
         registration__management__individualised_care_plan_include_first_aid=individualised_care_plan_include_first_aid,
         registration__management__individualised_care_plan_addresses_water_safety=individualised_care_plan_addresses_water_safety,
@@ -153,21 +155,22 @@ def test_measure_9B_comprehensive_care_planning_content(
 
 
 @pytest.mark.parametrize(
-    "has_rescue_medication_been_prescribed,individualised_care_plan_parental_prolonged_seizure_care,individualised_care_plan_include_first_aid,individualised_care_plan_addresses_water_safety,individualised_care_plan_includes_service_contact_details,individualised_care_plan_includes_general_participation_risk,individualised_care_plan_addresses_sudep, expected_score",
+    "has_rescue_medication_been_prescribed,individualised_care_plan_in_place,individualised_care_plan_parental_prolonged_seizure_care,individualised_care_plan_include_first_aid,individualised_care_plan_addresses_water_safety,individualised_care_plan_includes_service_contact_details,individualised_care_plan_includes_general_participation_risk,individualised_care_plan_addresses_sudep, expected_score",
     [
-        (False, False, True, True, True, True, True, KPI_SCORE["PASS"]),
-        (True, False, True, True, True, True, True, KPI_SCORE["FAIL"]),
-        (True, True, False, True, True, True, True, KPI_SCORE["FAIL"]),
-        (True, True, True, False, True, True, True, KPI_SCORE["FAIL"]),
-        (True, True, True, True, False, True, True, KPI_SCORE["FAIL"]),
-        (True, True, True, True, True, False, True, KPI_SCORE["FAIL"]),
-        (True, True, True, True, True, True, False, KPI_SCORE["FAIL"]),
+        (False, True, False, True, True, True, True, True, KPI_SCORE["PASS"]),
+        (True, True, False, True, True, True, True, True, KPI_SCORE["FAIL"]),
+        (True, True, True, False, True, True, True, True, KPI_SCORE["FAIL"]),
+        (True, True, True, True, False, True, True, True, KPI_SCORE["FAIL"]),
+        (True, True, True, True, True, False, True, True, KPI_SCORE["FAIL"]),
+        (True, True, True, True, True, True, False, True, KPI_SCORE["FAIL"]),
+        (True, True, True, True, True, True, True, False, KPI_SCORE["FAIL"]),
     ],
 )
 @pytest.mark.django_db
 def test_measure_9B_comprehensive_care_planning_content_no_rescue(
     e12_case_factory,
     has_rescue_medication_been_prescribed,
+    individualised_care_plan_in_place,
     individualised_care_plan_parental_prolonged_seizure_care,
     individualised_care_plan_include_first_aid,
     individualised_care_plan_addresses_water_safety,
@@ -186,6 +189,7 @@ def test_measure_9B_comprehensive_care_planning_content_no_rescue(
     # create case
     case = e12_case_factory(
         registration__management__has_rescue_medication_been_prescribed=has_rescue_medication_been_prescribed,
+        registration__management__individualised_care_plan_in_place=individualised_care_plan_in_place,
         registration__management__individualised_care_plan_parental_prolonged_seizure_care=individualised_care_plan_parental_prolonged_seizure_care,
         registration__management__individualised_care_plan_include_first_aid=individualised_care_plan_include_first_aid,
         registration__management__individualised_care_plan_addresses_water_safety=individualised_care_plan_addresses_water_safety,

--- a/epilepsy12/tests/factories/E12InvestigationsFactory.py
+++ b/epilepsy12/tests/factories/E12InvestigationsFactory.py
@@ -1,5 +1,6 @@
 """Factory fn to create new E12 Investigations, related to a created Registration.
 """
+
 # standard imports
 from datetime import date
 
@@ -7,35 +8,37 @@ from datetime import date
 import factory
 
 # rcpch imports
-from epilepsy12.models import (
-    Investigations
-)
+from epilepsy12.models import Investigations
+
 
 class E12InvestigationsFactory(factory.django.DjangoModelFactory):
     """Dependency factory for creating a minimum viable E12Investigations.
-    
+
     This Factory is generated AFTER a Registration is created.
-    
-    
+
+
     """
+
     class Meta:
         model = Investigations
-    
+
     # Once Registration instance made, it will attach to this instance
     registration = None
-    
+
     class Params:
         pass_ecg = factory.Trait(
-            twelve_lead_ecg_status = True,
+            twelve_lead_ecg_status=True,
         )
         fail_ecg = factory.Trait(
-            twelve_lead_ecg_status = False,
+            twelve_lead_ecg_status=False,
         )
         pass_mri = factory.Trait(
-            mri_brain_requested_date=date(2023,2,1),
-            mri_brain_reported_date=date(2023,2,2), # 1 day later
+            mri_indicated=True,
+            mri_brain_requested_date=date(2023, 2, 1),
+            mri_brain_reported_date=date(2023, 2, 2),  # 1 day later
         )
         fail_mri = factory.Trait(
-            mri_brain_requested_date=date(2023,2,1),
-            mri_brain_reported_date=date(2023,5,1), # 3 months later (>42 days)
+            mri_indicated=True,
+            mri_brain_requested_date=date(2023, 2, 1),
+            mri_brain_reported_date=date(2023, 5, 1),  # 3 months later (>42 days)
         )

--- a/epilepsy12/tests/factories/E12RegistrationFactory.py
+++ b/epilepsy12/tests/factories/E12RegistrationFactory.py
@@ -95,15 +95,15 @@ class E12RegistrationFactory(factory.django.DjangoModelFactory):
 
         E12ManagementFactory.create(
             registration=self,
-            antiepilepsymedicine__sodium_valproate=sodium_valproate
-            if sodium_valproate
-            else None,
+            antiepilepsymedicine__sodium_valproate=(
+                sodium_valproate if sodium_valproate else None
+            ),
             **kwargs,
         )
 
     class Params:
         ineligible_mri = factory.Trait(
-            first_paediatric_assessment_date=date(2023, 1, 1)
+            first_paediatric_assessment_date=date(2023, 1, 1),  # child < 2y
         )
 
         pass_assessment_of_mental_health_issues = factory.Trait(ineligible_mri=True)


### PR DESCRIPTION
### Overview

The PR contains far more fixes than first appears
The issue raised (901) identified that KPIs were scoring incomplete when they should scored fail under 2 sets of circumstances:
1. If MRI not performed, both dates by default were None and this scored incomplete.
2. Individualised care plan submeasures scored incomplete if they were unscored because there was no plan in place.
In both of these cases, an extra check has been put in place for this situation, so that these situations now return Fail

This then of course led the tests relating to KPIs 5, 9 and 10 to fail, so these have been changed.

### Code changes

Changes made to score_kpi_* files 5,9 and 10, test_measure_9B

### Documentation changes (done or required as a result of this PR)

No implications - this is a fix

### Related Issues

closes #901

### Mentions

thanks @amanikrayem
