### PR TITLE
Add prout

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,0 +1,6 @@
+{
+    "checkpoints": {
+      "STAGING": { "url": "https://e12-staging.rcpch.tech/", "overdue": "30M" },
+      "LIVE": { "url": "https://e12.rcpch.ac.uk/", "overdue": "30M" }
+    }
+  }

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,7 @@
   <meta name="keywords" content="Epilepsy12 RCPCH Audit Childhood Epilepsy" />
   <meta name="author" content="RCPCH" />
   <meta name="theme-color" content="#ffffff" />
+  <meta name="latest_git_commit" content="{{latest_git_commit}}" />
   <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests"> 
   <title>Epilepsy12 Platform | RCPCH</title>
   <link rel="stylesheet" href="{% static 'styles/semantic.min.css' %}" type="text/css" />


### PR DESCRIPTION
Now E12 is continuously deployed (#1029) we will use https://github.com/guardian/prout to notify us if a deployment fails