### PR TITLE
Eatyourpeas/address-date-validations

### DIFF
--- a/documentation/docs/development/date-validations.md
+++ b/documentation/docs/development/date-validations.md
@@ -1,0 +1,103 @@
+---
+title: Validating dates
+reviewers: Dr Simon Chapman
+---
+
+## Overview
+
+Dates are sparsely gathered across E12 as these are generally annoying for users to enter as they are slower to enter than other fields and involve digging back through clinical notes to find. Where they are collected, it is because something is calculated from them.
+
+### First paediatric assessment date
+
+Orginally this was registration_date, but was subsequently refactored to become first_paediatric_assessment_date. This is set in the registration form and is a one way value. Once set, it cannot be undone, except by RCPCH staff. It is a critical date, since cohort allocation and end of first year of care are both calculated from it. It is also used in date validation as the earliest allowable date for some measures.
+
+### episode date
+
+In the multiaxial diagnosis form, a child may have several episodes of seizure, each one associated with a date. Information is collected on confidence around that date, since many seizures are unwitnessed. The earliest allowable date an episode can be given is the date of birth.
+
+### syndrome diagnosis date
+
+In the multiaxial diagnosis form, a child may have more than one syndrome (though usually only one), each one associated with a date. The earliest allowable date a syndrome can be given is the date of birth.
+
+### comordibidity diagnosis date
+
+In the multiaxial diagnosis form, a child may have more than one comorbidity, each one associated with a date. The earliest allowable date a comorbidity can be given is the date of birth.
+
+### Consultant paediatrician with expertise in epilepsies
+
+2 dates are supplied and both are mandatory to complete the form - date referred and date seen
+The date seen cannot be before the date referred and the earliest allowable date is the date of birth.
+
+### Consultant paediatric neurologist
+
+2 dates are supplied and both are mandatory to complete the form - date referred and date seen
+The date seen cannot be before the date referred and the earliest allowable date is the first paediatric assessment date.
+
+### Epilepsy surgery
+
+Two dates are supplied if the child has been referred, but only the referral date is mandatory. The date seen cannot be before the date referred and the earliest allowable date is the first paediatric assessment date.
+
+### Epilepsy nurse specialist
+
+2 dates are supplied and both are mandatory to complete the form - date referred and date seen
+The date seen cannot be before the date referred and the earliest allowable date is the first paediatric assessment date.
+
+### EEG
+
+2 dates are supplied and both are mandatory to complete the form - date requested and date performed
+The date performed cannot be before the date requested and the earliest allowable date is the date of birth.
+
+### MRI
+
+2 dates are supplied and both are mandatory to complete the form - date requested and date performed
+The date performed cannot be before the date requested and the earliest allowable date is the date of birth.
+
+### Antiepilepsy medicine
+
+#### antiseizure medicine
+
+2 dates are supplied - date discontinued and date started -  but only date started is mandatory to complete the form if an antiseizure medicine has been given.
+
+The date discontinued cannot be before the date started and the earliest allowable date is the date of first paediatric assessment.
+
+#### rescue medicine
+
+2 dates are supplied - date discontinued and date started -  but only date started is mandatory to complete the form if an antiseizure medicine has been given.
+
+The date discontinued cannot be before the date started and the earliest allowable date is the date of first paediatric assessment.
+
+### Individualised care plan date
+
+One date is supplied. Earliest allowable date is the date of first paediatric assessment.
+
+### Validation
+
+Date validation occurs in `validators.py` and accepts a minimum of one date. If more than one date, a flag must be supplied to explain whether it is expected to be the earlier of the the two dates. The `earliest_allowable_date` parameter is an optional.
+
+It raises a ValueError which is caught in the UI.
+
+### Validation dates summary table
+
+| Model | Date | mandatory | earliest allowable date | other flags |
+| ---- | ---- | ---- | ---- | ---- |
+| Registration | first_paediatric_assessment_date | Yes | date_of_birth |   |
+| Episode | seizure_onset_date | Yes | date_of_birth |   |
+| Syndrome | syndrome_diagnosis_date | Yes | date_of_birth |   |
+| Comorbidity | comorbidity_diagnosis_date | Yes | date_of_birth |   |
+| Assessment | consultant_paediatrician_referral_date | Yes | date_of_birth |   |
+| Assessment | consultant_paediatrician_input_date | Yes | consultant_paediatrician_referral_date |   |
+| Assessment | paediatric_neurologist_referral_date | Yes | first_paediatric_assessment_date |   |
+| Assessment | paediatric_neurologist_input_date | Yes | paediatric_neurologist_referral_date |   |
+| Assessment | childrens_epilepsy_surgical_service_referral_date | Yes | first_paediatric_assessment_date |   |
+| Assessment | childrens_epilepsy_surgical_service_input_date | No | childrens_epilepsy_surgical_service_referral_date |   |
+| Assessment | epilepsy_specialist_nurse_referral_date | Yes | first_paediatric_assessment_date |   |
+| Assessment | epilepsy_specialist_nurse_input_date | Yes | epilepsy_specialist_nurse_referral_date |   |
+| Investigations | eeg_request_date | Yes | date_of_birth |   |
+| Investigations | eeg_performed_date | Yes | eeg_request_date |   |
+| Investigations | mri_brain_requested_date | Yes | date_of_birth |   |
+| Investigations | mri_brain_reported_date | Yes | mri_brain_requested_date |   |
+| AntiepilepsyMedicine | antiepilepsy_medicine_start_date | Yes | first_paediatric_assessment_date | is_rescue = False   |
+| AntiepilepsyMedicine | antiepilepsy_medicine_stop_date | No | antiepilepsy_medicine_start_date |  is_rescue = False |
+| AntiepilepsyMedicine | antiepilepsy_medicine_start_date | Yes | first_paediatric_assessment_date | is_rescue = True   |
+| AntiepilepsyMedicine | antiepilepsy_medicine_stop_date | No | antiepilepsy_medicine_start_date |  is_rescue = True |
+| Management | individualised_care_plan_date | Yes | first_paediatric_assessment_date |   |

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -172,6 +172,7 @@ nav:
       - Dropdown Lists: 'development/dropdowns.md'
       - Audit Forms: 'development/audit-forms.md'
       - Form Scoring: 'development/form-scoring.md'
