### PR TITLE
add `{ fullTextSearch: true }` to `ui select`

### DIFF
--- a/templates/epilepsy12/partials/page_elements/rcpch_organisations_select.html
+++ b/templates/epilepsy12/partials/page_elements/rcpch_organisations_select.html
@@ -24,7 +24,7 @@ test_positive: currently selected organisation id
                     hx-trigger="{{hx_trigger}}"
                     name='{{hx_name}}'
                     value="{{test_positive}}"
-                    _="init js $('.ui.rcpch.search.selection.dropdown').dropdown(); end"
+                    _="init js $('.ui.rcpch.search.selection.dropdown').dropdown({ fullTextSearch: true }); end"
                 >
                 <div class="default text">{{hx_default_text}}</div>
                 <div class="menu" >

--- a/templates/epilepsy12/partials/page_elements/select_model.html
+++ b/templates/epilepsy12/partials/page_elements/select_model.html
@@ -51,7 +51,7 @@
 
                 <i class="dropdown icon"></i>
                 <input type="hidden"
-                    _="init js $('.ui.rcpch_light_blue.fluid.search.selection.dropdown').dropdown(); end"
+                    _="init js $('.ui.rcpch_light_blue.fluid.search.selection.dropdown').dropdown({ fullTextSearch: true }); end"
                     name={{hx_name}}
                     hx-post="{{hx_post}}"
                     hx-target="{{hx_target}}"


### PR DESCRIPTION
### Overview

Users cannot search the select for strings in the middle of the word. This is an option in semantic UI that was not enabled

### Code changes

Add `{ fullTextSearch: true }` to the custom `us search select` partials

### Related Issues

closes #888