### PR TITLE
Bug fixes for progress tracking

### DIFF
--- a/static/styles/organisational-audit.css
+++ b/static/styles/organisational-audit.css
@@ -67,7 +67,22 @@
     padding: 1em;
 }
 
-.left-progress {
-    display: flex;
-    align-items: start;
+.org-audit-header {
+    margin: 0 0 1em 0;
+    position: absolute;
+}
+
+.org-audit-progress {
+    position: sticky;
+    top: 0;
+    z-index: 999;
+    text-align: right;
+    padding-bottom: 5em;
+}
+
+.org-audit-progress--label {
+    background-color: var(--rcpch_purple_dark_tint);
+    color: white;
+    padding: 1em;
+    float: right;
 }

--- a/templates/epilepsy12/organisational_audit.html
+++ b/templates/epilepsy12/organisational_audit.html
@@ -2,12 +2,12 @@
 {% block content %}
 <div class="ui rcpch container main_content">
     {% if submission_period %}
-    <h2>Organisational Audit {{submission_period.year}} - {{group_name}}</h2>
+        <h2 class="org-audit-header">Organisational Audit {{submission_period.year}} - {{group_name}}</h2>
         <form class="ui rcpch form" method="POST" hx-post="{{ request.path }}" hx-trigger="input delay:0.5s">
             {% include 'epilepsy12/partials/organisational_audit_form.html' %}
         </form>
     {% else %}
-        <h2>Organisational Audit - {{group_name}}</h2>
+        <h2 class="org-audit-header">Organisational Audit - {{group_name}}</h2>
         <div class="ui rcpch_info icon message">
             <i class="info icon"></i>
             The organisational audit is not currently open for submissions

--- a/templates/epilepsy12/partials/organisational_audit_form.html
+++ b/templates/epilepsy12/partials/organisational_audit_form.html
@@ -1,11 +1,15 @@
 {% load epilepsy12_template_tags %}
 
 {% csrf_token %}
+
+<div class="org-audit-progress">
+    <div class="org-audit-progress--label">
+        {{number_completed}} of {{total_questions}} complete
+    </div>
+</div>
+
 {% for section, questions in questions_by_section.items %}
     <div>
-        <div class="left-progress">
-            {% include 'epilepsy12/partials/charts/progress.html' with numerator=number_completed denominator=total_questions percentage=percentage_completed title="Progress" pie_size='small' %}
-        </div>
         <h3 class="org-audit-section-title">
             {{section}}
         </h3>
@@ -26,7 +30,7 @@
                                     <span data-tooltip="Scored field">
                                         <i class="rcpch_pink check circle outline icon"></i>
                                     </span>
-                                {% else %}
+                                {% elif "completed" in parent %}
                                     <span data-tooltip="Unscored field">
                                         <i class="rcpch_light_blue dot circle outline icon"></i>
                                     </span>


### PR DESCRIPTION
Follow up to #1058 

![Screenshot 2024-10-08 11 56 25](https://github.com/user-attachments/assets/2f146088-7b85-48b8-8442-833b9f798f68)

- Show progress sticky
- The question total is only the visible questions
- Don't show generated parent questions (eg 3.5) as incomplete
- Don't show "No" as incomplete
- Don't crash if no submission exists
