### PR TITLE
Skeleton page for the organisational audit

### DIFF
--- a/epilepsy12/tests/factories/seed_users.py
+++ b/epilepsy12/tests/factories/seed_users.py
@@ -40,39 +40,39 @@ def seed_users_fixture(django_db_setup, django_db_blocker):
     with django_db_blocker.unblock():
         # Don't repeat seed
         if not Epilepsy12User.objects.exists():
-            TEST_USER_ORGANISATION = Organisation.objects.get(
-                ods_code="RP401",
-                trust__ods_code="RP4",
-            )
+            GOSH = Organisation.objects.get(ods_code="RP401", trust__ods_code="RP4")
+            KINGS = Organisation.objects.get(ods_code="RJZ01", trust__ods_code="RJZ")
+            NOAHS_ARK = Organisation.objects.get(ods_code="7A4H1", local_health_board__ods_code="7A4")
 
-            is_active = True
-            is_staff = False
-            is_rcpch_audit_team_member = False
-            is_rcpch_staff = False
+            for org in [GOSH, KINGS, NOAHS_ARK]:
+                is_active = True
+                is_staff = False
+                is_rcpch_audit_team_member = False
+                is_rcpch_staff = False
 
-            # seed a user of each type at GOSH
-            for user in users:
-                first_name = user.role_str
+                # seed a user of each type
+                for user in users:
+                    first_name = user.role_str
 
-                # set RCPCH AUDIT TEAM MEMBER ATTRIBUTE
-                if user.role == RCPCH_AUDIT_TEAM:
-                    is_rcpch_audit_team_member = True
-                    is_rcpch_staff = True
+                    # set RCPCH AUDIT TEAM MEMBER ATTRIBUTE
+                    if user.role == RCPCH_AUDIT_TEAM:
+                        is_rcpch_audit_team_member = True
+                        is_rcpch_staff = True
 
-                if user.is_clinical_audit_team:
-                    is_rcpch_audit_team_member = True
-                    first_name = "CLINICAL_AUDIT_TEAM"
+                    if user.is_clinical_audit_team:
+                        is_rcpch_audit_team_member = True
+                        first_name = "CLINICAL_AUDIT_TEAM"
 
-                E12UserFactory(
-                    first_name=first_name,
-                    role=user.role,
-                    # Assign flags based on user role
-                    is_active=is_active,
-                    is_staff=is_staff,
-                    is_rcpch_audit_team_member=is_rcpch_audit_team_member,
-                    is_rcpch_staff=is_rcpch_staff,
-                    organisation_employer=TEST_USER_ORGANISATION,
-                    groups=[user.group_name],
-                )
+                    E12UserFactory(
+                        first_name=first_name,
+                        role=user.role,
+                        # Assign flags based on user role
+                        is_active=is_active,
+                        is_staff=is_staff,
+                        is_rcpch_audit_team_member=is_rcpch_audit_team_member,
+                        is_rcpch_staff=is_rcpch_staff,
+                        organisation_employer=org,
+                        groups=[user.group_name],
+                    )
         else:
             print("Test users already seeded. Skipping")

--- a/epilepsy12/tests/factories/seed_users.py
+++ b/epilepsy12/tests/factories/seed_users.py
@@ -52,7 +52,10 @@ def seed_users_fixture(django_db_setup, django_db_blocker):
 
                 # seed a user of each type
                 for user in users:
-                    first_name = user.role_str
+                    # HACK: a lot of tests assume there is only one organisation and so look up the user
+                    # user by name. To avoid changing all the tests, for GOSH only) set this as it was before
+                    # we added multiple organisations in test
+                    first_name = user.role_str if org == GOSH else f"{org.name}_{user.role_str}"
 
                     # set RCPCH AUDIT TEAM MEMBER ATTRIBUTE
                     if user.role == RCPCH_AUDIT_TEAM:
@@ -61,7 +64,7 @@ def seed_users_fixture(django_db_setup, django_db_blocker):
 
                     if user.is_clinical_audit_team:
                         is_rcpch_audit_team_member = True
