### PR TITLE
make-description-optional-*sad face*

### DIFF
--- a/epilepsy12/common_view_functions/recalculate_form_generate_response.py
+++ b/epilepsy12/common_view_functions/recalculate_form_generate_response.py
@@ -152,7 +152,6 @@ def completed_fields(model_instance):
                                 counter += 1
                     else:
                         counter += 1
-        print(f"field: {field.name} - counter: {counter}")
     return counter
 
 

--- a/epilepsy12/common_view_functions/recalculate_form_generate_response.py
+++ b/epilepsy12/common_view_functions/recalculate_form_generate_response.py
@@ -111,7 +111,7 @@ def completed_fields(model_instance):
             if getattr(model_instance, field.name, ()) is not None:
                 if (
                     field.name == "epilepsy_cause_categories"
-                    or field.name == "description"
+                    # or field.name == "description"
                     or field.name == "mental_health_issues"
                 ):
                     if len(getattr(model_instance, field.name)) > 0:
@@ -152,6 +152,7 @@ def completed_fields(model_instance):
                                 counter += 1
                     else:
                         counter += 1
+        print(f"field: {field.name} - counter: {counter}")
     return counter
 
 
@@ -376,6 +377,7 @@ def avoid_fields(model_instance):
         return META_VARIABLES + [
             "multiaxial_diagnosis",
             "description_keywords",
+            "description",  # Nolonger scored -  issue #1015
             "expected_score",
             "calculated_score",
         ]
@@ -519,7 +521,7 @@ def expected_score_for_single_episode(episode):
     # essential fields already accounted for are:
     # seizure_onset_date
     # seizure_onset_date_confidence
-    # episode_definition
+    # episode_definition - DEPRECATED
     # has_description_of_the_episode_or_episodes_been_gathered
     # epilepsy_or_nonepilepsy_status
 
@@ -533,7 +535,8 @@ def expected_score_for_single_episode(episode):
     if episode.has_description_of_the_episode_or_episodes_been_gathered:
         # essential fields are:
         # description
-        cumulative_score += 1
+        # cumulative_score += 1: DEPRECATED
+        pass
     if episode.epilepsy_or_nonepilepsy_status == "E":
         # epileptic seizure: essential fields:
         # epileptic_seizure_onset_type

--- a/epilepsy12/constants/form_calculation_constants.py
+++ b/epilepsy12/constants/form_calculation_constants.py
@@ -1,6 +1,7 @@
 """
 Constants file to be referenced from the `recalculate_form_generate_response` function and its helper functions.
 """
+
 from dataclasses import dataclass
 
 
@@ -70,7 +71,7 @@ Episode_minimum_scorable_fields = MinimumScorableFieldsForModel(
         "seizure_onset_date",
         "seizure_onset_date_confidence",
         "episode_definition",
-        "has_description_of_the_episode_or_episodes_been_gathered",
+        "has_description_of_the_episode_or_episodes_been_gathered",  # deprecated as per #1015
         "epilepsy_or_nonepilepsy_status",
     ],
 )

