### PR TITLE
reword recruitment closed fixes #781

### DIFF
--- a/templates/epilepsy12/partials/organisation/cohort_card.html
+++ b/templates/epilepsy12/partials/organisation/cohort_card.html
@@ -13,7 +13,7 @@
                         {% if cohort_data.submitting_cohort_end_date > cohort_data.today %}
                             Actively recruiting and submitting data
                         {% else %}
-                            Recruitment closed
+                            Recruitment closed - data collection ongoing until {{cohort_data.submitting_cohort_submission_date}}
                         {% endif %}
                     </h3>
                     <h4>{{cohort_data.submitting_cohort_start_date}} - {{cohort_data.submitting_cohort_end_date}}</h4>
@@ -40,10 +40,10 @@
                         {% if cohort_data.currently_recruiting_cohort_end_date > cohort_data.today %}
                             Actively recruiting
                         {% else %}
-                            Recruitment closed
+                        Recruitment closed - data collection ongoing until {{cohort_data.currently_recruiting_cohort_end_date}}
                         {% endif %}
                     </h3>
-                    <h4>{{cohort_data.currently_recruiting_cohort_start_date}} - {{cohort_data.currently_recruiting_cohort_end_date}}</h4>
+                    <h4>{{cohort_data.currently_recruiting_cohort_start_date}} - {{cohort_data.currently_recruiting_cohort_submission_date}}</h4>
                 </div>
 
                 <div class="rcpch_summary_stats_row">


### PR DESCRIPTION
### Overview

Users reporting ambiguity around the submitting cohort end date language. 

### Code changes

Changed wording to clarify that although recruitment closed, still actively collecting data until January 2025

### Related Issues

Closes #871