### PR TITLE
Allow password reset even if user has never confirmed their email

### DIFF
--- a/epilepsy12/forms_folder/epilepsy12_user_form.py
+++ b/epilepsy12/forms_folder/epilepsy12_user_form.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from typing import Any
 import logging
 
@@ -5,7 +6,11 @@ from django import forms
 from django.conf import settings
 from django.core import validators
 from django.core.exceptions import ValidationError
-from django.contrib.auth.forms import AuthenticationForm, SetPasswordForm
+from django.contrib.auth.forms import (
+    AuthenticationForm,
+    SetPasswordForm,
+    PasswordResetForm,
+)
 from django.utils.translation import gettext as _
 from django.utils import timezone
 
@@ -343,3 +348,17 @@ class CaptchaAuthenticationForm(AuthenticationForm):
                         "You have failed to login 5 or more consecutive times. You have been locked out for 10 minutes"
                     )
             return email.lower()
+
+
+class Epilepsy12PasswordResetForm(PasswordResetForm):
+    """
+    This is a standard Django form to be used by users to reset their password
+    It is not possible in standard Django for users to reset their passwords if their account is inactive or they have an unusable password.
+    Since new accounts are created with unusable passwords, if a user fails to confirm their email address they will be unable to reset their password.
+    This form is overridden to allow users to reset their password if their account has an unusable password. This still have to be active users
+    """
+
+    def get_users(self, email: str):
+        return Epilepsy12User.objects.filter(
+            email__iexact=email, is_active=True
+        )  # only return active users including those with unusable passwords

--- a/epilepsy12/scratchpad.md
+++ b/epilepsy12/scratchpad.md
@@ -9,4 +9,25 @@ This file is to write steps in a workflow. It is not a substitute for the docs.
 3. check email_confirmed flag in admin as superuser
 4. allow 2 minutes to expire
 5. click on confirm email link as logged out user to confirm token has expired
-6. Try and reset password as new user
+   Option 1
+
+- superuser clicks on resend email link and logs out
+- user clicks on password reset email from this and resets password then logs in
+- superuser checks admin
+
+Option 2
+
+- user has not confirmed account and that token has now expired
+- user tries to reset password - they are in the gulag: no email is sent
+
+1.  Try and reset password as new user
+
+
+Items to fix
+
+
+
+Observations
+The newly created user with email_confirmed being false and token expired has is_active still true, password_last_set datetime is same as creation datetime
+Option 1 workflow is working as expected: user has 
+

--- a/epilepsy12/scratchpad.md
+++ b/epilepsy12/scratchpad.md
@@ -1,33 +1,3 @@
 # Scratchpad
 
-This file is to write steps in a workflow. It is not a substitute for the docs.
-
-## If a user fails to click on the confirm email link they cannot subsequently reset their password. Debug work flow
-
-1. Set token expired to 2 minutes
-2. create new user
-3. check email_confirmed flag in admin as superuser
-4. allow 2 minutes to expire
-5. click on confirm email link as logged out user to confirm token has expired
-   Option 1
-
-- superuser clicks on resend email link and logs out
-- user clicks on password reset email from this and resets password then logs in
-- superuser checks admin
-
-Option 2
-
-- user has not confirmed account and that token has now expired
-- user tries to reset password - they are in the gulag: no email is sent
-
-1.  Try and reset password as new user
-
-
-Items to fix
-
-
-
-Observations
-The newly created user with email_confirmed being false and token expired has is_active still true, password_last_set datetime is same as creation datetime
-Option 1 workflow is working as expected: user has 
-
+This file is to write steps in a workflow. It is not a substitute for the docs. It is included for convenience

--- a/epilepsy12/scratchpad.md
+++ b/epilepsy12/scratchpad.md
@@ -1,3 +1,0 @@
-# Scratchpad
-
-This file is to write steps in a workflow. It is not a substitute for the docs. It is included for convenience

--- a/epilepsy12/scratchpad.md
+++ b/epilepsy12/scratchpad.md
@@ -1,0 +1,12 @@
+# Scratchpad
+
+This file is to write steps in a workflow. It is not a substitute for the docs.
+
+## If a user fails to click on the confirm email link they cannot subsequently reset their password. Debug work flow
+
+1. Set token expired to 2 minutes
+2. create new user
+3. check email_confirmed flag in admin as superuser
+4. allow 2 minutes to expire
+5. click on confirm email link as logged out user to confirm token has expired
+6. Try and reset password as new user

