### PR TITLE
kpi-5-mri-criteria-change

### DIFF
--- a/documentation/docs/development/key-performance-indicators.md
+++ b/documentation/docs/development/key-performance-indicators.md
@@ -145,11 +145,11 @@ class KPI(models.Model, HelpTextMixin):
     )
 
     """
-    16. Percentage of children and young people with defined indications for an MRI, who had timely MRI within 6 weeks of request
+    16. Percentage of children and young people with defined indications for an MRI, who had timely MRI within 6 weeks of request (KPI 5)
     
     Calculation Method
-    Numerator = Number of children and young people diagnosed with epilepsy at first year AND who are NOT JME or JAE or CAE or CECTS/Rolandic OR number of children aged under 2 years at first assessment with a diagnosis of epilepsy at first year AND who had an MRI within 6 weeks of request
-    Denominator = Number of children and young people diagnosed with epilepsy at first year AND ((who are NOT JME or JAE or CAE or BECTS) OR (number of children aged under  2 years  at first assessment with a diagnosis of epilepsy at first year))
+    Numerator = Number of children and young people diagnosed with epilepsy at first year AND who are NOT (JME OR JAE OR CAE OR Generalised tonic clonic seizures only OR self-limited epilepsy with centrotemporal spikes ~(SELECT)) AND who had an MRI within 6 weeks of referral.
+    Denominator = Number of children and young people diagnosed with epilepsy at first year AND who are NOT (JME OR JAE OR CAE OR Generalised tonic clonic seizures only OR self-limited epilepsy with centrotemporal spikes ~(SELECT))
     """
     mri = models.IntegerField(
         help_text={

--- a/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_5.py
+++ b/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_5.py
@@ -25,7 +25,6 @@ def score_kpi_5(registration_instance, age_at_first_paediatric_assessment) -> in
     multiaxial_diagnosis = registration_instance.multiaxialdiagnosis
     investigations = registration_instance.investigations
 
-    Episode = apps.get_model("epilepsy12", "Episode")
     Syndrome = apps.get_model("epilepsy12", "Syndrome")
 
     # define eligibility criteria 1
@@ -35,29 +34,18 @@ def score_kpi_5(registration_instance, age_at_first_paediatric_assessment) -> in
         # ELECTROCLINICAL SYNDROMES: BECTS/JME/JAE/CAE currently not included
         Q(
             syndrome__syndrome_name__in=[
-                "Self-limited epilepsy with centrotemporal spikes",
-                "Juvenile myoclonic epilepsy",
-                "Juvenile absence epilepsy",
-                "Childhood absence epilepsy",
+                "Self-limited epilepsy with centrotemporal spikes",  # 3
+                "Juvenile myoclonic epilepsy",  # 18
+                "Juvenile absence epilepsy",  # 17
+                "Childhood absence epilepsy",  # 16
+                "Epilepsy with generalized tonic–clonic seizures alone",  # 19
             ]
         )
     ).exists()
 
-    # define eligibility criteria 2
-    generalised_epilepsy_only_present = (
-        Episode.objects.filter(
-            multiaxial_diagnosis=multiaxial_diagnosis,
-            epilepsy_or_nonepilepsy_status=EPILEPSY_DIAGNOSIS_STATUS[0][0],
-            epileptic_seizure_onset_type=EPILEPSY_SEIZURE_TYPE[0][0],
-        ).count()
-        > 0  # epilepsy which is generalised onset
-        and multiaxial_diagnosis.syndrome_present is False
-    )
-
     # check eligibility criteria 1 & 2
     # 1 = none of the specified syndromes present
-    # 2 = epilepsy is not simple generalised
-    if not (ineligible_syndrome_present or generalised_epilepsy_only_present):
+    if not (ineligible_syndrome_present):
         # not scored
         mri_dates_are_none = [
             (investigations.mri_brain_requested_date is None),

--- a/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_5.py
+++ b/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_5.py
@@ -6,7 +6,11 @@ from django.apps import apps
 
 # E12 imports
 # from epilepsy12.models import Syndrome
-from epilepsy12.constants import KPI_SCORE
+from epilepsy12.constants import (
+    KPI_SCORE,
+    EPILEPSY_SEIZURE_TYPE,
+    EPILEPSY_DIAGNOSIS_STATUS,
+)
 
 
 def score_kpi_5(registration_instance, age_at_first_paediatric_assessment) -> int:
@@ -21,6 +25,7 @@ def score_kpi_5(registration_instance, age_at_first_paediatric_assessment) -> in
     multiaxial_diagnosis = registration_instance.multiaxialdiagnosis
     investigations = registration_instance.investigations
 
+    Episode = apps.get_model("epilepsy12", "Episode")
     Syndrome = apps.get_model("epilepsy12", "Syndrome")
 
     # define eligibility criteria 1
@@ -40,7 +45,12 @@ def score_kpi_5(registration_instance, age_at_first_paediatric_assessment) -> in
 
     # define eligibility criteria 2
     generalised_epilepsy_only_present = (
-        registration_instance.epilepsycontext.were_any_of_the_epileptic_seizures_convulsive
+        Episode.objects.filter(
+            multiaxial_diagnosis=multiaxial_diagnosis,
+            epilepsy_or_nonepilepsy_status=EPILEPSY_DIAGNOSIS_STATUS[0][0],
+            epileptic_seizure_onset_type=EPILEPSY_SEIZURE_TYPE[0][0],
+        ).count()
+        > 0  # epilepsy which is generalised onset
         and multiaxial_diagnosis.syndrome_present is False
     )
 

--- a/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_5.py
+++ b/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_5.py
@@ -40,7 +40,7 @@ def score_kpi_5(registration_instance, age_at_first_paediatric_assessment) -> in
 
     # define eligibility criteria 2
     generalised_epilepsy_only_present = (
-        registration_instance.epilepsy_context.were_any_of_the_epileptic_seizures_convulsive
+        registration_instance.epilepsycontext.were_any_of_the_epileptic_seizures_convulsive
         and multiaxial_diagnosis.syndrome_present is False
     )
 

--- a/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_5.py
+++ b/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_5.py
@@ -47,7 +47,7 @@ def score_kpi_5(registration_instance, age_at_first_paediatric_assessment) -> in
     # check eligibility criteria 1 & 2
     # 1 = none of the specified syndromes present
     # 2 = epilepsy is not simple generalised
-    if (not ineligible_syndrome_present) or (not generalised_epilepsy_only_present):
+    if not (ineligible_syndrome_present or generalised_epilepsy_only_present):
         # not scored
         mri_dates_are_none = [
             (investigations.mri_brain_requested_date is None),

--- a/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_5.py
+++ b/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_5.py
@@ -1,21 +1,20 @@
 """
 Measure 5 `mri`
 
-Number of children and young people diagnosed with epilepsy at first year AND who are NOT JME or JAE or CAE or CECTS/Rolandic OR number of children aged under 2 years at first assessment with a diagnosis of epilepsy at first year AND who had an MRI within 6 weeks of request
+Number of children and young people diagnosed with epilepsy at first year AND who are NOT JME or JAE or CAE or CECTS/Rolandic or Epilepsy with generalized tonic–clonic seizures alone at first assessment with a diagnosis of epilepsy at first year AND who had an MRI within 6 weeks of request
 
 =
 
 COUNT(kids)
 AND
-    NOT (JME or JAE or CAE or CECTS/Rolandic) 
-    OR 
-    age@FPA <2y 
+    NOT (JME or JAE or CAE or CECTS/Rolandic or Epilepsy with generalized tonic–clonic seizures alone) 
+
 AND
     had MRI within 6 weeks of request
 
-- [ x] Measure 5 passed (registration.kpi.mri == 1) if MRI done in 6 weeks and are NOT JME or JAE or CAE or CECTS/Rolandic or under 2 y (lines 270-324)
-- [ x] Measure 5 failed (registration.kpi.mri == 0) if MRI not done in 6 weeks and are NOT JME or JAE or CAE or CECTS/Rolandic or under 2 y (lines 270-324)
-- [ x] Measure 5 ineligible (registration.kpi.mri == 0) if JME or JAE or CAE or CECTS/Rolandic
+- [ x] Measure 5 passed (registration.kpi.mri == 1) if MRI done in 6 weeks and are NOT JME or JAE or CAE or CECTS/Rolandic or Epilepsy with generalized tonic–clonic seizures alone (lines 270-324)
+- [ x] Measure 5 failed (registration.kpi.mri == 0) if MRI not done in 6 weeks and are NOT JME or JAE or CAE or CECTS/Rolandic or Epilepsy with generalized tonic–clonic seizures alone (lines 270-324)
+- [ x] Measure 5 ineligible (registration.kpi.mri == 0) if JME or JAE or CAE or CECTS/Rolandic or Epilepsy with generalized tonic–clonic seizures alone
 """
 
 # Standard imports
@@ -69,9 +68,9 @@ def test_measure_5_mri_under2yo(
 ):
     """
     *PASS*
-    1) MRI done in 6 weeks post-referral and are under 2y@FPA
+    1) MRI done in 6 weeks post-referral
     *FAIL*
-    1) MRI NOT done in 6 weeks post-referral and are under 2y@FPA
+    1) MRI NOT done in 6 weeks post-referral
     """
     MRI_REQUESTED_DATE = FIRST_PAEDIATRIC_ASSESSMENT_DATE + relativedelta(days=1)
 
@@ -162,6 +161,7 @@ def test_measure_5_mri_syndromes_pass_fail(
                 "Juvenile myoclonic epilepsy",
                 "Juvenile absence epilepsy",
                 "Childhood absence epilepsy",
+                "Generalised tonic clonic seizures only",
             ]
         )
     )
@@ -191,6 +191,7 @@ def test_measure_5_mri_syndromes_pass_fail(
         (SYNDROMES[17][1]),  # Juvenile absence epilepsy
         (SYNDROMES[16][1]),  # Childhood absence epilepsy
         (SYNDROMES[3][1]),  # Self-limited epilepsy with centrotemporal spikes
+        (SYNDROMES[19][1]),  # Generalised tonic clonic seizures only
     ],
 )
 @pytest.mark.django_db