--- a/epilepsy12/tests/view_tests/form_calculations/test_number_of_completed_fields_in_related_models.py
+++ b/epilepsy12/tests/view_tests/form_calculations/test_number_of_completed_fields_in_related_models.py
@@ -143,7 +143,7 @@ def test_related_model_fields_count_all_episode_fully_completed(
         "seizure_onset_date_confidence": DATE_ACCURACY[0][0],
         "episode_definition": EPISODE_DEFINITION[0][0],
         "has_description_of_the_episode_or_episodes_been_gathered": True,
-        "description": "The seizure happened when child was watching TV",
+        # "description": "The seizure happened when child was watching TV", # deprecated as per #1015 to unscored field.
     }
 
     EPILEPTIC_FOCAL_ONSET = {
@@ -230,7 +230,7 @@ def test_related_model_fields_count_all_episode_random_answers(
         "seizure_onset_date_confidence": DATE_ACCURACY[0][0],
         "episode_definition": EPISODE_DEFINITION[0][0],
         "has_description_of_the_episode_or_episodes_been_gathered": True,
-        "description": "The seizure happened when child was watching TV",
+        # "description": "The seizure happened when child was watching TV", # deprecated description as per #1015 to unscored field.
     }
 
     EPILEPTIC_FOCAL_ONSET = {

--- a/epilepsy12/tests/view_tests/form_calculations/test_total_fields_expected.py
+++ b/epilepsy12/tests/view_tests/form_calculations/test_total_fields_expected.py
@@ -100,8 +100,9 @@ def test_count_episode_fields_epileptic_focal_onset(e12_case_factory, GOSH):
     return_value = count_episode_fields(episode_queryset)
 
     assert (
-        return_value == 8
-    ), f"Single completely filled Focal Onset Episode ({episode_queryset=}) inserted into count_episode_fields() fn. Should return 8. Instead, returned {return_value}"
+        return_value
+        == 7  # reduced from 8 as the episode description is nolonger a mandatory field: see issue #1015
+    ), f"Single completely filled Focal Onset Episode ({episode_queryset=}) inserted into count_episode_fields() fn. Should return 7. Instead, returned {return_value}"
 
 
 @pytest.mark.django_db
@@ -123,8 +124,9 @@ def test_count_episode_fields_epileptic_generalised_onset(e12_case_factory, GOSH
     return_value = count_episode_fields(episode_queryset)
 
     assert (
-        return_value == 8
-    ), f"Single completely filled Generalised Onset Episode ({episode_queryset=}) inserted into count_episode_fields() fn. Should return 8. Instead, returned {return_value}"
+        return_value
+        == 7  # reduced from 8 as the episode description is nolonger a mandatory field: see issue #1015
+    ), f"Single completely filled Generalised Onset Episode ({episode_queryset=}) inserted into count_episode_fields() fn. Should return 7. Instead, returned {return_value}"
 
 
 @pytest.mark.django_db
@@ -146,8 +148,9 @@ def test_count_episode_fields_epileptic_unclassified_onset(e12_case_factory, GOS
     return_value = count_episode_fields(episode_queryset)
 
     assert (
-        return_value == 7
-    ), f"Single completely filled unclassified Onset Episode ({episode_queryset=}) inserted into count_episode_fields() fn. Should return 7. Instead, returned {return_value}"
+        return_value
+        == 6  # reduced from 7 as the episode description is nolonger a mandatory field: see issue #1015
+    ), f"Single completely filled unclassified Onset Episode ({episode_queryset=}) inserted into count_episode_fields() fn. Should return 6. Instead, returned {return_value}"
 
 
 @pytest.mark.django_db
@@ -169,8 +172,9 @@ def test_count_episode_fields_epileptic_unknown_onset(e12_case_factory, GOSH):
     return_value = count_episode_fields(episode_queryset)
 
     assert (
-        return_value == 7
-    ), f"Single completely filled unknown Onset Episode ({episode_queryset=}) inserted into count_episode_fields() fn. Should return 7. Instead, returned {return_value}"
+        return_value
+        == 6  # reduced from 7 as the episode description is nolonger a mandatory field: see issue #1015
+    ), f"Single completely filled unknown Onset Episode ({episode_queryset=}) inserted into count_episode_fields() fn. Should return 6. Instead, returned {return_value}"
 
 
 @pytest.mark.django_db
@@ -178,7 +182,7 @@ def test_count_episode_fields_nonepileptic(e12_case_factory, GOSH):
     """
     Tests count_episode_fields with single non epileptic Episode queryset returns correct expected output, with a completed episode.
     """
