### PR TITLE
Fixes Organisation search bar doesn't maintain organisation once selected

### DIFF
--- a/epilepsy12/views/organisation_views.py
+++ b/epilepsy12/views/organisation_views.py
@@ -160,7 +160,6 @@ def selected_organisation_summary(request, organisation_id):
         # select any organisations except currently selected organisation
         organisation_list = (
             Organisation.objects.all()
-            .exclude(pk=selected_organisation.pk)
             .order_by("name")
         )
     else:


### PR DESCRIPTION
### Overview

When using E12 in development, once an organisation is selected, it disappears from the search bar, which I feel is a little less intuitive than keeping the title of the organisation in the search bar:

Before PR:

<img width="1341" alt="image" src="https://github.com/rcpch/rcpch-audit-engine/assets/65614251/b2c49437-fa03-4733-aff7-281fa5dbc33f">


After PR:

<img width="1347" alt="image" src="https://github.com/rcpch/rcpch-audit-engine/assets/65614251/976c6a5a-53b6-4b4f-b283-6ce73a4e7ba1">


@eatyourpeas what do you think of this? I know @nikyraja and @AmaniKrayemRCPCH wanted to make it more obvious to users that they could view patients in their trust as well, but I don't feel this goes against that too much. Perhaps there is a better way to make it more obvious that users can view trust-wide patients, not just organisation-wide.

### Code changes

Removes an .exclude() statement from view

### Documentation changes (done or required as a result of this PR)

N/A

### Related Issues

Closes #982 
