### PR TITLE
add cause to migration__006

### DIFF
--- a/epilepsy12/migrations/0006_seed_epilepsy_causes.py
+++ b/epilepsy12/migrations/0006_seed_epilepsy_causes.py
@@ -88,6 +88,7 @@ def seed_epilepsy_causes(apps, schema_editor):
     # Chromosome 11p13 deletion syndrome (disorder) SCTID: 715215007
     # Cortical dysplasia (disorder) SCTID: 253153000
     # 2q23.3 Microdeletion Syndrome - NOTE THIS NEEDS ADDING TO THE DATABASE MANUALLY AS THERE IS NO SNOMED CODE
+    # 14q32 deletion syndrome (disorder) SCTID: 879939002
 
     extra_concept_ids = [
         764946008,
@@ -126,6 +127,7 @@ def seed_epilepsy_causes(apps, schema_editor):
         416824008,
         715215007,
         253153000,
+        879939002,
     ]
     add_epilepsy_cause_list_by_sctid(extra_concept_ids=extra_concept_ids)
 


### PR DESCRIPTION
### Overview

Adding 879939002 Snomed CT ID - 14q32 deletion syndrome (disorder) to migration_0006
Already added to database in development, staging and live

### Related Issues

closes #990