### PR TITLE
Eatyourpeas/all-rcpch-access-to-disabled-records

### DIFF
--- a/documentation/docs/development/date-validations.md
+++ b/documentation/docs/development/date-validations.md
@@ -80,7 +80,7 @@ It raises a ValueError which is caught in the UI.
 
 | Model | Date | mandatory | earliest allowable date | other flags |
 | ---- | ---- | ---- | ---- | ---- |
-| Registration | first_paediatric_assessment_date | Yes | date_of_birth |   |
+| Registration | first_paediatric_assessment_date | Yes | current submitting cohort start date for clinicians or date_of_birth if RCPCH audit team |   |
 | Episode | seizure_onset_date | Yes | date_of_birth |   |
 | Syndrome | syndrome_diagnosis_date | Yes | date_of_birth |   |
 | Comorbidity | comorbidity_diagnosis_date | Yes | date_of_birth |   |

--- a/epilepsy12/admin.py
+++ b/epilepsy12/admin.py
@@ -127,7 +127,7 @@ admin.site.register(FirstPaediatricAssessment, SimpleHistoryAdmin)
 admin.site.register(Management, SimpleHistoryAdmin)
 admin.site.register(Registration, SimpleHistoryAdmin)
 admin.site.register(Site, SimpleHistoryAdmin)
-admin.site.register(AuditProgress)
+admin.site.register(AuditProgress, SimpleHistoryAdmin)
 admin.site.register(Episode, SimpleHistoryAdmin)
 
 admin.site.register(Keyword, SimpleHistoryAdmin)

--- a/epilepsy12/models_folder/audit_progress.py
+++ b/epilepsy12/models_folder/audit_progress.py
@@ -1,3 +1,4 @@
+from django.apps import apps
 from django.contrib.gis.db import models
 from .help_text_mixin import HelpTextMixin
 
@@ -135,7 +136,18 @@ class AuditProgress(models.Model, HelpTextMixin):
             return False
 
     def __str__(self):
-        return f"Audit progress for {self.registration.case}"
+        Registration = apps.get_model("epilepsy12", "Registration")
+        Site = apps.get_model("epilepsy12", "Site")
+        registration = Registration.objects.filter(audit_progress=self).first()
+        if registration:
+            lead_site = Site.objects.get(
+                case=registration.case,
+                site_is_actively_involved_in_epilepsy_care=True,
+                site_is_primary_centre_of_epilepsy_care=True,
+            )
+            return f"Audit progress for {self.registration.case} [{lead_site.organisation}](cohort {registration.cohort})"
+        else:
+            return f"No AuditProgress record yet"
 
     class Meta:
         verbose_name = "Audit Progress"

--- a/epilepsy12/models_folder/audit_progress.py
+++ b/epilepsy12/models_folder/audit_progress.py
@@ -139,7 +139,7 @@ class AuditProgress(models.Model, HelpTextMixin):
         Registration = apps.get_model("epilepsy12", "Registration")
         Site = apps.get_model("epilepsy12", "Site")
         registration = Registration.objects.filter(audit_progress=self).first()
