### PR TITLE
Converts percentage in KPI report to decimal

### DIFF
--- a/epilepsy12/common_view_functions/aggregate_by.py
+++ b/epilepsy12/common_view_functions/aggregate_by.py
@@ -869,7 +869,7 @@ def create_kpi_report_row(key, measure, kpi, aggregation_row, level):
         if numerator is not None and denominator is not None:
             # Make sure we don't divide by zero
             ret["Percentage"] = (
-                0 if denominator == 0 else (numerator / denominator) * 100
+                0 if denominator == 0 else (numerator / denominator)
             )
             ret["Numerator"] = numerator
             ret["Denominator"] = denominator


### PR DESCRIPTION
### Overview

In the KPI report, percentages will now take the form 0.799 instead of taking the form 79.9, as requested in #952 

### Code changes

Remove division by 100

### Documentation changes (done or required as a result of this PR)

N/A

### Related Issues

Closes #952 
