### PR TITLE
Eatyourpeas/issue1007

### DIFF
--- a/documentation/docs/development/date-validations.md
+++ b/documentation/docs/development/date-validations.md
@@ -40,7 +40,7 @@ Two dates are supplied if the child has been referred, but only the referral dat
 ### Epilepsy nurse specialist
 
 2 dates are supplied and both are mandatory to complete the form - date referred and date seen
-The date seen cannot be before the date referred and the earliest allowable date is the first paediatric assessment date.
+The date seen cannot be before the date referred and the earliest allowable date is the date of birth (see [issue 1007](https://github.com/rcpch/rcpch-audit-engine/issues/1007#issue-2392653824)).
 
 ### EEG
 

--- a/epilepsy12/views/assessment_views.py
+++ b/epilepsy12/views/assessment_views.py
@@ -1578,7 +1578,7 @@ def epilepsy_specialist_nurse_referral_date(request, assessment_id):
             page_element="date_field",
             comparison_date_field_name="epilepsy_specialist_nurse_input_date",
             is_earliest_date=True,
-            earliest_allowable_date=assessment.registration.first_paediatric_assessment_date,
+            earliest_allowable_date=assessment.registration.case.date_of_birth,
         )
     except ValueError as error:
         error_message = error


### PR DESCRIPTION
### Overview

Request from @nikyraja to update permissions for ESN referral to allow dates before the first paediatric assessment, but after date of birth.

### Code changes

Update to the ESN referral date endpoint in `assessment_views.py`

### Documentation changes (done or required as a result of this PR)

Update to `date-validations.md` in documentation


### Related Issues

Closes #1007
