### PR TITLE
Eatyourpeas/aggregate-by-logs-and-test-fix

### DIFF
--- a/epilepsy12/common_view_functions/__init__.py
+++ b/epilepsy12/common_view_functions/__init__.py
@@ -16,10 +16,10 @@ from .aggregate_by import (
     update_kpi_aggregation_model,
     get_filtered_cases_queryset_for,
     calculate_kpi_value_counts_queryset,
+    filter_completed_cases_at_one_year_by_abstraction_level,
     get_abstraction_model_from_level,
     get_abstraction_value_from,
     get_all_kpi_aggregation_data_for_view,
-    # aggregate_kpis_update_models_all_abstractions_for_organisation,
     update_all_kpi_agg_models,
     _seed_all_aggregation_models,
 )

--- a/epilepsy12/common_view_functions/aggregate_by.py
+++ b/epilepsy12/common_view_functions/aggregate_by.py
@@ -586,7 +586,6 @@ def get_filtered_cases_queryset_for(
 
     cases = Case.objects.filter(
         **abstraction_filter,
-        # site__organisation__country__boundary_identifier="E92000001",
         site__site_is_actively_involved_in_epilepsy_care=True,
         site__site_is_primary_centre_of_epilepsy_care=True,
         registration__cohort=cohort,

--- a/epilepsy12/common_view_functions/aggregate_by.py
+++ b/epilepsy12/common_view_functions/aggregate_by.py
@@ -563,7 +563,7 @@ def get_filtered_cases_queryset_for(
 
     Ensures the Case is filtered for an active, primary Site, and in the correct cohort, and all cases are completely scored and have completed a full year of care
     NOTE as this is confusing. It is NOT used in any aggregation calculation steps prior to updating KPIAggregation models. It is only used to pull existing data from KPIAggregation tables
-    It is also used in the test suite.
+    It has been deprecated from the test suite.
     """
 
     cases_filter_key = f"organisations__{abstraction_level.value}"

--- a/epilepsy12/tests/common_view_functions_tests/aggregate_by_tests/helpers.py
+++ b/epilepsy12/tests/common_view_functions_tests/aggregate_by_tests/helpers.py
@@ -98,9 +98,12 @@ def _register_kpi_scored_cases(
             filled_case_objects += test_cases
 
     for test_case in filled_case_objects:
+        test_case.registration.first_paediatric_assessment_date = date(
+            year=2023, month=3, day=1
+        )
         test_case.registration.completed_first_year_of_care_date = (
             test_case.registration.first_paediatric_assessment_date
-            + relativedelta(years=1)
+            + relativedelta(years=1)  # this is before today, so will not fail
         )
         test_case.registration.audit_progress.registration_complete = True
         test_case.registration.audit_progress.first_paediatric_assessment_complete = (

--- a/epilepsy12/tests/common_view_functions_tests/aggregate_by_tests/test_update_kpiaggregation_model.py
+++ b/epilepsy12/tests/common_view_functions_tests/aggregate_by_tests/test_update_kpiaggregation_model.py
@@ -99,13 +99,15 @@ def test_update_kpi_aggregation_model_all_levels(
     _register_kpi_scored_cases(
         e12_case_factory,
         ods_codes=ods_codes,
-        num_cases=5
-        if abstraction_level
-        not in [
-            EnumAbstractionLevel.ORGANISATION,
-            EnumAbstractionLevel.TRUST,
-        ]
-        else 10,
+        num_cases=(
+            5
+            if abstraction_level
+            not in [
+                EnumAbstractionLevel.ORGANISATION,
+                EnumAbstractionLevel.TRUST,
+            ]
+            else 10
+        ),
     )
 
     # PERFORM AGGREGATIONS AND UPDATE AGGREGATION MODEL
@@ -134,7 +136,7 @@ def test_update_kpi_aggregation_model_all_levels(
         )
 
     # ASSERTION
-    if abstraction_level is EnumAbstractionLevel.NATIONAL:
+    if abstraction_level == EnumAbstractionLevel.NATIONAL:
         output = NationalKPIAggregation.objects.get(cohort=6).get_value_counts_for_kpis(
             kpis_tested
         )
@@ -176,8 +178,7 @@ def test_update_kpi_aggregation_model_all_levels(
 
             kpi_aggregation_model_instance = (
                 abstraction_kpi_aggregation_model.objects.get(
-                    abstraction_relation=abstraction_relation_instance,
-                    cohort=6
+                    abstraction_relation=abstraction_relation_instance, cohort=6
                 )
             )
 


### PR DESCRIPTION
### Overview

Another incremental improvement in the aggregation suite.
This ensures logs for any updates or creates to the KPIAggregation models, with a summary of how many models changed, and how many records updated with 0 if unscored.

There are also some fixes to the tests:
1. update the filter to accept only completed cases who have completed a full year of care
2. deprecate the get_filtered_cases_queryset_for which is not used for the aggregations anyway in favour of the newer `filter_completed_cases_at_one_year_by_abstraction_level` so testing closer to real life

### Code changes

1. add `filter_completed_cases_at_one_year_by_abstraction_level` to `__init__.py` to allow easier importing
2. remove the `return` statement after testing for None, and nest any code below this test into a conditional.
3. Change `_register_kpi_scored_cases` function in the e12case factory to include cases who have completed a full year of care
4. deprecate `get_filtered_cases_queryset_for` which was now failing update KPIAggregation table tests, and replace with `filter_completed_cases_at_one_year_by_abstraction_level` which is used in the actual calculations anyway

### Documentation changes (done or required as a result of this PR)

This needs doing - mostly to make explicit that the aggregation tables now only contain fully scored cases that have completed a full year of care

### Related Issues

Closes #907