+      - Date Validations: 'development/date-validations.md'
       - KPIs: 'development/key-performance-indicators.md'
       - Organisations, Trusts and Regions: 'development/organisations.md'
       - Reporting: 'development/reporting.md'

--- a/epilepsy12/models_folder/investigations.py
+++ b/epilepsy12/models_folder/investigations.py
@@ -68,7 +68,7 @@ class Investigations(
 
     mri_indicated = models.BooleanField(
         help_text={
-            "label": "Has a brain MRI been requested?",
+            "label": "Has a brain MRI been achieved?",
             "reference": "NICE recommends that an MRI scan should be offered to children, young people and adults diagnosed with epilepsy, unless they have idiopathic generalised epilepsy or self-limited epilepsy with centrotemporal spikes. The MRI should be carried out within 6 weeks of the MRI referral.",
         },
         default=None,

--- a/epilepsy12/views/assessment_views.py
+++ b/epilepsy12/views/assessment_views.py
@@ -253,7 +253,7 @@ def consultant_paediatrician_referral_date(request, assessment_id):
             page_element="date_field",
             comparison_date_field_name="consultant_paediatrician_input_date",
             is_earliest_date=True,
-            earliest_allowable_date=None,
+            earliest_allowable_date=assessment.registration.case.date_of_birth,
         )
     except ValueError as error:
         error_message = error
@@ -723,7 +723,7 @@ def paediatric_neurologist_input_date(request, assessment_id):
             page_element="date_field",
             comparison_date_field_name="paediatric_neurologist_referral_date",
             is_earliest_date=False,
-            earliest_allowable_date=assessment.registration.first_paediatric_assessment_date,
+            earliest_allowable_date=assessment.paediatric_neurologist_referral_date,
         )
     except ValueError as error:
         error_message = error
@@ -1244,7 +1244,7 @@ def childrens_epilepsy_surgical_service_input_date(request, assessment_id):
             page_element="date_field",
             comparison_date_field_name="childrens_epilepsy_surgical_service_referral_date",
             is_earliest_date=False,
-            earliest_allowable_date=assessment.registration.first_paediatric_assessment_date,
+            earliest_allowable_date=assessment.childrens_epilepsy_surgical_service_referral_date,
         )
     except ValueError as error:
         error_message = error
@@ -1572,7 +1572,7 @@ def epilepsy_specialist_nurse_referral_date(request, assessment_id):
             page_element="date_field",
             comparison_date_field_name="epilepsy_specialist_nurse_input_date",
             is_earliest_date=True,
