### PR TITLE
user account activity tidy remove 2FA device in logs

### DIFF
--- a/epilepsy12/forms_folder/epilepsy12_user_form.py
+++ b/epilepsy12/forms_folder/epilepsy12_user_form.py
@@ -54,6 +54,12 @@ class Epilepsy12UserUpdatePasswordForm(SetPasswordForm):
         if commit:
             logger.debug(f"Updating password_last_set to {timezone.now()}")
             user.save()
+            VisitActivity.objects.create(
+                activity_datetime=timezone.now(),
+                activity=5,
+                ip_address=self.request.META.get("REMOTE_ADDR"),
+                epilepsy12user=user,
+            )
         return user
 
 

--- a/epilepsy12/middleware.py
+++ b/epilepsy12/middleware.py
@@ -8,7 +8,7 @@ class CurrentUserMiddleware:
 
     def __call__(self, request):
         if request.user.is_authenticated:
-            Epilepsy12User._created_by = request.user
-            Epilepsy12User._updated_by = request.user
+            Epilepsy12User.created_by = request.user
+            Epilepsy12User.updated_by = request.user
         response = self.get_response(request)
         return response

--- a/epilepsy12/urls.py
+++ b/epilepsy12/urls.py
@@ -95,11 +95,6 @@ user_patterns = [
         name="logs",
     ),
     path(
-        "organisation/<int:organisation_id>/epilepsy12_users/<int:epilepsy12_user_id>/log_list",
-        view=log_list,
-        name="log_list",
-    ),
-    path(
         "organisation/<int:organisation_id>/epilepsy12_user_list/",
         view=epilepsy12_user_list,
         name="epilepsy12_user_list",

--- a/templates/epilepsy12/log_table.html
+++ b/templates/epilepsy12/log_table.html
@@ -2,13 +2,18 @@
 {% load static %}
 {% csrf_token %}
 
+<div id="logs_user_summary">
+    {% include 'epilepsy12/logs_user_summary.html' with epilepy12_user=epilepy12_user devices=devices organisation=organisation %}
+</div>
+
 {% if activities|length > 0 %}
     <div 
         hx-target='#log_table' 
-        hx-get="{% url 'log_list' organisation_id=organisation.pk epilepsy12_user_id=epilepsy12_user.pk %}" 
+        hx-get="{% url 'logs' organisation_id=organisation.pk epilepsy12_user_id=epilepsy12_user.pk %}" 
         hx-trigger='log_table from:body'
         hx-swap='innerHTML' 
         name='log_table'>
+
     
         <table class="ui rcpch table">
             <thead>
@@ -20,13 +25,6 @@
                 </tr>
             </thead>
             <tbody>
-                <tr>
-                    <td colspan="4" style="background-color: #d9d9d9;">
-                        <h5>{{epilepsy12user}} user account was created on {{epilepsy12_user.date_joined}} Created by: {{epilepsy12_user.created_by}}</h5>
-                        <h5><i>User record last updated: {{epilepsy12_user.updated_at}} by: {{epilepsy12_user.updated_by}}</i></h5>
-                        <h5><i>Password last set: {{epilepsy12_user.password_last_set}}</i></h5>
-                    </td>
-                </tr>
                 {% for activity in activities %}
                     <tr>
                         <td>{{activity.epilepsy12user}}</td>

--- a/templates/epilepsy12/logs.html
+++ b/templates/epilepsy12/logs.html
@@ -5,8 +5,8 @@
 
         <div class='ui top attached rcpch_dark_blue clearing segment'>
 
-                <h5 class="ui left floated header">
-                    Logs for {{epilepsy12_user}}
+                <h5 class="ui left floated header view_label_container tables">
+                    Activity Logs for {{epilepsy12_user}}
                 </h5>
     
                 <div class='back link'>

--- a/templates/epilepsy12/logs_user_summary.html
+++ b/templates/epilepsy12/logs_user_summary.html
@@ -1,0 +1,28 @@
+<div>
+    <h5>{{epilepsy12_user}} user account was created on {{epilepsy12_user.date_joined}} by {{epilepsy12_user.created_by}}</h5>
+    <h5><i>User record last updated: {{epilepsy12_user.updated_at}} by: {{epilepsy12_user.updated_by}}</i></h5>
+    <h5><i>Password last set: {{epilepsy12_user.password_last_set}}</i></h5>
+    {% if has_device %}
+        {% for device in devices %}
+            <span
+                id="device-delete"
+                data-title="Warning"
+                data-content="This will delete any authorized devices associated with user. When they next log in, they will have to set up two factor authentication again."
+                data-position="top left"
+                data-variation="basic"
+                _="init js $('#device-delete').popup(); end"
+            >
+                <button 
+                    class="ui rcpch_danger button"
+                    hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                    hx-post="{% url 'logs' organisation_id=organisation.pk epilepsy12_user_id=epilepsy12_user.pk %}"
+                    hx-target='#logs_user_summary' 
+                    hx-trigger="click"
+                    name="{{device.name}}"
+                    hx-swap="innerHTML">Remove Device: <i><b>{{device.name}}</b></i></button>
+            </span>
+        {% endfor %}
+    {% else %}
+        <div class="ui rcpch_warning message">{{epilepsy12_user}} has no active, registered devices for two factor authentication.</div>
+    {% endif %}
+</div>

--- a/templates/epilepsy12/logs_user_summary.html
+++ b/templates/epilepsy12/logs_user_summary.html
@@ -19,7 +19,21 @@
                     hx-target='#logs_user_summary' 
                     hx-trigger="click"
                     name="{{device.name}}"
-                    hx-swap="innerHTML">Remove Device: <i><b>{{device.name}}</b></i></button>
+                    hx-swap="innerHTML"
+                    _="on htmx:confirm(issueRequest)
+                        halt the event
+                        call Swal.fire({
+                            title: 'Confirmation Required',
+                            text: 'This will permanently remove Device `{{device.name}}` from {{epilepsy12_user}}`s profile',
+                            icon: 'warning',
+                            iconColor: '#e00087',
+                            showCancelButton: true,
+                            position: 'top',
+                            confirmButtonColor: '#11a7f2',
+                            cancelButtonColor: '#e60700',
+                            confirmButtonText: 'Remove device'
+                          })
+                        if result.isConfirmed issueRequest()">Remove Device: <i><b>{{device.name}}</b></i></button>
             </span>
         {% endfor %}
     {% else %}


### PR DESCRIPTION
### Overview

E12 team request ability to remove 2FA devices for users in the UI rather than the admin.

Involved abstracting the user activity summary into a separate partial and rendering above the activity table. 
Deprecated the duplicate logs_list endpoint

Used the two_factor dependency functions to identify user devices and list them in the new partial, with a button to delete.

In the process I identified a bug in the updated_by/created_by user middleware and fixed it

### Code changes

- remove unused `logs_list` from `urls.py` and `user_management_views.py`
- implement `devices_for_user` and `user_has_device` in the logs endpoint to delete selected device on button click
- create new partial template `logs_user_summary.html` and place above user activity table
- fix underscore in middleware
- update `epilepsy_12_user_form.py` to update VisitActivity on password reset

### Related Issues

closes #905