### PR TITLE
fix mri indicated always true

### DIFF
--- a/epilepsy12/common_view_functions/calculate_kpis.py
+++ b/epilepsy12/common_view_functions/calculate_kpis.py
@@ -106,8 +106,6 @@ def calculate_kpis(registration_instance):
     if has_all_attributes(
         registration_instance, ["multiaxialdiagnosis", "investigations"]
     ):
-
-        registration_instance.investigations.mri_indicated = True
         mri = score_kpi_5(registration_instance, age_at_first_paediatric_assessment)
 
     if hasattr(registration_instance, "multiaxialdiagnosis"):


### PR DESCRIPTION
### Overview

MRI bug fix
calculate_kpis was setting mri_indicated to True prior to running kpis so the template was not updating the state.
Remove this statement `registration_instance.investigations.mri_indicated = True` fixes the problem