-        if registration:
+        if registration and hasattr(registration, "case"):
             lead_site = Site.objects.get(
                 case=registration.case,
                 site_is_actively_involved_in_epilepsy_care=True,

--- a/epilepsy12/models_folder/kpi.py
+++ b/epilepsy12/models_folder/kpi.py
@@ -1,3 +1,4 @@
+from django.apps import apps
 from django.contrib.gis.db import models
 from django.utils.translation import gettext_lazy as _
 from .help_text_mixin import HelpTextMixin
@@ -364,7 +365,12 @@ class KPI(models.Model, HelpTextMixin):
         ordering = ["registration__case"]
 
     def __str__(self):
-        if self.organisation.trust:
-            return f"KPI for {self.registration.case} in {self.organisation.name}({self.organisation.trust.name})"
+        Registration = apps.get_model("epilepsy12", "Registration")
+        registration = Registration.objects.filter(kpi=self).get()
+        if registration:
+            if self.organisation.trust:
+                return f"KPI for {registration.case} in {self.organisation.name}({self.organisation.trust.name})[cohort {registration.cohort}]"
+            else:
+                return f"KPI for {registration.case} in {self.organisation.name}({self.organisation.local_health_board.name})[cohort {registration.cohort}]"
         else:
-            return f"KPI for {self.registration.case} in {self.organisation.name}({self.organisation.local_health_board.name})"
+            return "There is no Registration associated with this KPI"

--- a/epilepsy12/models_folder/kpi.py
+++ b/epilepsy12/models_folder/kpi.py
@@ -365,12 +365,10 @@ class KPI(models.Model, HelpTextMixin):
         ordering = ["registration__case"]
 
     def __str__(self):
-        Registration = apps.get_model("epilepsy12", "Registration")
-        registration = Registration.objects.filter(kpi=self).get()
-        if registration:
+        if hasattr(self, "registration"):
             if self.organisation.trust:
-                return f"KPI for {registration.case} in {self.organisation.name}({self.organisation.trust.name})[cohort {registration.cohort}]"
+                return f"KPI for {self.registration.case} in {self.organisation.name}({self.organisation.trust.name})[cohort {self.registration.cohort}]"
             else:
-                return f"KPI for {registration.case} in {self.organisation.name}({self.organisation.local_health_board.name})[cohort {registration.cohort}]"
+                return f"KPI for {self.registration.case} in {self.organisation.name}({self.organisation.local_health_board.name})[cohort {self.registration.cohort}]"
         else:
             return "There is no Registration associated with this KPI"

--- a/epilepsy12/models_folder/registration.py
+++ b/epilepsy12/models_folder/registration.py
@@ -122,6 +122,6 @@ class Registration(
 
     def __str__(self) -> str:
         if self.first_paediatric_assessment_date:
-            return f"Epilepsy12 registration for {self.case} on {self.first_paediatric_assessment_date}"
+            return f"Epilepsy12 registration for {self.pk} - {self.case} on {self.first_paediatric_assessment_date}"
         else:
             return f"Epilepsy12 registration for {self.case} incomplete."

--- a/templates/epilepsy12/partials/case_table.html
+++ b/templates/epilepsy12/partials/case_table.html
@@ -108,7 +108,7 @@
     <tbody>
       {% for case in case_list %}
         
-          {% if case.registration.days_remaining_before_submission == 0 %}
+          {% if case.registration.days_remaining_before_submission == 0 and not request.user.is_rcpch_audit_team_member %}
               <tr class='disabled'>
           {% elif case in cases_in_transfer %}
               <tr class='active_transfer'>
@@ -136,12 +136,12 @@
             <div class='ui buttons'>
               <button 
                 data-tooltip='Edit or delete child.'
-                {% if case.locked or case.registration.days_remaining_before_submission == 0 %}
+                {% if case.locked or case.registration.days_remaining_before_submission == 0 and not request.user.is_rcpch_audit_team_member %}
                   class="ui rcpch_purple icon disabled button"
                 {% else %}
                   class="ui rcpch_purple icon button"
                 {% endif %}
-                tabindexed="0" {% if case.locked or not perms.epilepsy12.change_case %}disabled{% endif %}>
+                tabindexed="0" {% if case.locked or not perms.epilepsy12.change_case and not request.user.is_rcpch_audit_team_member %}disabled{% endif %}>
                 <a href="{% url 'update_case' organisation_id=organisation_id case_id=case.id%}" class="rcpch_purple half_button">
                   <i class="edit outline icon icon_white"></i>
                   Edit
@@ -159,7 +159,7 @@
                 {% else %}
                 <button 
                   data-tooltip='Complete audit details.'
-                  {% if case.registration.days_remaining_before_submission == 0 %}
+                  {% if case.registration.days_remaining_before_submission == 0 and not request.user.is_rcpch_audit_team_member %}
                     class="ui rcpch_dark_purple disabled button"
                   {% else %}
                     class="ui rcpch_dark_purple button"
@@ -170,7 +170,7 @@
                 
                 {% endif %}
               {% else %}
-                {% if case.locked %}
+                {% if case.locked and not request.user.is_rcpch_audit_team_member %}
 
                 <button 
                   class="ui rcpch_dark_purple disabled button" 


### PR DESCRIPTION
### Overview

The E12 would like to be able to edit records which are disabled as are in a historical cohort (eg 5). This used to happen in error when users put in a first paediatric assessment date that was wrong, but now the minimum date for users to select is the start of the currently submitting cohort.

In the course of investigating this it was discovered that the Django admin Registration, KPI and AuditProgress would not render if there were orphan records. This PR therefore also fixes:
1. cascade case deletions to include AuditProgress and KPI related records
2. Admin template rendering if orphan records present

### Code changes

Update to documentation to clarify first paediatric assessment date minimum values for users

Fix AuditProgress and KPI and Registration models to return sensible string even if orphan records

Fix `case_views.py` to cascade deletes to to KPI and AuditProgress related records

Update `case_table` partial to allow RCPCH users access to disabled records





### Documentation changes (done or required as a result of this PR)

Please describe any changes to documentation here.

### Related Issues

List any issues related to this PR here.

### Mentions

@mentions of the person or team responsible for reviewing proposed changes.
