### PR TITLE
recalculate-all-kpis

### DIFF
--- a/epilepsy12/common_view_functions/__init__.py
+++ b/epilepsy12/common_view_functions/__init__.py
@@ -22,6 +22,7 @@ from .aggregate_by import (
     # aggregate_kpis_update_models_all_abstractions_for_organisation,
     update_all_kpi_agg_models,
     _seed_all_aggregation_models,
+    _calculate_all_kpis,
 )
 from .report_queries import (
     all_registered_cases_for_cohort_and_abstraction_level,

--- a/epilepsy12/common_view_functions/aggregate_by.py
+++ b/epilepsy12/common_view_functions/aggregate_by.py
@@ -28,6 +28,7 @@ from epilepsy12.constants import (
     OPEN_UK_NETWORKS_TRUSTS,
 )
 from epilepsy12.general_functions import cohorts_and_dates
+from epilepsy12.common_view_functions import calculate_kpis
 
 # Logging setup
 logger = logging.getLogger(__name__)
@@ -696,6 +697,23 @@ def get_abstraction_model_from_level(
 #             kpi_value_counts=kpi_value_counts,
 #             cohort=cohort,
 #         )
+
+def _calculate_all_kpis():
+    """
+    Loops through all registered cases for all cohorts and reruns the KPI calculation for each one
+    """
+    Case = apps.get_model("epilepsy12", "Case")
+    all_cases = Case.objects.filter(registration__isnull=False)
+    index = 0
+    for case in all_cases:
+        try:
+            calculate_kpis(case.registration)
+            logger.debug(f"KPIs recalculated for {case}")
+            index += 1
+        except Exception as error:
+            logger.error(f"It was not possible to calculate and update KPI record for {case}: {error}")
+            continue
+    logger.info(f"{index} cases updated from a total of {all_cases.count()}")
 
 """
 Sets up the KPIAggregation models - one for each cohort and each level of abstraction


### PR DESCRIPTION
### Overview

Pulling recalculate_kpi function into live to allow calling this from the shell. This address orphan records that were scored prior to the update in calculation methodology in KPI 9

tests are passing and it works in development