### PR TITLE
Fix the docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - live
-      - mbarton/fix-the-docs
 
 permissions:
   id-token: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - live
+      - mbarton/fix-the-docs
 
 permissions:
   id-token: write

--- a/epilepsy12/urls.py
+++ b/epilepsy12/urls.py
@@ -178,8 +178,7 @@ redirect_patterns = [
 ]
 
 home_page_patterns = [
-    path("", index, name="index"),
-    path("docs/", view=documentation, name="docs"),
+    path("", index, name="index")
 ]
 
 case_patterns = [

--- a/rcpch-audit-engine/wsgi.py
+++ b/rcpch-audit-engine/wsgi.py
@@ -16,5 +16,5 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'rcpch-audit-engine.settings')
 
 application = get_wsgi_application()
 
-application = WhiteNoise(application)
+application = WhiteNoise(application, index_file=True)
 application.add_files("/app/staticdocs", prefix="docs/")

--- a/rcpch-audit-engine/wsgi.py
+++ b/rcpch-audit-engine/wsgi.py
@@ -17,3 +17,4 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'rcpch-audit-engine.settings')
 application = get_wsgi_application()
 
 application = WhiteNoise(application)
+application.add_files("/app/staticdocs", prefix="docs/")

--- a/s/ci
+++ b/s/ci
@@ -14,6 +14,10 @@ az storage file download \
 # Burn in build info (git hash, branch etc) into the image
 s/get-build-info > build_info.json
 
+# Build the docs
+docker compose run mkdocs /bin/bash -c 'mkdocs build --config-file documentation/mkdocs.yml'
+
+# Build the app
 docker compose build
 
 # Tests (against local Postgres)
@@ -34,8 +38,8 @@ az containerapp revision copy \
     --query 'properties.provisioningState'
 
 # Deploy to production
-az containerapp revision copy \
-    --name ${AZURE_LIVE_APP_NAME} \
-    --resource-group ${AZURE_RESOURCE_GROUP} \
-    --image ${azure_tag} \
-    --query 'properties.provisioningState'
+# az containerapp revision copy \
+#     --name ${AZURE_LIVE_APP_NAME} \
+#     --resource-group ${AZURE_RESOURCE_GROUP} \
+#     --image ${azure_tag} \
+#     --query 'properties.provisioningState'

--- a/s/ci
+++ b/s/ci
@@ -41,8 +41,8 @@ az containerapp revision copy \
     --query 'properties.provisioningState'
 
 # Deploy to production
-# az containerapp revision copy \
-#     --name ${AZURE_LIVE_APP_NAME} \
-#     --resource-group ${AZURE_RESOURCE_GROUP} \
-#     --image ${azure_tag} \
-#     --query 'properties.provisioningState'
+az containerapp revision copy \
+    --name ${AZURE_LIVE_APP_NAME} \
+    --resource-group ${AZURE_RESOURCE_GROUP} \
+    --image ${azure_tag} \
+    --query 'properties.provisioningState'

--- a/s/ci
+++ b/s/ci
@@ -14,10 +14,13 @@ az storage file download \
 # Burn in build info (git hash, branch etc) into the image
 s/get-build-info > build_info.json
 
+# Build the app
+docker compose build
+
 # Build the docs
 docker compose run mkdocs /bin/bash -c 'mkdocs build --config-file documentation/mkdocs.yml'
 
-# Build the app
+# HOTFIX: Build again to embed the docs
 docker compose build
 
 # Tests (against local Postgres)

--- a/templates/epilepsy12/nav.html
+++ b/templates/epilepsy12/nav.html
@@ -66,7 +66,7 @@
 
         <a {% if request.resolver_match.url_name|is_in:'docs' %}class="active item" id="active_menu_item" {% else %} class="item" {% endif %}
         id="link"
-        href="{% url 'docs' %}">
+        href="/docs">
         Guidance
         </a>
 


### PR DESCRIPTION
When we migrated to Azure Container Apps (#1029) I forgot that the documentation was hosted via `mkdocs serve` and a special route in the Caddyfile. There was nothing in the new setup that reproduced this, so we fell back to the old iframe docs route which referenced a static site that no longer exists.

To put the docs back to how they were I've configured Whitenoise to serve them. Unfortunately this means we need to run `docker compose build` twice because we use the Django container to run mkdocs as we have plugins installed. In practice though all the base layers are already built so it's not much slower.

I've tested this by manually editing the GitHub deploy workflow to deploy to staging from this branch.