-                        first_name = "CLINICAL_AUDIT_TEAM"
+                        first_name = "CLINICAL_AUDIT_TEAM" if org == GOSH else f"{org.name}_CLINICAL_AUDIT_TEAM"
 
                     E12UserFactory(
                         first_name=first_name,

--- a/epilepsy12/tests/view_tests/permissions_tests/test_permissions_organisational_audit.py
+++ b/epilepsy12/tests/view_tests/permissions_tests/test_permissions_organisational_audit.py
@@ -1,0 +1,23 @@
+def test_anonymous_user_cannot_access_organisational_audit():
+    raise Exception('not implemented yet')
+
+def test_clinicians_cannot_access_organisational_audit():
+    raise Exception('not implemented yet')
+
+def test_administrators_cannot_access_organisational_audit():
+    raise Exception('not implemented yet')
+
+def test_lead_clinician_can_access_organisational_audit_for_their_trust():
+    raise Exception('not implemented yet')
+
+def test_lead_clinician_cannot_access_organisational_audit_for_another_trust():
+    raise Exception('not implemented yet')
+
+def test_lead_clinician_cannot_access_organisational_audit_for_another_health_board():
+    raise Exception('not implemented yet')
+
+def test_rcpch_audit_team_can_access_organisational_audit_for_any_trust():
+    raise Exception('not implemented yet')
+
+def test_rcpch_audit_team_can_access_organisational_audit_for_any_health_board():
+    raise Exception('not implemented yet')

--- a/epilepsy12/tests/view_tests/permissions_tests/test_permissions_organisational_audit.py
+++ b/epilepsy12/tests/view_tests/permissions_tests/test_permissions_organisational_audit.py
@@ -11,7 +11,7 @@ from epilepsy12.tests.view_tests.permissions_tests.perm_tests_utils import twofa
     "local_health_board"
 ])
 def test_anonymous_user_cannot_access_organisational_audit(client, group):
-    response = client.get(reverse(f"organisational_audit_{group}", kwargs={ "id": 1 }))
+    response = client.get(reverse(f"organisational_audit_{group}", kwargs={ f"id": 1 }))
 
     assert(response.status_code == 302)
     assert(response.headers["Location"] == "/account/login/")
