### PR TITLE
Fixes s/seed bug where first paediatric assessment date was in the future

### DIFF
--- a/epilepsy12/management/commands/seed.py
+++ b/epilepsy12/management/commands/seed.py
@@ -204,7 +204,7 @@ def complete_registrations(verbose=True, cohort=None, full_year=False):
 
         fpa_date = random_date(
             start=current_cohort_data["cohort_start_date"],
-            end=current_cohort_data["cohort_end_date"],
+            end=date.today(),
         )
 
         if full_year:
@@ -222,7 +222,7 @@ def complete_registrations(verbose=True, cohort=None, full_year=False):
                     # regenerate any dates that cannot be complete
                     fpa_date = random_date(
                         start=current_cohort_data["cohort_start_date"],
-                        end=current_cohort_data["cohort_end_date"],
+                        end=date.today(),
                     )
 
         registration.first_paediatric_assessment_date = fpa_date


### PR DESCRIPTION
### Overview

When generating dummy data, a first paediatric assessment date is randomly generated at some date between the current cohort's start and end date. This, however, means that the assessment date could be in the future, which is impossible.

This PR contains a simple fix to set the range of possible FPA dates from the cohort start date to today, no longer using the cohort end date

### Code changes

Changes range of random date generation in complete_registrations() in seed.py

### Documentation changes (done or required as a result of this PR)

N/A

### Related Issues

Closes #927 

### Mentions

@mbarton @eatyourpeas this is a simple fix that we should be able to merge without any problems - but I am quite curious as to why this error popped up all of a sudden today? The last time I ran a fresh s/up I had no such issues.