-    expected_value = 11  # 5 for incomplete epileptic episode, ++6 for non epileptic episode base value incomplete fields
+    expected_value = 10  # 4 for incomplete epileptic episode, ++6 for non epileptic episode base value incomplete fields - not incomplete epileptic episode now reduced to 4 as the episode description is nolonger a mandatory field: see issue #1015
 
     # Either BPP (++3 to expected score) OR Oth (++2 to expected score)
     seizure_type_answer = random.choice(
@@ -226,7 +230,7 @@ def test_count_episode_fields_uncertain(e12_case_factory, GOSH):
     """
     Tests count_episode_fields with single uncertain epileptic Episode queryset returns correct expected output, with a completed episode.
     """
-    expected_value = 11  # 5 for incomplete epileptic episode, ++6 for uncertain episode base value incomplete fields
+    expected_value = 10  # 4 for incomplete epileptic episode, ++6 for uncertain episode base value incomplete fields - incomplete epileptic episode now reduced to 4 as the episode description is nolonger a mandatory field: see issue #1015
 
     CASE = e12_case_factory(
         first_name=f"temp_child_{GOSH.name}",
@@ -268,8 +272,8 @@ def test_total_fields_expected_multiaxial_diagnosis_episode_fields(
 
     multiaxial_diagnosis = CASE.registration.multiaxialdiagnosis
 
-    # Multiaxial diagnosis fields minimum == 7 ++ focal onset episode fields == 8
-    expected_value = 15
+    # Multiaxial diagnosis fields minimum == 7 ++ focal onset episode fields == 7 :  focal onset fields reduced to 7 as the episode description is nolonger a mandatory field: see issue #1015
+    expected_value = 14
     return_value = total_fields_expected(multiaxial_diagnosis)
 
     assert (
@@ -299,7 +303,7 @@ def test_total_fields_expected_multiaxial_diagnosis_syndrome_fields(
     # Initial value because Multiaxial diagnosis fields minimum == 7 ++ no episodes == 5
     expected_value = 12
 
-    ADD_SYNDROMES = random.choice([ True])
+    ADD_SYNDROMES = random.choice([True])
     if ADD_SYNDROMES is not None:
         # Create 3 syndromes
         SYNDROMES_LIST = SyndromeList.objects.all()[:3]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 -r requirements/requirements.txt
+fibble

--- a/templates/epilepsy12/partials/multiaxial_diagnosis/description.html
+++ b/templates/epilepsy12/partials/multiaxial_diagnosis/description.html
@@ -1,8 +1,7 @@
 <form class="ui form">
   <div class="ui rcpch_important message">
-    Include an optional freehand description of each episode as recorded in the clinical
-    records, using as much detail as you can, to a maximum of 2000 characters.
-    Any key words that have an agreed ILAE meaning will automatically be labelled and allow RCPCH to perform word analysis to broaden this list.
+    Optional Question - Please include a freehand description of each episode as recorded in the patient notes, using as much detail as you can (2000 character max).
+    Key words with an agreed ILAE meaning will be automatically labelled and facilitate future word analyses to help broaden ILAE description lists.
   </div>
 
   <div

--- a/templates/epilepsy12/partials/multiaxial_diagnosis/description.html
+++ b/templates/epilepsy12/partials/multiaxial_diagnosis/description.html
@@ -1,8 +1,8 @@
 <form class="ui form">
   <div class="ui rcpch_important message">
-    Write a freehand description of each episode as recorded in the clinical
+    Include an optional freehand description of each episode as recorded in the clinical
     records, using as much detail as you can, to a maximum of 2000 characters.
-    Any key words that have an agreed meaning will automatically be labelled.
+    Any key words that have an agreed ILAE meaning will automatically be labelled and allow RCPCH to perform word analysis to broaden this list.
   </div>
 
   <div

--- a/templates/epilepsy12/partials/multiaxial_diagnosis/description_labels.html
+++ b/templates/epilepsy12/partials/multiaxial_diagnosis/description_labels.html
@@ -17,7 +17,7 @@
         <i class="rcpch_pink check circle outline icon"></i>
     {% else %}
         <span
-        data-tooltip="Incomplete field. This must be scored to complete the record."
+        data-tooltip="Incomplete field. This item is not scored so may be left blank."
         data-inverted=""
         data-position="top left"
         >


### PR DESCRIPTION
### Overview

The E12 data group have accepted a request from some users requesting the episode free text description to be made non-mandatory. The description field uses fuzzy logic to match any key words (taken from a validated list produced by the american international league against epilepsy ILAE group). The original reason to include the feature in the early build had been to do frequency analysis on terms in the free text and improve on this slightly odd and eclectic American list of terms (which includes words like 'fencers posture' but does not include words like 'shaking'). By making this an optional field, it seems unlikely now it will be completed by many users hence the *sad face*, and depending on how much it is completed, the validity of any data collected will be watered down. Sorry this is only an audit, I should possibly not be quite so involved...

Anyway, this PR removes the `description` field from the scoreable fields and amends the signposting to users to reflect this in the templates. It also updates the tests which check the form scoring.

### Code changes

- `form_calculation_constants`: this file stores the minimum scoreable fields. `description` is commented out with a reference to this issue for future.
- `recalculate_form_generate_response`: omits `description from the scored fields
- test files: these remove description from the totals
- `description.html` and `description_labels.html`: update the tooltip and message to signpost to users that the field is optional.

### Related Issues

closes #1015