@@ -134,3 +134,25 @@ def test_rcpch_audit_team_can_access_all_organisational_audits(client, seed_grou
 
     response = client.get(reverse("organisational_audit_local_health_board", kwargs={ "id": noahs_ark_local_health_board.id }))
     assert(response.status_code == 200)
+
+
+@pytest.mark.django_db
+def test_organisational_audit_for_trust_that_doesnt_exist(client, seed_groups_fixture, seed_users_fixture):
+    rcpch_user = Epilepsy12User.objects.filter(is_rcpch_audit_team_member=True).first()
+
+    client.force_login(rcpch_user)
+    twofactor_signin(client, rcpch_user)
+
+    response = client.get(reverse("organisational_audit_trust", kwargs={ "id": 0 }))
+    assert(response.status_code == 404)
+
+
+@pytest.mark.django_db
+def test_organisational_audit_for_local_health_board_that_doesnt_exist(client, seed_groups_fixture, seed_users_fixture):
+    rcpch_user = Epilepsy12User.objects.filter(is_rcpch_audit_team_member=True).first()
+
+    client.force_login(rcpch_user)
+    twofactor_signin(client, rcpch_user)
+
+    response = client.get(reverse("organisational_audit_local_health_board", kwargs={ "id": 0 }))
+    assert(response.status_code == 404)

--- a/epilepsy12/tests/view_tests/permissions_tests/test_permissions_organisational_audit.py
+++ b/epilepsy12/tests/view_tests/permissions_tests/test_permissions_organisational_audit.py
@@ -1,23 +1,57 @@
-def test_anonymous_user_cannot_access_organisational_audit():
+import pytest
+
+from django.urls import reverse
+
+@pytest.mark.parametrize("group", [
+    pytest.param("trust", id = "Trust"),
+    pytest.param("health_board", id = "Health Board")
+])
+def test_anonymous_user_cannot_access_organisational_audit(client, group):
+    response = client.get(reverse(f"organisational_audit_{group}", kwargs={ "id": 1 }))
+
+    assert(response.status_code == 302)
+    assert(response.headers["Location"] == "/account/login/")
+
+
+@pytest.mark.parametrize("group,role", [
+    ("trust", "clinician"),
+    ("trust", "administrator"),
+    ("health_board", "clinician"),
+    ("health_board", "administrator")
+])
+def test_non_leads_cannot_access_organisational_audit_for_their_group(client, seed_groups_fixture, seed_users_fixture, group, role):
+    # user =  
+
     raise Exception('not implemented yet')
 
-def test_clinicians_cannot_access_organisational_audit():
+
+@pytest.mark.parametrize("group,role", [
+    ("trust", "clinician"),
+    ("trust", "administrator"),
+    ("health_board", "clinician"),
+    ("health_board", "administrator")
+])
+def test_non_leads_cannot_access_organisational_audit_for_another_group(seed_groups_fixture, seed_users_fixture, group, role):
+    # user =  
+
     raise Exception('not implemented yet')
 
-def test_administrators_cannot_access_organisational_audit():
-    raise Exception('not implemented yet')
 
 def test_lead_clinician_can_access_organisational_audit_for_their_trust():
     raise Exception('not implemented yet')
 
+
 def test_lead_clinician_cannot_access_organisational_audit_for_another_trust():
     raise Exception('not implemented yet')
+
 
 def test_lead_clinician_cannot_access_organisational_audit_for_another_health_board():
     raise Exception('not implemented yet')
 
+
 def test_rcpch_audit_team_can_access_organisational_audit_for_any_trust():
     raise Exception('not implemented yet')
+
 
 def test_rcpch_audit_team_can_access_organisational_audit_for_any_health_board():
     raise Exception('not implemented yet')

--- a/epilepsy12/tests/view_tests/permissions_tests/test_permissions_organisational_audit.py
+++ b/epilepsy12/tests/view_tests/permissions_tests/test_permissions_organisational_audit.py
@@ -2,9 +2,13 @@ import pytest
 
 from django.urls import reverse
 
+from epilepsy12.models import Organisation, Epilepsy12User
+from epilepsy12.constants import AUDIT_CENTRE_CLINICIAN, AUDIT_CENTRE_ADMINISTRATOR, AUDIT_CENTRE_LEAD_CLINICIAN, RCPCH_AUDIT_TEAM
+from epilepsy12.tests.view_tests.permissions_tests.perm_tests_utils import twofactor_signin
+
 @pytest.mark.parametrize("group", [
-    pytest.param("trust", id = "Trust"),
-    pytest.param("health_board", id = "Health Board")
+    "trust",
+    "local_health_board"
 ])
 def test_anonymous_user_cannot_access_organisational_audit(client, group):
     response = client.get(reverse(f"organisational_audit_{group}", kwargs={ "id": 1 }))
@@ -13,45 +17,112 @@ def test_anonymous_user_cannot_access_organisational_audit(client, group):
     assert(response.headers["Location"] == "/account/login/")
 
 
-@pytest.mark.parametrize("group,role", [
-    ("trust", "clinician"),
-    ("trust", "administrator"),
-    ("health_board", "clinician"),
-    ("health_board", "administrator")
+@pytest.mark.parametrize("role", [
+    pytest.param(AUDIT_CENTRE_CLINICIAN, id="clinican"),
+    pytest.param(AUDIT_CENTRE_ADMINISTRATOR, id="administrator")
 ])
-def test_non_leads_cannot_access_organisational_audit_for_their_group(client, seed_groups_fixture, seed_users_fixture, group, role):
-    # user =  
+@pytest.mark.django_db
+def test_non_leads_cannot_access_organisational_audit_for_their_trust(client, seed_groups_fixture, seed_users_fixture, role):
+    gosh_org = Organisation.objects.get(ods_code="RP401")
+    gosh_user = Epilepsy12User.objects.get(role=role, organisation_employer__ods_code="RP401")
 
-    raise Exception('not implemented yet')
+    client.force_login(gosh_user)
+    twofactor_signin(client, gosh_user)
+
+    response = client.get(reverse("organisational_audit_trust", kwargs={ "id": gosh_org.id }))
+    assert(response.status_code == 403)
 
 
-@pytest.mark.parametrize("group,role", [
-    ("trust", "clinician"),
-    ("trust", "administrator"),
-    ("health_board", "clinician"),
-    ("health_board", "administrator")
+@pytest.mark.parametrize("role", [
+    pytest.param(AUDIT_CENTRE_CLINICIAN, id="clinican"),
+    pytest.param(AUDIT_CENTRE_ADMINISTRATOR, id="administrator")
 ])
-def test_non_leads_cannot_access_organisational_audit_for_another_group(seed_groups_fixture, seed_users_fixture, group, role):
-    # user =  
+@pytest.mark.django_db
+def test_non_leads_cannot_access_organisational_audit_for_their_local_health_board(client, seed_groups_fixture, seed_users_fixture, role):
+    noahs_ark_org = Organisation.objects.get(ods_code="7A4H1")
+    noahs_ark_user = Epilepsy12User.objects.get(role=role, organisation_employer__ods_code="7A4H1")
 
-    raise Exception('not implemented yet')
+    client.force_login(noahs_ark_user)
+    twofactor_signin(client, noahs_ark_user)
 
-
-def test_lead_clinician_can_access_organisational_audit_for_their_trust():
-    raise Exception('not implemented yet')
-
-
-def test_lead_clinician_cannot_access_organisational_audit_for_another_trust():
-    raise Exception('not implemented yet')
+    response = client.get(reverse("organisational_audit_local_health_board", kwargs={ "id": noahs_ark_org.id }))
+    assert(response.status_code == 403)
 
 
-def test_lead_clinician_cannot_access_organisational_audit_for_another_health_board():
-    raise Exception('not implemented yet')
+@pytest.mark.django_db
+def test_lead_clinician_can_access_organisational_audit_for_their_trust(client, seed_groups_fixture, seed_users_fixture):
+    gosh_org = Organisation.objects.get(ods_code="RP401")
+    gosh_user = Epilepsy12User.objects.filter(role=AUDIT_CENTRE_LEAD_CLINICIAN, organisation_employer__ods_code="RP401").first()
+
+    client.force_login(gosh_user)
+    twofactor_signin(client, gosh_user)
+
+    response = client.get(reverse("organisational_audit_trust", kwargs={ "id": gosh_org.id }))
+    assert(response.status_code == 200)
 
 
-def test_rcpch_audit_team_can_access_organisational_audit_for_any_trust():
-    raise Exception('not implemented yet')
+@pytest.mark.django_db
+def test_lead_clinician_can_access_organisational_audit_for_their_local_health_board(client, seed_groups_fixture, seed_users_fixture):
+    noahs_ark_org = Organisation.objects.get(ods_code="7A4H1")
+    noahs_ark_user = Epilepsy12User.objects.filter(role=AUDIT_CENTRE_LEAD_CLINICIAN, organisation_employer__ods_code="7A4H1").first()
+
+    client.force_login(noahs_ark_user)
+    twofactor_signin(client, noahs_ark_user)
+
+    response = client.get(reverse("organisational_audit_local_health_board", kwargs={ "id": noahs_ark_org.id }))
+    assert(response.status_code == 403)
 
 
-def test_rcpch_audit_team_can_access_organisational_audit_for_any_health_board():
-    raise Exception('not implemented yet')
+@pytest.mark.parametrize("role", [
+    pytest.param(AUDIT_CENTRE_CLINICIAN, id="clinican"),
+    pytest.param(AUDIT_CENTRE_ADMINISTRATOR, id="administrator"),
+    pytest.param(AUDIT_CENTRE_LEAD_CLINICIAN, id="lead_clinician")
+])
+@pytest.mark.django_db
+def test_users_cannot_access_organisational_audit_for_a_trust_that_isnt_theirs(client, seed_groups_fixture, seed_users_fixture, role):
+    gosh_org = Organisation.objects.get(ods_code="RP401")
+    gosh_user = Epilepsy12User.objects.filter(role=role, organisation_employer__ods_code="RP401").first()
+
+    client.force_login(gosh_user)
+    twofactor_signin(client, gosh_user)
+
+    kings_org = Organisation.objects.get(ods_code="RJZ01")
+
+    response = client.get(reverse("organisational_audit_trust", kwargs={ "id": kings_org.id }))
+    assert(response.status_code == 403)
+
+
+@pytest.mark.parametrize("role", [
+    pytest.param(AUDIT_CENTRE_CLINICIAN, id="clinican"),
+    pytest.param(AUDIT_CENTRE_ADMINISTRATOR, id="administrator"),
+    pytest.param(AUDIT_CENTRE_LEAD_CLINICIAN, id="lead_clinician")
+])
+@pytest.mark.django_db
+def test_users_cannot_access_organisational_audit_for_a_local_health_board_that_isnt_theirs(client, seed_groups_fixture, seed_users_fixture, role):
+    gosh_org = Organisation.objects.get(ods_code="RP401")
+    gosh_user = Epilepsy12User.objects.filter(role=role, organisation_employer__ods_code="RP401").first()
+
+    client.force_login(gosh_user)
+    twofactor_signin(client, gosh_user)
+
+    noahs_ark_org = Organisation.objects.get(ods_code="7A4H1")
+
+    response = client.get(reverse("organisational_audit_local_health_board", kwargs={ "id": noahs_ark_org.id }))
+    assert(response.status_code == 403)
+
+
+@pytest.mark.django_db
+def test_rcpch_audit_team_can_access_all_organisational_audits(client, seed_groups_fixture, seed_users_fixture):
+    rcpch_user = Epilepsy12User.objects.filter(role=RCPCH_AUDIT_TEAM).first()
+
+    client.force_login(rcpch_user)
+    twofactor_signin(client, rcpch_user)
+
+    gosh_org = Organisation.objects.get(ods_code="RP401")
+    noahs_ark_org = Organisation.objects.get(ods_code="7A4H1")
+
+    response = client.get(reverse("organisational_audit_trust", kwargs={ "id": gosh_org.id }))
+    assert(response.status_code == 200)
+
+    response = client.get(reverse("organisational_audit_local_health_board", kwargs={ "id": noahs_ark_org.id }))
+    assert(response.status_code == 200)

--- a/epilepsy12/tests/view_tests/permissions_tests/test_permissions_view.py
+++ b/epilepsy12/tests/view_tests/permissions_tests/test_permissions_view.py
@@ -248,7 +248,9 @@ def test_users_and_case_list_views_permissions_success(
         trust__ods_code="RGT",
     )
 
-    users = Epilepsy12User.objects.all()
+    users = Epilepsy12User.objects.filter(
+        organisation_employer__ods_code="RP401"
+    )
 
     for test_user in users:
         # Log in Test User
@@ -363,7 +365,9 @@ def test_registration_view_permissions_success(client):
         first_name=f"child_{TEST_USER_ORGANISATION.name}"
     )
 
-    users = Epilepsy12User.objects.all()
+    users = Epilepsy12User.objects.filter(
+        organisation_employer__ods_code="RP401"
+    )
 
     for test_user in users:
         client.force_login(test_user)
@@ -470,7 +474,9 @@ def test_episode_syndrome_aem_view_permissions_success(client):
         first_name=f"child_{TEST_USER_ORGANISATION.name}"
     )
 
-    users = Epilepsy12User.objects.all()
+    users = Epilepsy12User.objects.filter(
+        organisation_employer__ods_code="RP401"
+    )
 
     # Create objs to search for
     episode = Episode.objects.create(
@@ -756,7 +762,9 @@ def test_comborbidity_view_permissions_success(client, URL):
         ).first(),
     )
 
-    users = Epilepsy12User.objects.all()
+    users = Epilepsy12User.objects.filter(
+        organisation_employer__ods_code="RP401"
+    )
 
     for test_user in users:
         client.force_login(test_user)
@@ -915,7 +923,9 @@ def test_multiple_views_permissions_success(client):
         first_name=f"child_{TEST_USER_ORGANISATION.name}"
     )
 
-    users = Epilepsy12User.objects.all()
+    users = Epilepsy12User.objects.filter(
+        organisation_employer__ods_code="RP401"
+    )
 
     for test_user in users:
         client.force_login(test_user)

--- a/epilepsy12/tests/view_tests/permissions_tests/test_perms_download_e12users_list.py
+++ b/epilepsy12/tests/view_tests/permissions_tests/test_perms_download_e12users_list.py
@@ -51,7 +51,7 @@ def test_download_button_access(
                 kwargs={"organisation_id": TEST_USER_ORGANISATION.id},
             )
         )
