### PR TITLE
Bump to latest versions

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,51 +1,51 @@
 # Python standard library imports
 python-dateutil==2.9.0.post0
-requests==2.31.0
+requests==2.32.3
 
 # third party imports
 ## django and misc
-dj_database_url==2.1.0
-django==5.0.3
+dj_database_url==2.2.0
+django==5.1
 django-auto-logout==0.5.1
-django-filter==23.5
-django-htmx==1.17.3
-django-semantic-admin==0.4.1
+django-filter==24.3
+django-htmx==1.19.0
+django-semantic-admin==0.6.0
 django-simple-captcha==0.6.0
-django-simple-history==3.5.0
-django-two-factor-auth==1.16.0
+django-simple-history==3.7.0
+django-two-factor-auth==1.17.0
 django-widget-tweaks==1.5.0
-djangorestframework==3.14.0
-docutils==0.20.1
-pandas==2.2.1
+djangorestframework==3.15.2
+docutils==0.21.2
+pandas==2.2.2
 # We don't use this but django-two-factor-auth requires it
 # They are working to make it optional https://github.com/jazzband/django-two-factor-auth/issues/469
-phonenumbers==8.13.31
+phonenumbers==8.13.43
 psycopg2-binary==2.9.9
-whitenoise==6.6.0
-openpyxl==3.1.2
+whitenoise==6.7.0
+openpyxl==3.1.5
 
 ## graphing
-plotly==5.19.0
+plotly==5.23.0
 
 # NHS number
 nhs-number==1.3.4
 
 # live application server
-gunicorn==22.0.0
+gunicorn==23.0.0
 
 # code linting and formatting
-autopep8==2.0.4
-black==24.2.0
+autopep8==2.3.1
+black==24.8.0
 
 # testing and code analysis
-coverage==7.4.3
+coverage==7.6.1
 pytest-django==4.8.0
 pytest-factoryboy==2.7.0
-rapidfuzz==3.6.2
+rapidfuzz==3.9.6
 
-mkdocs-material==9.5.13
+mkdocs-material==9.5.32
 mkdocs-git-committers-plugin-2==2.3.0 # displays authors at the bottom of the page
-mkdocs-git-revision-date-localized-plugin==1.2.4 # displays last edit date at the bottom of the page
+mkdocs-git-revision-date-localized-plugin==1.2.7 # displays last edit date at the bottom of the page
 mkdocs-macros-plugin==1.0.5 # enables 'foldable' admonition text (used for large code blocks)
 mkdocs-with-pdf==0.9.3 # PDF export feature
 


### PR DESCRIPTION
In particular to address a critical vulnerability in Django (https://github.com/rcpch/rcpch-audit-engine/security/dependabot/12)