### PR TITLE
Update first_paediatric_assessment_date tooltip

### DIFF
--- a/epilepsy12/models_folder/registration.py
+++ b/epilepsy12/models_folder/registration.py
@@ -34,7 +34,7 @@ class Registration(
     first_paediatric_assessment_date = models.DateField(
         help_text={
             "label": "First paediatric assessment",
-            "reference": "Setting this date is an irreversible step. Confirmation will be requested to complete this step.",
+            "reference": "'First paediatric assessment' is when the patient was initally seen by a paedaitric professional for parozysmal episodes in any healthcare setting. Setting this date is an irreversible step. Confirmation will be requested to complete this step.",
         },
         null=True,
         default=None,


### PR DESCRIPTION
Updated tooltip on first paediatric assessment date to describe what can be included as the initial assessment