### PR TITLE
Eatyourpeas/aggregation-shmaggregation-fix

### DIFF
--- a/epilepsy12/common_view_functions/aggregate_by.py
+++ b/epilepsy12/common_view_functions/aggregate_by.py
@@ -471,44 +471,21 @@ def get_filtered_cases_queryset_for(
 
         abstraction_filter = {cases_filter_key: abstraction_key}
 
-    # filter out Welsh cases if England, or English cases if Wales
-
-    if (
-        abstraction_level is EnumAbstractionLevel.ICB
-        or abstraction_level is EnumAbstractionLevel.TRUST
-        or abstraction_level is EnumAbstractionLevel.NHS_ENGLAND_REGION
-    ):
-        cases = Case.objects.filter(
-            **abstraction_filter,
-            site__organisation__country__boundary_identifier="E92000001",
-            site__site_is_actively_involved_in_epilepsy_care=True,
-            site__site_is_primary_centre_of_epilepsy_care=True,
-            registration__cohort=cohort,
-            registration__completed_first_year_of_care_date__lte=date.today(),
-            registration__audit_progress__registration_complete=True,
-            registration__audit_progress__first_paediatric_assessment_complete=True,
-            registration__audit_progress__assessment_complete=True,
-            registration__audit_progress__epilepsy_context_complete=True,
-            registration__audit_progress__multiaxial_diagnosis_complete=True,
-            registration__audit_progress__investigations_complete=True,
-            registration__audit_progress__management_complete=True,
-        )
-    else:
-        cases = Case.objects.filter(
-            **abstraction_filter,
-            site__organisation__country__boundary_identifier="W92000004",
-            site__site_is_actively_involved_in_epilepsy_care=True,
-            site__site_is_primary_centre_of_epilepsy_care=True,
-            registration__cohort=cohort,
-            registration__completed_first_year_of_care_date__lte=date.today(),
-            registration__audit_progress__registration_complete=True,
-            registration__audit_progress__first_paediatric_assessment_complete=True,
-            registration__audit_progress__assessment_complete=True,
-            registration__audit_progress__epilepsy_context_complete=True,
-            registration__audit_progress__multiaxial_diagnosis_complete=True,
-            registration__audit_progress__investigations_complete=True,
-            registration__audit_progress__management_complete=True,
-        )
+    cases = Case.objects.filter(
+        **abstraction_filter,
+        # site__organisation__country__boundary_identifier="E92000001",
+        site__site_is_actively_involved_in_epilepsy_care=True,
+        site__site_is_primary_centre_of_epilepsy_care=True,
+        registration__cohort=cohort,
+        registration__completed_first_year_of_care_date__lte=date.today(),
+        registration__audit_progress__registration_complete=True,
+        registration__audit_progress__first_paediatric_assessment_complete=True,
+        registration__audit_progress__assessment_complete=True,
+        registration__audit_progress__epilepsy_context_complete=True,
+        registration__audit_progress__multiaxial_diagnosis_complete=True,
+        registration__audit_progress__investigations_complete=True,
+        registration__audit_progress__management_complete=True,
+    )
 
     return cases
 

--- a/epilepsy12/common_view_functions/aggregate_by.py
+++ b/epilepsy12/common_view_functions/aggregate_by.py
@@ -950,7 +950,7 @@ def create_KPI_aggregation_dataframe(
                 item = create_kpi_report_row(
                     "wales", measure_title, kpi, wales_region_object
                 )
-                item["NHSregionMeasure"]: f"Health Boards{measure_title}"
+                item["NHSregionMeasure"]=f"Health Boards{measure_title}"
                 item[title] = "Health Boards"
                 final_list.append(item)
             for key in objects:

--- a/epilepsy12/common_view_functions/comorbidity_choices.py
+++ b/epilepsy12/common_view_functions/comorbidity_choices.py
@@ -1,6 +1,7 @@
 from django.apps import apps
 from ..constants import COLIN_EDIT_SNOMED_NEURODISABILITY_REFSET
 
+
 def get_comorbidity_choices(multiaxial_diagnosis, comorbidity_id=None):
     """
     Returns list of comorbidities to populate dropdown lists
@@ -11,12 +12,16 @@ def get_comorbidity_choices(multiaxial_diagnosis, comorbidity_id=None):
     Comorbidity = apps.get_model("epilepsy12", "Comorbidity")
     ComorbidityList = apps.get_model("epilepsy12", "ComorbidityList")
 
-    all_selected_comorbidityentities = Comorbidity.objects.filter(
-        multiaxial_diagnosis=multiaxial_diagnosis
-    ).exclude(pk=comorbidity_id).values_list("comorbidityentity", flat=True)
+    all_selected_comorbidityentities = (
+        Comorbidity.objects.filter(multiaxial_diagnosis=multiaxial_diagnosis)
+        .exclude(pk=comorbidity_id)
+        .values_list("comorbidityentity", flat=True)
+    )
 
     comorbidity_choices = (
-        ComorbidityList.objects.all().filter(preferredTerm__in=COLIN_EDIT_SNOMED_NEURODISABILITY_REFSET).exclude(pk__in=all_selected_comorbidityentities)
+        ComorbidityList.objects.all()
+        .filter(preferredTerm__in=COLIN_EDIT_SNOMED_NEURODISABILITY_REFSET)
+        .exclude(pk__in=all_selected_comorbidityentities)
         .order_by("preferredTerm")
     )
 

--- a/epilepsy12/management/commands/seed.py
+++ b/epilepsy12/management/commands/seed.py
@@ -119,14 +119,14 @@ def run_dummy_cases_seed(verbose=True, cases=50):
         cases = 50
 
     different_organisations = [
-        "RJZ01",
-        "RGT01",
-        "RBS25",
-        "RQM01",
-        "RCF22",
-        "7A2AJ",
-        "7A6BJ",
-        "7A6AV",
+        "RJZ01",  # King's College Hospital
+        "RGT01",  # Addenbrooks
+        "RBS25",  # Alderhey
+        "RQM01",  # Chelsea and Westminster
+        "RCF22",  # Airedale
+        "7A2AJ",  # Bronglais
+        "7A6BJ",  # Chepstow Community
+        "7A6AV",  # Ysbyty Ystrad Fawr
     ]
     organisations_list = Organisation.objects.filter(
         ods_code__in=different_organisations

--- a/epilepsy12/tests/common_view_functions_tests/aggregate_by_tests/helpers.py
+++ b/epilepsy12/tests/common_view_functions_tests/aggregate_by_tests/helpers.py
@@ -2,6 +2,7 @@
 import pytest
 import random
 from datetime import date
+from dateutil.relativedelta import relativedelta
 
 # 3rd party imports
 
@@ -97,6 +98,20 @@ def _register_kpi_scored_cases(
             filled_case_objects += test_cases
 
     for test_case in filled_case_objects:
+        test_case.registration.completed_first_year_of_care_date = (
+            test_case.registration.first_paediatric_assessment_date
+            + relativedelta(years=1)
+        )
+        test_case.registration.audit_progress.registration_complete = True
+        test_case.registration.audit_progress.first_paediatric_assessment_complete = (
+            True
+        )
+        test_case.registration.audit_progress.assessment_complete = True
+        test_case.registration.audit_progress.epilepsy_context_complete = True
+        test_case.registration.audit_progress.multiaxial_diagnosis_complete = True
+        test_case.registration.audit_progress.investigations_complete = True
+        test_case.registration.audit_progress.management_complete = True
+
         calculate_kpis(registration_instance=test_case.registration)
 
 

--- a/epilepsy12/tests/common_view_functions_tests/aggregate_by_tests/test_calculate_kpi_value_counts_queryset.py
+++ b/epilepsy12/tests/common_view_functions_tests/aggregate_by_tests/test_calculate_kpi_value_counts_queryset.py
@@ -89,14 +89,16 @@ def test_calculate_kpi_value_counts_queryset_all_levels(
     _register_kpi_scored_cases(
         e12_case_factory,
         ods_codes=ods_codes,
-        num_cases=5
-        if abstraction_level
-        not in [
-            # in these 3 abstraction levels, kids are split into half the number of organisations, so register double the nubmer of kids (10) instead of 5
-            EnumAbstractionLevel.ORGANISATION,
-            EnumAbstractionLevel.TRUST,
-        ]
-        else 10, 
+        num_cases=(
+            5
+            if abstraction_level
+            not in [
+                # in these 3 abstraction levels, kids are split into half the number of organisations, so register double the nubmer of kids (10) instead of 5
+                EnumAbstractionLevel.ORGANISATION,
+                EnumAbstractionLevel.TRUST,
+            ]
+            else 10
+        ),
     )
 
     for code in ods_codes:

--- a/epilepsy12/tests/factories/E12AuditProgressFactory.py
+++ b/epilepsy12/tests/factories/E12AuditProgressFactory.py
@@ -1,6 +1,7 @@
 """
 E12 Audit Progress Factory.
 """
+
 # standard imports
 import datetime
 
@@ -20,13 +21,13 @@ class E12AuditProgressFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = AuditProgress
 
-    registration_complete = False
-    first_paediatric_assessment_complete = False
-    assessment_complete = False
-    epilepsy_context_complete = False
-    multiaxial_diagnosis_complete = False
-    management_complete = False
-    investigations_complete = False
+    registration_complete = True
+    first_paediatric_assessment_complete = True
+    assessment_complete = True
+    epilepsy_context_complete = True
+    multiaxial_diagnosis_complete = True
+    management_complete = True
+    investigations_complete = True
     registration_total_expected_fields = 3
     registration_total_completed_fields = 0
     first_paediatric_assessment_total_expected_fields = 0

--- a/epilepsy12/tests/factories/E12CaseFactory.py
+++ b/epilepsy12/tests/factories/E12CaseFactory.py
@@ -1,4 +1,5 @@
 """Factory fn to create new E12 Cases"""
+
 # standard imports
 from datetime import date
 
@@ -9,10 +10,7 @@ import factory
 from epilepsy12.models import Case
 from .E12SiteFactory import E12SiteFactory
 from .E12RegistrationFactory import E12RegistrationFactory
-from epilepsy12.constants import (
-    SEX_TYPE,
-    DEPRIVATION_QUINTILES
-    )
+from epilepsy12.constants import SEX_TYPE, DEPRIVATION_QUINTILES
 import nhs_number
 
 
@@ -26,7 +24,7 @@ class E12CaseFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = Case
-        skip_postgeneration_save=True
+        skip_postgeneration_save = True
 
     class Params:
         # helper eligibility flags to set age
@@ -60,14 +58,14 @@ class E12CaseFactory(factory.django.DjangoModelFactory):
             pass_school_individual_healthcare_plan=True,
         )
         seed_male = factory.Trait(
-            first_name = 'Agent',
-            surname = factory.Sequence(lambda n: f'Smith-{n}'),
-            registration=None
+            first_name="Agent",
+            surname=factory.Sequence(lambda n: f"Smith-{n}"),
+            registration=None,
         )
         seed_female = factory.Trait(
-            first_name = 'Dolly',
-            surname = factory.Sequence(lambda n: f'Shepard-{n}'),
-            registration=None
+            first_name="Dolly",
+            surname=factory.Sequence(lambda n: f"Shepard-{n}"),
+            registration=None,
         )
 
     @factory.lazy_attribute
@@ -90,7 +88,7 @@ class E12CaseFactory(factory.django.DjangoModelFactory):
     date_of_birth = date(2022, 1, 1)
 
     ethnicity = "A"
-    index_of_multiple_deprivation_quintile=DEPRIVATION_QUINTILES.first
+    index_of_multiple_deprivation_quintile = DEPRIVATION_QUINTILES.first
     locked = False
 
     # once case created, create a Site, which acts as a link table between the Case and Organisation

--- a/epilepsy12/tests/view_tests/permissions_tests/test_permissions_update.py
+++ b/epilepsy12/tests/view_tests/permissions_tests/test_permissions_update.py
@@ -243,6 +243,7 @@
 
 
 """
+
 # python imports
 import pytest
 from http import HTTPStatus
@@ -378,6 +379,7 @@ def test_users_update_users_forbidden(
                 response.status_code == HTTPStatus.FORBIDDEN
             ), f"{test_user.first_name} (from {test_user.organisation_employer}) requested update user {test_user} in {TEST_USER_ORGANISATION}. Has groups: {test_user.groups.all()} Expected {HTTPStatus.FORBIDDEN} response status code, received {response.status_code}"
 
+
 @pytest.mark.django_db
 def test_user_cant_change_rcpch_or_superuser_flag(
     client,
@@ -451,12 +453,12 @@ def test_user_cant_change_rcpch_or_superuser_flag(
                 "role": USER_FROM_DIFFERENT_ORG.role,
                 "is_rcpch_audit_team_member": True,
                 "is_superuser": False,
-                'email':USER_FROM_DIFFERENT_ORG.email,
+                "email": USER_FROM_DIFFERENT_ORG.email,
             },
         )
-        
+
         assert r.status_code == HTTPStatus.FORBIDDEN
-        
+
         # Attempt to change is_superuser
         r = client.post(
             url,
@@ -466,10 +468,10 @@ def test_user_cant_change_rcpch_or_superuser_flag(
                 "role": USER_FROM_DIFFERENT_ORG.role,
                 "is_rcpch_audit_team_member": False,
                 "is_superuser": True,
-                'email':USER_FROM_DIFFERENT_ORG.email,
+                "email": USER_FROM_DIFFERENT_ORG.email,
             },
         )
-        
+
         assert r.status_code == HTTPStatus.FORBIDDEN
 
 
@@ -537,9 +539,12 @@ def test_user_cannot_see_rcpch_or_superuser_flag_in_template(
             },
         )
         r = client.get(url)
-        
-        for flag in ['id_is_rcpch_audit_team_member', 'id_is_superuser']:
-            assert flag.encode() not in r.content, f'{test_user} should not be able to see {flag} in template'
+
+        for flag in ["id_is_rcpch_audit_team_member", "id_is_superuser"]:
+            assert (
+                flag.encode() not in r.content
+            ), f"{test_user} should not be able to see {flag} in template"
+
 
 @pytest.mark.django_db
 def test_users_update_users_success(
@@ -1200,7 +1205,7 @@ def test_users_update_multiaxial_diagnosis_success(client):
                         },
                     ),
                     headers={"Hx-Trigger-Name": "epilepsy_cause", "Hx-Request": "true"},