--- a/epilepsy12/views/user_management_views.py
+++ b/epilepsy12/views/user_management_views.py
@@ -1,3 +1,6 @@
+# Logging setup
+import logging
+
 # Django
 from django.utils import timezone
 from django.contrib.auth.decorators import permission_required
@@ -54,6 +57,8 @@ from ..constants import (
     AUDIT_CENTRE_ROLES,
     EPILEPSY12_AUDIT_TEAM_FULL_ACCESS,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @login_and_otp_required()
@@ -605,7 +610,7 @@ class ResetPasswordConfirmView(PasswordResetConfirmView):
     def form_valid(self, form):
         # Store the user's email in the session
         self.request.session["user_email"] = form.user.email
-        print(f"Password reset requested for {form.user.email}")
+        logging.info(f"Password reset requested for {form.user.email}")
         return super().form_valid(form)
 
 

--- a/epilepsy12/views/user_management_views.py
+++ b/epilepsy12/views/user_management_views.py
@@ -36,6 +36,7 @@ from ..models import Epilepsy12User, Organisation, VisitActivity, Site
 from epilepsy12.forms_folder.epilepsy12_user_form import (
     Epilepsy12UserAdminCreationForm,
     CaptchaAuthenticationForm,
+    Epilepsy12PasswordResetForm,
 )
 from ..general_functions import (
     construct_confirm_email,
@@ -580,6 +581,7 @@ class ResetPasswordView(SuccessMessageMixin, PasswordResetView):
         + timedelta(seconds=int(settings.PASSWORD_RESET_TIMEOUT))
     }
     success_url = reverse_lazy("index")
+    form_class = Epilepsy12PasswordResetForm
 
     # extend form_valid to set user.password_last_set
     def form_valid(self, form):
@@ -598,11 +600,12 @@ class ResetPasswordView(SuccessMessageMixin, PasswordResetView):
 
 
 class ResetPasswordConfirmView(PasswordResetConfirmView):
-    # overridden custom django password reset work flow. User has submitted a valide password for reset
+    # overridden custom django password reset work flow. User has submitted a valid password for reset
     # their email is stored in session for use later to update logs if they are successful
     def form_valid(self, form):
         # Store the user's email in the session
         self.request.session["user_email"] = form.user.email
+        print(f"Password reset requested for {form.user.email}")
         return super().form_valid(form)
 
 

--- a/rcpch-audit-engine/settings.py
+++ b/rcpch-audit-engine/settings.py
@@ -253,13 +253,13 @@ else:
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 logger.info("EMAIL_BACKEND: %s", EMAIL_BACKEND)
 
-PASSWORD_RESET_TIMEOUT = os.environ.get(
-    "PASSWORD_RESET_TIMEOUT", 120
-)  # Default: 259200 (2 minutes, in seconds)
-
 # PASSWORD_RESET_TIMEOUT = os.environ.get(
-#     "PASSWORD_RESET_TIMEOUT", 259200
-# )  # Default: 259200 (3 days, in seconds)
+#     "PASSWORD_RESET_TIMEOUT", 120
+# )  # Default: 259200 (2 minutes, in seconds) - 2 minutes for testing
+
+PASSWORD_RESET_TIMEOUT = os.environ.get(
+    "PASSWORD_RESET_TIMEOUT", 259200
+)  # Default: 259200 (3 days, in seconds)
 
 SITE_CONTACT_EMAIL = os.environ.get("SITE_CONTACT_EMAIL")
 

--- a/rcpch-audit-engine/settings.py
+++ b/rcpch-audit-engine/settings.py
@@ -28,7 +28,7 @@ from .logging_settings import (
 
 logger = logging.getLogger(__name__)
 
-load_dotenv('envs/.env')
+load_dotenv("envs/.env")
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -193,15 +193,11 @@ database_config = {
 password_file = os.environ.get("E12_POSTGRES_DB_PASSWORD_FILE")
 
 if password_file:
-    database_config["OPTIONS"] = {
-        "passfile": password_file
-    }
+    database_config["OPTIONS"] = {"passfile": password_file}
 else:
     database_config["PASSWORD"] = os.environ.get("E12_POSTGRES_DB_PASSWORD")
 
-DATABASES = {
-    "default": database_config
-}
+DATABASES = {"default": database_config}
 
 # Password validation
 # https://docs.djangoproject.com/en/3.2/ref/settings/#auth-password-validators
@@ -258,8 +254,12 @@ else:
 logger.info("EMAIL_BACKEND: %s", EMAIL_BACKEND)
 
 PASSWORD_RESET_TIMEOUT = os.environ.get(
-    "PASSWORD_RESET_TIMEOUT", 259200
-)  # Default: 259200 (3 days, in seconds)
+    "PASSWORD_RESET_TIMEOUT", 120
+)  # Default: 259200 (2 minutes, in seconds)
+
+# PASSWORD_RESET_TIMEOUT = os.environ.get(
+#     "PASSWORD_RESET_TIMEOUT", 259200
+# )  # Default: 259200 (3 days, in seconds)
 
 SITE_CONTACT_EMAIL = os.environ.get("SITE_CONTACT_EMAIL")
 

--- a/templates/registration/admin_create_user.html
+++ b/templates/registration/admin_create_user.html
@@ -124,7 +124,7 @@
                 name="resend"
                 value="resend"
               >
-                Resend Email
+                Resend Account Confirmation Email
               </button>
             {% endif %}
             

--- a/templates/registration/admin_reset_password.html
+++ b/templates/registration/admin_reset_password.html
@@ -18,6 +18,7 @@
     This link can only be used once, and expires in 72 hours. To request a new link, get in touch with your Epilepsy12 local admin
     or get in touch with
     <a href="mailto:epilepsy12@rcpch.ac.uk">The Epilepsy12 Team</a>
+    . Alternatively, you can go to {{ protocol }}://{{ domain }}{% url 'password_reset' %} to request a new link.
   </p>
   <br />
   <p style="font-family: 'Montserrat', sans-serif;">

--- a/templates/registration/password_reset_confirm.html
+++ b/templates/registration/password_reset_confirm.html
@@ -49,7 +49,7 @@
         
     {% else %}
         <h1>Password reset failed</h1>
-        <p>The password reset link was invalid, possibly because it has already been used. Please request a new password reset.</p>
+        <p>The password reset link was invalid, possibly because it has already been used or it has expired - tokens only last 72 hours. Please request a new password reset.</p>
     {% endif %}
 
 

--- a/templates/registration/password_reset_confirm.html
+++ b/templates/registration/password_reset_confirm.html
@@ -49,7 +49,7 @@
         
     {% else %}
         <h1>Password reset failed</h1>
-        <p>The password reset link was invalid, possibly because it has already been used or it has expired - tokens only last 72 hours. Please request a new password reset.</p>
+        <p>The password reset link was invalid, possibly because it has already been used or it has expired after 72 hours. Please request a new password reset.</p> 
     {% endif %}
 
 

--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -9,7 +9,7 @@
   <p style="font-family: 'Montserrat', sans-serif;">Epilepsy12 Password Reset</p>
   <p style="font-family: 'Montserrat', sans-serif;">Dear {{user}},</p>
   <p style="font-family: 'Montserrat', sans-serif;">To reset your password for the Epilepsy12 platform, click the link
-    below:</p>
+    below. Note if you did not confirm your account within 72 hours of creation, you can also use this link to create a new password:</p>
   <p>
     <a href="{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}" target="_blank">
       {{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}

--- a/templates/registration/user_management/epilepsy12_user_table.html
+++ b/templates/registration/user_management/epilepsy12_user_table.html
@@ -147,7 +147,7 @@
             <td>{{ epilepsy12_user.get_role_display }}</td>
             <td>{{ epilepsy12_user.organisation_employer  }}</td>
             <td>
-                {% if not epilepsy12_user.email_confirmed and not epilepsy12_user.is_active %}
+                {% if not epilepsy12_user.email_confirmed and epilepsy12_user.is_active %}
                     <i 
                         class="rcpch_light_blue dot circle outline icon"
                         id="{{epilepsy12_user.id}}_not_email_confirmed_icon"
@@ -162,7 +162,7 @@
                         class="rcpch_pink check circle outline icon"
                         id="{{epilepsy12_user.id}}_email_confirmed_icon"
                         data-title="User status"
-                        data-content="{{epilepsy12_user}} is an active user."
+                        data-content="{{epilepsy12_user}} has confirmed their account and is an active user."
                         data-position="top left"
                         data-variation="basic"
                         _="init js $('#{{epilepsy12_user.id}}_email_confirmed_icon').popup(); end"
@@ -172,7 +172,17 @@
                         class="red close icon"
                         id="{{epilepsy12_user.id}}_is_inactive_icon"
                         data-title="User status"
-                        data-content="{{epilepsy12_user}} is an inactive user."
+                        data-content="{{epilepsy12_user}} has previously confirmed their account but is now an inactive user."
+                        data-position="top left"
+                        data-variation="basic"
+                        _="init js $('#{{epilepsy12_user.id}}_is_inactive_icon').popup(); end"
+                    >
+                {% elif not epilepsy12_user.email_confirmed and not epilepsy12_user.is_active %}
+                    <i 
+                        class="red close icon"
+                        id="{{epilepsy12_user.id}}_is_inactive_icon"
+                        data-title="User status"
+                        data-content="{{epilepsy12_user}} has never confirmed their account but is now an inactive user."
                         data-position="top left"
                         data-variation="basic"
                         _="init js $('#{{epilepsy12_user.id}}_is_inactive_icon').popup(); end"


### PR DESCRIPTION
### Overview

A common situation is that users fail to click on their account creation link within 72 hours.
*What should happen:*
User contacts Epilepsy12 who navigate to the user in the platform -> edit user -> click on reset password
This triggers a password reset email with a token to the user who clicks through to set a password
This pathway has been retested and works.
*What actually happens:*
User does not contact Epilepsy12 team as directed as does not read the email. User navigates to password reset page and requests new password. Because the user does not yet have a useable password, no email is sent - this is django stock behaviour. There is no messaging to the user to say this, so frustration follows.

Proposed solution offered in this PR
- user account created by their centre lead clinician. An email is sent out with updated details on steps to take to confirm their email in future if they do not click on the link within 72hrs
- user fails to confirm account within 72 hr and enters the gulag
Two options then result:
**Option One**
1. user contacts epilepsy12 who navigate to user account in the platform - this is the original expected workflow. E12 admin click on the resend email button which only appears for users who have not yet confirmed their accounts. The title of this button has been clarified to `Resend Account Confirmation Email`.
2. User gets email with fresh token and has a further 72 hrs to confirm account and set password. User has escaped the gulag.
**Option Two**
1. User does not read any of the emails and navigates to password reset, or reads the original email with the expired token, and follows link to reset password
2. User receives email with reset password link and confirms email as well as resetting password. User has escaped the gulag.

Along with this small change in workflow, better signposting in the user table has been added, where a blue target appears next to the user if they have an active account (all accounts are active by default) but have yet to confirm their email. This is replaced by a pink tick if email has been confirmed. The popups have also been changed to clarify the users status.

## Implications
Currently the email confirmation step is controlled by E12. This new work flow gives control for the email confirmation step to the user. 

The alternative solution would be to retain the current work flow but institute better messaging in the emails and on the login and password reset screen directing users who have not yet confirmed their accounts to contact E12 and ask for the account confirmation email to be resent. 

The only implications of this new proposed workflow are possibly that is a little less secure. In either situation, the only way an account could be created by a bad actor would be for them to intercept the emails or have access to the user's email account. The current workflow allows an E12 audit team member to have communication with the user wishing to confirm their account as an extra layer of security that they are happy the person is who they say they are. In the new work flow, a user that has access to an email address in the platform can reset the password and confirm the account in one step.

### Code changes

The standard django ResetPasswordForm has been subclassed and the `get_users` method has been overridden to return all users with a matching email, so long as they are active, whether they have useable passwords or not. This class is used by the reset password view.

Some wording changes to the emails sent have been made, and to the create user form.

### Related Issues

Closes #1039

