### PR TITLE
Fix reading log level settings in Azure

### DIFF
--- a/rcpch-audit-engine/settings.py
+++ b/rcpch-audit-engine/settings.py
@@ -21,14 +21,15 @@ from dotenv import load_dotenv
 # third party imports
 from django.core.management.utils import get_random_secret_key
 
+# Must be above importing logging settigns as we read environment variables there
+load_dotenv('envs/.env')
+
 # RCPCH imports
 from .logging_settings import (
     LOGGING,
 )  # no it is not an unused import, it pulls LOGGING into the settings file
 
 logger = logging.getLogger(__name__)
-
-load_dotenv('envs/.env')
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
Move reading env file before we import the logging settings (which read the level from environment variables)