-                    data={"epilepsy_cause": "142"}, # Saldino-Mainzer dysplasia
+                    data={"epilepsy_cause": "142"},  # Saldino-Mainzer dysplasia
                 )
 
             assert (
@@ -1711,11 +1716,11 @@ def test_users_update_comorbidity_success(client):
                     reverse(
                         URL,
                         kwargs={
-                            "comorbidity_id": comorbidity.pk,
+                            "comorbidity_id": comorbidity.id,
                         },
                     ),
                     headers={"Hx-Trigger-Name": URL, "Hx-Request": "true"},
-                    data={URL: Comorbidity.objects.all().first().id},
+                    data={URL: ComorbidityList.objects.all().first().id},
                 )
 
             assert (


### PR DESCRIPTION
### Overview

This brings together two observations of errors in the console, errors in the UI and a request that all table values represented only completed audit records. The issue related to a filtering error with an empy aggregation_level key being added to a the interpolated string of a query parameter. This led to a database matching error and django console errors with every aggregation.
The fix is a simple one - it tests for the aggregation_level key being None and terminates the query at that point.


### Code changes
1. Complete refactor of the `aggregate_by` file which will be difficult to review because I have reorganised the functions with comments to make it clearer what they all do. Those related to spreadsheet download are at the bottom. 
2. There is a new function: `filter_completed_cases_at_one_year_by_abstraction_level` which generates the list of cases. This function is called from within `update_kpi_aggregation_model`, itself called from within `update_kpi_aggregation_models`. It ensures only completed audit cases are included.
3. `get_filtered_cases_queryset_for` has been refactored also to include only completed cases. The conditionals relating to Wales vs England have been removed. Note this function is only used in the tests and when pulling aggregation results from disk. It is not used in the aggregation queries themselves.
4. Refactor tests. Not all tests explicitly expected fully completed audit cases, so this has been updated
5. An obvious error in a test relating to ComorbidityList which arose after has been fixed. It is not clear why it was not failing previously

### Documentation changes (done or required as a result of this PR)
Bug fixes only

### Related Issues
Hopefully will address #907 king's lynn issue but will only be clear once merged to live