-        if test_user.first_name == test_user_rcpch_audit_team_data.role_str:
+        if test_user.first_name.endswith(test_user_rcpch_audit_team_data.role_str):
             
             print(response)
             assert (

--- a/epilepsy12/urls.py
+++ b/epilepsy12/urls.py
@@ -1062,7 +1062,7 @@ antiepilepsy_medicine_patterns = [
 
 organisational_audit_patterns = [
     path("trust/<int:id>/audit/", view=organisational_audit, name="organisational_audit_trust"),
-    path("health_board/<int:id>/audit/", view=organisational_audit, name="organisational_audit_health_board"),
+    path("local_health_board/<int:id>/audit/", view=organisational_audit, name="organisational_audit_local_health_board"),
 ]
 
 urlpatterns = []

--- a/epilepsy12/urls.py
+++ b/epilepsy12/urls.py
@@ -1061,8 +1061,8 @@ antiepilepsy_medicine_patterns = [
 ]
 
 organisational_audit_patterns = [
-    path("trust/<int:id>/audit/", view=organisational_audit, name="organisational_audit"),
-    path("health_board/<int:id>/audit/", view=organisational_audit, name="organisational_audit"),
+    path("trust/<int:id>/audit/", view=organisational_audit, name="organisational_audit_trust"),
+    path("health_board/<int:id>/audit/", view=organisational_audit, name="organisational_audit_health_board"),
 ]
 
 urlpatterns = []

--- a/epilepsy12/urls.py
+++ b/epilepsy12/urls.py
@@ -1060,6 +1060,10 @@ antiepilepsy_medicine_patterns = [
     ),
 ]
 
+organisational_audit_patterns = [
+    path("trust/<int:id>/audit/", view=organisational_audit, name="organisational_audit"),
+    path("health_board/<int:id>/audit/", view=organisational_audit, name="organisational_audit"),
+]
 
 urlpatterns = []
 
@@ -1092,6 +1096,7 @@ urlpatterns += epilepsy_causes_patterns
 urlpatterns += comorbidities_patterns
 urlpatterns += registration_patterns
 urlpatterns += antiepilepsy_medicine_patterns
+urlpatterns += organisational_audit_patterns
 
 # This is related to the DRF
 # urlpatterns += drf_routes

--- a/epilepsy12/urls.py
+++ b/epilepsy12/urls.py
@@ -1061,8 +1061,8 @@ antiepilepsy_medicine_patterns = [
 ]
 
 organisational_audit_patterns = [
-    path("trust/<int:id>/audit/", view=organisational_audit, name="organisational_audit_trust"),
-    path("local_health_board/<int:id>/audit/", view=organisational_audit, name="organisational_audit_local_health_board"),
+    path("trust/<int:id>/audit/", view=organisational_audit_trust, name="organisational_audit_trust"),
+    path("local_health_board/<int:id>/audit/", view=organisational_audit_local_health_board, name="organisational_audit_local_health_board"),
 ]
 
 urlpatterns = []

--- a/epilepsy12/views/__init__.py
+++ b/epilepsy12/views/__init__.py
@@ -13,3 +13,4 @@ from .route_views import *
 from .redirects import *
 from .htmx_globals import *
 from .api import *
+from .organisational_audit_views import *

--- a/epilepsy12/views/organisational_audit_views.py
+++ b/epilepsy12/views/organisational_audit_views.py
@@ -2,10 +2,19 @@ from django.shortcuts import render
 
 from ..decorator import (
     login_and_otp_required,
+    user_may_view_organisational_audit
 )
 
 @login_and_otp_required()
-def organisational_audit(request, id):
+@user_may_view_organisational_audit("trust")
+def organisational_audit_trust(request, id):
+    context = {}
+    template_name = "epilepsy12/organisational_audit.html"
+    return render(request, template_name, context)
+
+@login_and_otp_required()
+@user_may_view_organisational_audit("local_health_board")
+def organisational_audit_local_health_board(request, id):
     context = {}
     template_name = "epilepsy12/organisational_audit.html"
     return render(request, template_name, context)

--- a/epilepsy12/views/organisational_audit_views.py
+++ b/epilepsy12/views/organisational_audit_views.py
@@ -1,19 +1,21 @@
 from django.shortcuts import render
 
+from ..models import Trust, LocalHealthBoard
+
 from ..decorator import (
     login_and_otp_required,
     user_may_view_organisational_audit
 )
 
 @login_and_otp_required()
-@user_may_view_organisational_audit("trust")
+@user_may_view_organisational_audit(Trust, "trust")
 def organisational_audit_trust(request, id):
     context = {}
     template_name = "epilepsy12/organisational_audit.html"
     return render(request, template_name, context)
 
 @login_and_otp_required()
-@user_may_view_organisational_audit("local_health_board")
+@user_may_view_organisational_audit(LocalHealthBoard, "local_health_board")
 def organisational_audit_local_health_board(request, id):
     context = {}
     template_name = "epilepsy12/organisational_audit.html"

--- a/epilepsy12/views/organisational_audit_views.py
+++ b/epilepsy12/views/organisational_audit_views.py
@@ -1,0 +1,11 @@
+from django.shortcuts import render
+
+from ..decorator import (
+    login_and_otp_required,
+)
+
+@login_and_otp_required()
+def organisational_audit(request, id):
+    context = {}
+    template_name = "epilepsy12/organisational_audit.html"
+    return render(request, template_name, context)

--- a/epilepsy12/views/redirects.py
+++ b/epilepsy12/views/redirects.py
@@ -52,7 +52,7 @@ def redirect_403(request):
 def rcpch_404(request, exception):
     # return the custom 404 template. There is no context to add.
     return render(
-        request, template_name="epilepsy12/error_pages/rcpch_404.html", context={}
+        request, template_name="epilepsy12/error_pages/rcpch_404.html", status=404, context={}
     )
 
 

--- a/templates/epilepsy12/organisational_audit.html
+++ b/templates/epilepsy12/organisational_audit.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}  
+{% block content %}
+<div class="ui rcpch container main_content">
+    <h2>It lives!</h2>
+</div>
+{% endblock %}

--- a/templates/epilepsy12/organisational_audit.html
+++ b/templates/epilepsy12/organisational_audit.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}  
 {% block content %}
 <div class="ui rcpch container main_content">
-    <h2>It lives!</h2>
+    <h2>This is a placeholder page for the organisational audit form</h2>
 </div>
 {% endblock %}


### PR DESCRIPTION
Part of #876 

Our existing URL patterns start `organisation/:id`. As the organisational audit is done at the trust and local health board (Wales) level I've added new top level groupings:

- `trust/:id/audit`
- `local_health_board/:id/audit`

The actual page itself just has placeholder text. It does have visibility checking however - to see the page you must be a Lead Clinican at your trust or health board or an RCPCH audit team member.

We don't signpost the page anywhere at the moment, you need to know the URL. So it's safe to merge this to live.

Future PRs will actually implement the audit!