### PR TITLE
Refactor to use consistent helper functions when generating the KPI report

### DIFF
--- a/epilepsy12/common_view_functions/aggregate_by.py
+++ b/epilepsy12/common_view_functions/aggregate_by.py
@@ -870,19 +870,18 @@ def create_kpi_report_row(key, kpi_field, aggregation_row, level):
 
 def get_kpi_aggregation_rows(
     model_aggregation,
+    cohort,
     abstraction_key_field,
-    cohort
 ):
     return model_aggregation.objects.filter(
         cohort=cohort,
         open_access=False
     ).annotate(
         key_field=F(f"abstraction_relation__{abstraction_key_field}")
-    )
+    ).values()
 
 def create_KPI_aggregation_dataframe(
     aggregation_rows,
-    cohort,
     measures,
     title,
 ):

--- a/epilepsy12/common_view_functions/aggregate_by.py
+++ b/epilepsy12/common_view_functions/aggregate_by.py
@@ -883,7 +883,9 @@ def get_kpi_aggregation_rows(
             key_field=F(f"abstraction_relation__{abstraction_key_field}")
         )
     
-    # Eagerly evaluate the query
+    # Eagerly evaluate the query as we use some result sets twice in kpi.py
+    # Otherwise we'd have to re-run the query to avoid getting empty results
+    # the second time we try and use it.
     return list(query.values())
 
 def create_KPI_aggregation_dataframe(

--- a/epilepsy12/common_view_functions/aggregate_by.py
+++ b/epilepsy12/common_view_functions/aggregate_by.py
@@ -873,12 +873,12 @@ def get_kpi_aggregation_rows(
     cohort,
     abstraction_key_field,
 ):
-    return model_aggregation.objects.filter(
+    return list(model_aggregation.objects.filter(
         cohort=cohort,
         open_access=False
     ).annotate(
         key_field=F(f"abstraction_relation__{abstraction_key_field}")
-    ).values()
+    ).values())
 
 def create_KPI_aggregation_dataframe(
     aggregation_rows,
@@ -889,12 +889,14 @@ def create_KPI_aggregation_dataframe(
 
     for measure in measures:
         for aggregation_row in aggregation_rows:
-            final_list.append(create_kpi_report_row(
+            report_row = create_kpi_report_row(
                 aggregation_row["key_field"],
                 measure,
                 aggregation_row,
                 title
-            ))
+            )
+
+            final_list.append(report_row)
 
     return pd.DataFrame.from_dict(final_list)
 

--- a/epilepsy12/common_view_functions/aggregate_by.py
+++ b/epilepsy12/common_view_functions/aggregate_by.py
@@ -871,14 +871,20 @@ def create_kpi_report_row(key, kpi_field, aggregation_row, level):
 def get_kpi_aggregation_rows(
     model_aggregation,
     cohort,
-    abstraction_key_field,
+    abstraction_key_field=None,
 ):
-    return list(model_aggregation.objects.filter(
+    query = model_aggregation.objects.filter(
         cohort=cohort,
         open_access=False
-    ).annotate(
-        key_field=F(f"abstraction_relation__{abstraction_key_field}")
-    ).values())
+    )
+
+    if abstraction_key_field:
+        query = query.annotate(
+            key_field=F(f"abstraction_relation__{abstraction_key_field}")
+        )
+    
+    # Eagerly evaluate the query
+    return list(query.values())
 
 def create_KPI_aggregation_dataframe(
     aggregation_rows,

--- a/epilepsy12/kpi.py
+++ b/epilepsy12/kpi.py
@@ -18,7 +18,7 @@ from epilepsy12.common_view_functions.aggregate_by import (
     create_reference_dataframe,
     create_kpi_report_row,
 )
-from epilepsy12.models import (Organisation, Trust)
+from epilepsy12.models import (Organisation, Trust, KPI)
 
 
 def download_kpi_summary_as_csv(cohort):
@@ -36,35 +36,20 @@ def download_kpi_summary_as_csv(cohort):
     - National_comparison
     """
 
-    # Define KPI measures for extraction
+    # The summary only includes some measures
     measures = [
-        "paediatrician_with_expertise_in_epilepsies",
-        "epilepsy_specialist_nurse",
-        "tertiary_input",
-        "epilepsy_surgery_referral",
-        "ecg",
-        "mri",
-        "assessment_of_mental_health_issues",
-        "mental_health_support",
-        "sodium_valproate",
-        "comprehensive_care_planning_agreement",
-        "comprehensive_care_planning_content",
-        "school_individual_healthcare_plan",
-    ]
-
-    measures_titles = [
-        "1. Paediatrician with expertise",
-        "2. Epilepsy specialist nurse",
-        "3a. Tertiary involvement",
-        "3b. Epilepsy surgery referral",
-        "4. ECG",
-        "5. MRI",
-        "6. Assessment of mental health issues",
-        "7. Mental health support",
-        "8. Sodium valproate",
-        "9a. Comprehensive care planning agreement",
-        "9b. Comprehensive care planning content",
-        "10. School Individual Health Care Plan",
+        KPI._meta.get_field('paediatrician_with_expertise_in_epilepsies'),
+        KPI._meta.get_field('epilepsy_specialist_nurse'),
+        KPI._meta.get_field('tertiary_input'),
+        KPI._meta.get_field('epilepsy_surgery_referral'),
+        KPI._meta.get_field('ecg'),
+        KPI._meta.get_field('mri'),
+        KPI._meta.get_field('assessment_of_mental_health_issues'),
+        KPI._meta.get_field('mental_health_support'),
+        KPI._meta.get_field('sodium_valproate'),
+        KPI._meta.get_field('comprehensive_care_planning_agreement'),
+        KPI._meta.get_field('comprehensive_care_planning_content'),
+        KPI._meta.get_field('school_individual_healthcare_plan'),
     ]
 
     trusts_from_organisations = Organisation.objects.values('trust').distinct()
@@ -88,14 +73,12 @@ def download_kpi_summary_as_csv(cohort):
     )
 
     final_list = []
-    for index, kpi in enumerate(measures):
-        measure_title = measures_titles[index]
-
+    for measure in measures:
         england_row = create_kpi_report_row(
-            "england", measure_title, kpi, england_kpi_aggregation, "Country"
+            "england", measure, england_kpi_aggregation, "Country"
         )
         wales_row = create_kpi_report_row(
-            "wales", measure_title, kpi, wales_kpi_aggregation, "Country"
+            "wales", measure, wales_kpi_aggregation, "Country"
         )
 
         final_list.append(england_row)
@@ -110,7 +93,6 @@ def download_kpi_summary_as_csv(cohort):
         "ods_code",
         cohort,
         measures,
-        measures_titles,
         "HBT",
         KPI_model2="TrustKPIAggregation",
         abstraction_key_field2="ods_code",
@@ -119,7 +101,7 @@ def download_kpi_summary_as_csv(cohort):
     # ICB (Integrated Care Board) - SHEET 3
 
     icb_df = create_KPI_aggregation_dataframe(
-        "ICBKPIAggregation", "name", cohort, measures, measures_titles, "ICB"
+        "ICBKPIAggregation", "name", cohort, measures, "ICB"
     )
 
     # NHS region level - SHEET 4
@@ -129,7 +111,6 @@ def download_kpi_summary_as_csv(cohort):
         "name",
         cohort,
         measures,
-        measures_titles,
         "NHSregion",
         is_regional=True,
     )
@@ -137,7 +118,7 @@ def download_kpi_summary_as_csv(cohort):
     # NETWORKS - SHEET 5
 
     network_df = create_KPI_aggregation_dataframe(
-        "OpenUKKPIAggregation", "boundary_identifier", cohort, measures, measures_titles, "Network"
+        "OpenUKKPIAggregation", "boundary_identifier", cohort, measures, "Network"
     )
 
     # NATIONAL - SHEET 6
@@ -154,10 +135,9 @@ def download_kpi_summary_as_csv(cohort):
     )
 
     final_list = []
-    for index, kpi in enumerate(measures):
-        measure_title = measures_titles[index]
+    for measure in measures:
         item = create_kpi_report_row(
-            "national", measure_title, kpi, national_kpi_aggregation, "uk"
+            "national", measure, national_kpi_aggregation, "uk"
         )
         item["uk"] = "England and Wales"
         final_list.append(item)

--- a/epilepsy12/kpi.py
+++ b/epilepsy12/kpi.py
@@ -19,7 +19,7 @@ from epilepsy12.common_view_functions.aggregate_by import (
     create_kpi_report_row,
     get_kpi_aggregation_rows
 )
-from epilepsy12.models import (Organisation, Trust, KPI, ICBKPIAggregation, OpenUKKPIAggregation, CountryKPIAggregation, LocalHealthBoardKPIAggregation, TrustKPIAggregation, NHSEnglandRegionKPIAggregation)
+from epilepsy12.models import (Organisation, Trust, KPI, ICBKPIAggregation, OpenUKKPIAggregation, CountryKPIAggregation, LocalHealthBoardKPIAggregation, TrustKPIAggregation, NHSEnglandRegionKPIAggregation, NationalKPIAggregation)
 
 
 def download_kpi_summary_as_csv(cohort):
@@ -147,25 +147,15 @@ def download_kpi_summary_as_csv(cohort):
     # NATIONAL - SHEET 6
     # create a dataframe with a row for each measure, and column for each of ["Measure", "Percentage", "Numerator", "Denominator"]
     # note rows are named ["1. Paediatrician with expertise","2. Epilepsy specialist nurse","3a. Tertiary involvement","3b. Epilepsy surgery referral","4. ECG","5. MRI","6. Assessment of mental health issues","7. Mental health support","8. Sodium valproate","9a. Comprehensive care planning agreement","9b. Comprehensive care planning content","10. School Individual Health Care Plan"]
-    # Note that the function create_dataframe is not called here because there is no list of organisations to iterate through
+    
+    # NationalKPIAggregation has no abstraction relation to walk so add the key field manually
+    national_rows = [row | {"key_field": "England and Wales"} for row in get_kpi_aggregation_rows(NationalKPIAggregation, cohort)]
 
-    NationalKPIAggregation = apps.get_model("epilepsy12", "NationalKPIAggregation")
-
-    national_kpi_aggregation = (
-        NationalKPIAggregation.objects.filter(cohort=cohort, open_access=False)
-        .values()
-        .first()
+    national_df = create_KPI_aggregation_dataframe(
+        national_rows,
+        measures,
+        title="uk"
     )
-
-    final_list = []
-    for measure in measures:
-        item = create_kpi_report_row(
-            "national", measure, national_kpi_aggregation, "uk"
-        )
-        item["uk"] = "England and Wales"
-        final_list.append(item)
-
-    national_df = pd.DataFrame.from_dict(final_list)
 
     # REFERENCE - SHEET 7
 

--- a/epilepsy12/kpi.py
+++ b/epilepsy12/kpi.py
@@ -1,6 +1,3 @@
-# Python imports
-from itertools import chain
-
 # Django Imports
 from django.apps import apps
 
@@ -71,11 +68,11 @@ def download_kpi_summary_as_csv(cohort):
     # Only England and Wales participate in the audit but we have entries in the country table for NI and Scotland
     # Even if a participating country doesn't have any data yet we'd still like to include a blank row for it
     # We keep a row for Wales as we need it later on for SHEET 4 - NHS Region level
-    england_rows = all_country_rows.filter(key_field="England")
-    wales_rows = all_country_rows.filter(key_field="Wales")
+    england_rows = [row for row in all_country_rows if row["key_field"] == "England"]
+    wales_rows = [row for row in all_country_rows if row["key_field"] == "Wales"]
 
     country_df = create_KPI_aggregation_dataframe(
-        chain(england_rows, wales_rows),
+        england_rows + wales_rows,
         measures,
         title="Country"
     )
@@ -97,7 +94,7 @@ def download_kpi_summary_as_csv(cohort):
     )
 
     trust_hb_df = create_KPI_aggregation_dataframe(
-        chain(local_health_board_rows, trust_rows),
+        local_health_board_rows + trust_rows,
         measures,
         title="HBT"
     )
@@ -125,7 +122,7 @@ def download_kpi_summary_as_csv(cohort):
     )
 
     # Treat Wales as a single region
-    region_rows = chain(nhs_england_regional_rows, wales_rows)
+    region_rows = nhs_england_regional_rows + wales_rows
 
     region_df = create_KPI_aggregation_dataframe(
         region_rows,

--- a/epilepsy12/kpi.py
+++ b/epilepsy12/kpi.py
@@ -58,33 +58,13 @@ def download_kpi_summary_as_csv(cohort):
     # COUNTRY - SHEET 1
     # create a dataframe with a row for each measure of each country, and a column for each of ["Measure", "Percentage", "Numerator", "Denominator"]
 
-    CountryKPIAggregation = apps.get_model("epilepsy12", "CountryKPIAggregation")
-
-    england_kpi_aggregation = (
-        CountryKPIAggregation.objects.filter(cohort=cohort, abstraction_relation=1)
-        .values()
-        .first()
+    country_df = create_KPI_aggregation_dataframe(
+        "CountryKPIAggregation",
+        "name",
+        cohort,
+        measures,
+        "Country"
     )
-
-    wales_kpi_aggregation = (
-        CountryKPIAggregation.objects.filter(cohort=cohort, abstraction_relation=4)
-        .values()
-        .first()
-    )
-
-    final_list = []
-    for measure in measures:
-        england_row = create_kpi_report_row(
-            "england", measure, england_kpi_aggregation, "Country"
-        )
-        wales_row = create_kpi_report_row(
-            "wales", measure, wales_kpi_aggregation, "Country"
-        )
-
-        final_list.append(england_row)
-        final_list.append(wales_row)
-
-    country_df = pd.DataFrame.from_dict(final_list)
 
     # HBT (Trusts & Health Boards) - SHEET 2
 

--- a/s/logs
+++ b/s/logs
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+docker compose logs -f --timestamps


### PR DESCRIPTION
When @eatyourpeas, @dc2007git and I mob coded on https://github.com/rcpch/rcpch-audit-engine/pull/941 we felt like there was a simpler way to express the code but focused on fixing the report with the minimum possible changes.

This PR tries to capture as many simplifications as possible before the context inevitably falls out of my head!

The core change is to use the functions from aggregate_by.py consistently across all sheets we generate in the report. To achieve this I broke them out into two:

- `get_kpi_aggregation_rows`
  - Extracts all the rows from the KPI aggregation model and adds an additional `key_field` (eg Country, NHS region...)
- `create_kpi_aggregation_dataframe`
  - Now just loops through all the measures which a4rre hard-coded at the top of kpi.py as not all measures are included in the report
  - It then uses the existing `create_kpi_report_row` function to add the row to the dataframe. That function defends against missing/null/zero field values

These changes allow us to push the sheet specific logic back up into `kpi.py`, for example combining local health boards in Wales and trusts in England when generating the "HBT" sheet.

I've also linked the definition of the measures directly to the fields on the models. This doesn't change any functionality but makes it clearer they're linked and in the unlikely event we change them we would automatically update here.

That means we can pass the Django field definition all the way down to `create_kpi_report_row`, meaning one less parameter for all the function calls. This is maybe not clearer than before but felt like a logical follow on from linking directly to the model definitions at the top level of `kpi.py`.

**Questions**

- [x] ~Our current code and the [template spreadsheet](https://github.com/rcpch/rcpch-audit-engine/issues/791#issue-2128940055) group all the rows by measure except for the HBT sheet where it's grouped by ODS code. This refactor has broken that. Do we need to maintain that behaviour?~
  - Confirmed with @nikyraja the order doesn't matter