### PR TITLE
update home link in nav to redirect to organisation summary page if logged in. if rcpch member, redirected to first organisation in list.

### DIFF
--- a/templates/epilepsy12/nav.html
+++ b/templates/epilepsy12/nav.html
@@ -45,11 +45,25 @@
         </a>
         <h4 class="med">Epilepsy12 Audit Platform</h4>
         <div class='right menu'>
+        {% if user.is_authenticated %}
+          <a {% if request.resolver_match.url_name|is_in:'index' %}class="active item" id="active_menu_item"{% else %} class="item" {% endif %}
+            id="link"
+            {% if user.organisation_employer %}
+            href="{% url 'selected_organisation_summary' organisation_id=user.organisation_employer.pk %}">
+            {% else %}
+            href="{% url 'selected_organisation_summary' organisation_id=1 %}">
+            {% endif %}
+            Home
+          </a>
+          
+        {% else %}
           <a {% if request.resolver_match.url_name|is_in:'index' %}class="active item" id="active_menu_item"{% else %} class="item" {% endif %}
              id="link"
              href="{% url 'index' %}">
             Home
           </a>
+        {% endif %}
+
         {% if user.is_authenticated %}
           
           <a {% if request.resolver_match.url_name|is_in:'docs' %}class="active item" id="active_menu_item" {% else %} class="item" {% endif %}


### PR DESCRIPTION
### Overview

Home button redirects to epilepsy12index.html. For logged in users, should redirect to selected_organisation_summary.html

### Code changes

Conditional applied to nav for home link - redirect logged in users to their organisation page, or the first organisation if RCPCH users.

### Related Issues

closes #930