-            earliest_allowable_date=None,
+            earliest_allowable_date=assessment.registration.first_paediatric_assessment_date,
         )
     except ValueError as error:
         error_message = error

--- a/epilepsy12/views/investigation_views.py
+++ b/epilepsy12/views/investigation_views.py
@@ -135,7 +135,7 @@ def eeg_request_date(request, investigations_id):
             page_element="date_field",
             comparison_date_field_name="eeg_performed_date",
             is_earliest_date=True,
-            earliest_allowable_date=None,
+            earliest_allowable_date=investigations.registration.case.date_of_birth,
         )
 
     except ValueError as error:
@@ -419,7 +419,7 @@ def mri_brain_requested_date(request, investigations_id):
             page_element="date_field",
             comparison_date_field_name="mri_brain_reported_date",
             is_earliest_date=True,
-            earliest_allowable_date=investigations.registration.first_paediatric_assessment_date,
+            earliest_allowable_date=investigations.registration.case.date_of_birth,
         )
 
     except ValueError as errors:
@@ -471,7 +471,7 @@ def mri_brain_reported_date(request, investigations_id):
             page_element="date_field",
             comparison_date_field_name="mri_brain_requested_date",
             is_earliest_date=False,
-            earliest_allowable_date=investigations.registration.first_paediatric_assessment_date,
+            earliest_allowable_date=investigations.mri_brain_requested_date,
         )
 
     except ValueError as errors:

--- a/epilepsy12/views/management_views.py
+++ b/epilepsy12/views/management_views.py
@@ -628,7 +628,7 @@ def antiepilepsy_medicine_stop_date(request, antiepilepsy_medicine_id):
             page_element="date_field",
             comparison_date_field_name="antiepilepsy_medicine_start_date",
             is_earliest_date=False,
-            earliest_allowable_date=antiepilepsy_medicine.management.registration.first_paediatric_assessment_date,
+            earliest_allowable_date=antiepilepsy_medicine.antiepilepsy_medicine_start_date,
         )
     except ValueError as error:
         error_message = error

--- a/epilepsy12/views/multiaxial_diagnosis_views.py
+++ b/epilepsy12/views/multiaxial_diagnosis_views.py
@@ -380,7 +380,7 @@ def seizure_onset_date(request, episode_id):
             model_id=episode_id,
             field_name="seizure_onset_date",
             page_element="date_field",
-            earliest_allowable_date=None,  # episodes may precede the first assessment date or cohort date
+            earliest_allowable_date=episode.multiaxial_diagnosis.registration.case.date_of_birth,  # episodes may precede the first assessment date or cohort date
         )
     except ValueError as error:
         error_message = error

--- a/epilepsy12/views/multiaxial_diagnosis_views.py
+++ b/epilepsy12/views/multiaxial_diagnosis_views.py
@@ -1660,7 +1660,7 @@ def comorbidity_diagnosis_date(request, comorbidity_id):
             model_id=comorbidity_id,
             field_name="comorbidity_diagnosis_date",
             page_element="date_field",
-            earliest_allowable_date=comorbidity.multiaxial_diagnosis.registration.first_paediatric_assessment_date,
+            earliest_allowable_date=comorbidity.multiaxial_diagnosis.registration.case.date_of_birth,
         )
     except ValueError as error:
         error_message = error

--- a/epilepsy12/views/syndrome_views.py
+++ b/epilepsy12/views/syndrome_views.py
@@ -26,7 +26,7 @@ def syndrome_diagnosis_date(request, syndrome_id):
             model_id=syndrome_id,
             field_name="syndrome_diagnosis_date",
             page_element="date_field",
-            # earliest_allowable_date=syndrome.multiaxial_diagnosis.registration.first_paediatric_assessment_date,
+            earliest_allowable_date=syndrome.multiaxial_diagnosis.registration.case.date_of_birth,
         )
     except ValueError as error:
         error_message = error


### PR DESCRIPTION
### Overview

Addresses date validations for all dates. Does not change any validation code, but alters some of the earliest allowable dates for some measures as current settings are not practice. For example, may people will have an MRI performed for other reasons or a comorbidity diagnosed prior to epilepsy diagnosis.

### Code changes

Update the `earliest_allowable_date` parameter in the validation call for all the dates across the code base

Create new docs to summarise date validation and what the minimum dates allowed are (sanctioned by E12)

### Documentation changes (done or required as a result of this PR)

As above


### Related Issues

Closes #956 and #940