@@ -200,9 +201,7 @@ def test_measure_5_mri_syndromes_ineligible(
     """
     *INELIGIBLE*
     1)      ONE OF:
-                JME or JAE or CAE or CECTS/Rolandic
-        AND
-        age_at_first_paediatric_assessment >= 2 (testing using age at fpa = 2y exactly)
+                JME or JAE or CAE or CECTS/Rolandic or Generalised tonic clonic seizures only
     """
 
     FIRST_PAEDIATRIC_ASSESSMENT_DATE = date(2023, 1, 1)

--- a/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_5.py
+++ b/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_5.py
@@ -161,7 +161,7 @@ def test_measure_5_mri_syndromes_pass_fail(
                 "Juvenile myoclonic epilepsy",
                 "Juvenile absence epilepsy",
                 "Childhood absence epilepsy",
-                "Generalised tonic clonic seizures only",
+                "Epilepsy with generalized tonic–clonic seizures alone",
             ]
         )
     )
@@ -191,7 +191,7 @@ def test_measure_5_mri_syndromes_pass_fail(
         (SYNDROMES[17][1]),  # Juvenile absence epilepsy
         (SYNDROMES[16][1]),  # Childhood absence epilepsy
         (SYNDROMES[3][1]),  # Self-limited epilepsy with centrotemporal spikes
-        (SYNDROMES[19][1]),  # Generalised tonic clonic seizures only
+        (SYNDROMES[19][1]),  # Epilepsy with generalized tonic–clonic seizures alone
     ],
 )
 @pytest.mark.django_db
@@ -201,7 +201,7 @@ def test_measure_5_mri_syndromes_ineligible(
     """
     *INELIGIBLE*
     1)      ONE OF:
-                JME or JAE or CAE or CECTS/Rolandic or Generalised tonic clonic seizures only
+                JME or JAE or CAE or CECTS/Rolandic or Epilepsy with generalized tonic–clonic seizures alone
     """
 
     FIRST_PAEDIATRIC_ASSESSMENT_DATE = date(2023, 1, 1)


### PR DESCRIPTION
### Overview

See discussion in issue #1016. Removes the under twos from requiring MRIs by default. Also adds Epilepsy with generalized tonic–clonic seizures alone to list of excluded syndromes requiring MRI. Other criteria (timeliness of scan) remain the same.

Updates the tests to reflect this.
Updates the documentation to reflect this

closes #1016