### PR TITLE
Download organisational audit submissions as CSV

### DIFF
--- a/epilepsy12/admin.py
+++ b/epilepsy12/admin.py
@@ -1,6 +1,7 @@
 from typing import Any
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
+from django.http import HttpResponse
 from simple_history.admin import SimpleHistoryAdmin
 
 # Register your models here.
@@ -115,6 +116,17 @@ class CaseAdmin(SimpleHistoryAdmin):
     search_fields = ["first_name", "surname", "nhs_number", "date_of_birth"]
 
 
+class OrganisationalAuditSubmissionPeriodAdmin(SimpleHistoryAdmin):
+    actions = ["download"]
+
+    @admin.action(description="Download submissions as CSV")
+    def download(self, request, queryset):
+        response = HttpResponse("", content_type="text/csv")
+        response['Content-Disposition']="attachment; filename=org-audit-export.csv"
+
+        return response
+
+
 admin.site.register(Epilepsy12User, Epilepsy12UserAdmin)
 admin.site.register(AntiEpilepsyMedicine, SimpleHistoryAdmin)
 admin.site.register(Assessment, SimpleHistoryAdmin)
@@ -159,7 +171,7 @@ admin.site.register(LocalHealthBoard)
 admin.site.register(OPENUKNetwork)
 
 admin.site.register(OrganisationalAuditSubmission)
-admin.site.register(OrganisationalAuditSubmissionPeriod)
+admin.site.register(OrganisationalAuditSubmissionPeriod, OrganisationalAuditSubmissionPeriodAdmin)
 
 admin.site.site_header = "Epilepsy12 admin"
 admin.site.site_title = "Epilepsy12 admin"

--- a/epilepsy12/admin.py
+++ b/epilepsy12/admin.py
@@ -5,6 +5,8 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from simple_history.admin import SimpleHistoryAdmin
 
+import pandas as pd
+
 # Register your models here.
 from .models import *
 from .organisational_audit import export_submission_period_as_csv
@@ -129,9 +131,13 @@ class OrganisationalAuditSubmissionPeriodAdmin(SimpleHistoryAdmin):
             submission_period = queryset.first()
             
             filename = f"e12-org-audit-{submission_period.year}.csv"
-            data = export_submission_period_as_csv(submission_period)
+            
+            rows = export_submission_period_as_csv(submission_period)
+            data = pd.DataFrame.from_dict(rows).to_csv(index=False)
 
-            response = HttpResponse("", content_type="text/csv")
+            print(f"!! {data}")
+
+            response = HttpResponse(data, content_type="text/csv")
             response['Content-Disposition'] = f"attachment; filename={filename}"
 
             return response

--- a/epilepsy12/admin.py
+++ b/epilepsy12/admin.py
@@ -5,8 +5,6 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from simple_history.admin import SimpleHistoryAdmin
 
-import pandas as pd
-
 # Register your models here.
 from .models import *
 from .organisational_audit import export_submission_period_as_csv
@@ -132,10 +130,7 @@ class OrganisationalAuditSubmissionPeriodAdmin(SimpleHistoryAdmin):
             
             filename = f"e12-org-audit-{submission_period.year}.csv"
             
-            rows = export_submission_period_as_csv(submission_period)
-            data = pd.DataFrame.from_dict(rows).to_csv(index=False)
-
-            print(f"!! {data}")
+            data = export_submission_period_as_csv(submission_period)
 
             response = HttpResponse(data, content_type="text/csv")
             response['Content-Disposition'] = f"attachment; filename={filename}"

--- a/epilepsy12/admin.py
+++ b/epilepsy12/admin.py
@@ -118,6 +118,10 @@ class CaseAdmin(SimpleHistoryAdmin):
     search_fields = ["first_name", "surname", "nhs_number", "date_of_birth"]
 
 
+class OrganisationalAuditSubmissionAdmin(SimpleHistoryAdmin):
+    search_fields = ["trust__name", "local_health_board__name", "trust__ods_code", "local_health_board__ods_code"]
+    list_filter = ["submission_period"]
+
 class OrganisationalAuditSubmissionPeriodAdmin(SimpleHistoryAdmin):
     actions = ["download"]
 
@@ -181,7 +185,7 @@ admin.site.register(Trust)
 admin.site.register(LocalHealthBoard)
 admin.site.register(OPENUKNetwork)
 
-admin.site.register(OrganisationalAuditSubmission)
+admin.site.register(OrganisationalAuditSubmission, OrganisationalAuditSubmissionAdmin)
 admin.site.register(OrganisationalAuditSubmissionPeriod, OrganisationalAuditSubmissionPeriodAdmin)
 
 admin.site.site_header = "Epilepsy12 admin"

--- a/epilepsy12/management/commands/import_org_audit_submissions.py
+++ b/epilepsy12/management/commands/import_org_audit_submissions.py
@@ -1,5 +1,3 @@
-import pandas as pd
-
 from django.core.management.base import BaseCommand
 from ...epilepsy12.organisational_audit import import_submissions_from_csv
 
@@ -24,11 +22,10 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         file = options["file"]
-        data = pd.read_csv(file)
 
         submission_period = OrganisationalAuditSubmissionPeriod.objects.get(
             id=options["submission_period"]
         )
 
-        import_submissions_from_csv(submission_period, data)
+        import_submissions_from_csv(submission_period, file)
             

--- a/epilepsy12/management/commands/import_org_audit_submissions.py
+++ b/epilepsy12/management/commands/import_org_audit_submissions.py
@@ -1,5 +1,7 @@
 from django.core.management.base import BaseCommand
-from ...epilepsy12.organisational_audit import import_submissions_from_csv
+
+from ...models import OrganisationalAuditSubmissionPeriod
+from ...organisational_audit import import_submissions_from_csv
 
 class Command(BaseCommand):
     help = "Import organisational audit submissions from CSV export"

--- a/epilepsy12/management/commands/import_org_audit_submissions.py
+++ b/epilepsy12/management/commands/import_org_audit_submissions.py
@@ -1,21 +1,7 @@
 import pandas as pd
 
 from django.core.management.base import BaseCommand
-from django.forms.fields import TypedChoiceField
-
-from multiselectfield.forms.fields import MultiSelectFormField 
-
-from ...models import (
-    OrganisationalAuditSubmissionPeriod,
-    OrganisationalAuditSubmission,
-    Trust,
-    LocalHealthBoard
-)
-
-from ...forms_folder import OrganisationalAuditSubmissionForm
-
-def adapt_multiselect_field(row, choices_to_column):
-    return [key for key, value in choices_to_column.items() if row[value] == 1]
+from ...epilepsy12.organisational_audit import import_submissions_from_csv
 
 class Command(BaseCommand):
     help = "Import organisational audit submissions from CSV export"
@@ -44,111 +30,5 @@ class Command(BaseCommand):
             id=options["submission_period"]
         )
 
-        for _, row in data.iterrows():
-            ods_code = row["SiteCode"]
-
-            submission = OrganisationalAuditSubmission()
-            submission.submission_period = submission_period
-
-            try:
-                submission.trust = Trust.objects.get(ods_code=row["SiteCode"])
-            except Trust.DoesNotExist:
-                submission.local_health_board = LocalHealthBoard.objects.get(ods_code=row["SiteCode"])
-            
-            field_types = { field.name: type(field.field) for field in OrganisationalAuditSubmissionForm() }
-
-            #######################
-            # Single value fields #
-            #######################
-
-            for column, raw_value in row.to_dict().items():
-                if column in field_types and field_types[column] is not MultiSelectFormField:
-                    value = None if pd.isnull(raw_value) else raw_value
-
-                    # Special case - choice fields need integer values not decimal
-                    if type(value) == float and field_types[column] == TypedChoiceField:
-                        value = int(value)
-
-                    # Special case - NA parses as NaN
-                    if column == "S02TFC223" and pd.isna(raw_value):
-                        value = 'NA'
-
-                    setattr(submission, column, value)
-
-            ######################
-            # Multiselect fields #
-            ######################      
-
-            submission.S01ESNFunctions = adapt_multiselect_field(row, {
-                1: 'S01ESNEDVisit',
-                2: 'S01ESNHomeVisit',
-                3: 'S01ESNIndividualHealthcare',
-                4: 'S01ESNNurseLedClinic',
-                5: 'S01ESNNursePrescribing',
-                6: 'S01ESNRescueMedicationParent',
-                7: 'S01ESNRescueMedicationSchool',
-                8: 'S01ESNSchoolMeetings',
-                9: 'S01ESNWardVisits',
-                10: 'S01ESNNoneOfTheAbove'
-            })
-
-            submission.S06ProfessionalsRoutinelyInvolvedInTransition = adapt_multiselect_field(row, {
-                1: 'S06ProfessionalsRoutinelyInvolvedInTransitionAdultESN',
-                2: 'S06ProfessionalsRoutinelyInvolvedInTransitionAdultLDESN',
-                3: 'S06ProfessionalsRoutinelyInvolvedInTransitionAdultNeuro',
-                4: 'S06ProfessionalsRoutinelyInvolvedInTransitionYouthWorker',
-                5: 'S06ProfessionalsRoutinelyInvolvedInTransitionOther'
-                # The other free text field is handled as a normal single value field earlier
-            })
-
-            # TODO MRB: should there be an explicit none option?
-            submission.S07MentalHealthQuestionnaire = adapt_multiselect_field(row, {
-                1: 'S07MentalHealthQuestionnaireBDI',
-                2: "S07MentalHealthQuestionnaireConnors",
-                3: 'S07MentalHealthQuestionnaireETT',
-                4: 'S07MentalHealthQuestionnaireGAD',
-                5: 'S07MentalHealthQuestionnaireGAD2',
-                6: 'S07MentalHealthQuestionnaireGAD7',
-                7: 'S07MentalHealthQuestionnaireHADS',
-                8: 'S07MentalHealthQuestionnaireMFQ',
-                9: 'S07MentalHealthQuestionnaireNDDI',
-                10: 'S07MentalHealthQuestionnairePHQ',
-                11: 'S07MentalHealthQuestionnaireSDQ',
-                12: 'S07MentalHealthQuestionnaireOther'
-            })
-
-            submission.S07MentalHealthAgreedPathway = adapt_multiselect_field(row, {
-                1: 'S07MentalHealthAgreedPathwayAnxiety',
-                # 2: 'S07MentalHealthAgreedPathwayDepression' doesn't appear to have a corresponding column in the CSV,
-                3: 'S07MentalHealthAgreedPathwayMoodDisorders',
-                4: 'S07MentalHealthAgreedPathwayNonEpilepticAttackDisorders',
-                5: 'S07MentalHealthAgreedPathwayOtherDetails'
-            })
-
-            submission.S07DoesThisComprise = adapt_multiselect_field(row, {
-                1: 'S07DoesThisCompriseEpilepsyClinics',
-                2: 'S07DoesThisCompriseMDT',
-                3: 'S07DoesThisCompriseOther'
-            })
-
-            submission.S07TrustAchieve = adapt_multiselect_field(row, {
-                1: 'S07TrustAchieveClinicalPsychology',
-                2: 'S07TrustAchieveEducationalPsychology',
-                3: 'S07TrustAchieveFormalDevelopmental',
-                4: 'S07TrustAchieveNeuropyschology',
-                5: 'S07TrustAchievePsychiatricAssessment',
-                6: 'S07TrustAchieveNone'
-            })
-
-            submission.S08AgreedReferralCriteriaChildrenNeurodevelopmental = adapt_multiselect_field(row, {
-                1: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalADHD',
-                2: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalASD',
-                3: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalBehaviour',
-                4: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalDCD',
-                5: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalIntellectualDisability',
-                6: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalLearningDisabilities',
-                7: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalOtherDetails'
-            })
-
-            submission.save()
+        import_submissions_from_csv(submission_period, data)
             

--- a/epilepsy12/models_folder/organisational_audit.py
+++ b/epilepsy12/models_folder/organisational_audit.py
@@ -65,6 +65,9 @@ class OrganisationalAuditSubmission(TimeStampAbstractBaseClass, UserStampAbstrac
     def _history_user(self, value):
         self.updated_by = value
 
+    def __str__(self) -> str:
+        return f"Organisational Audit Submission for {self.trust or self.local_health_board} in {self.submission_period.year}"
+
     # These field names mostly match the CSV export format from the old system for convenience
 
     # 1. Workforce

--- a/epilepsy12/organisational_audit.py
+++ b/epilepsy12/organisational_audit.py
@@ -5,7 +5,6 @@ from django.forms.fields import TypedChoiceField
 from multiselectfield.forms.fields import MultiSelectFormField 
 
 from .models import (
-    OrganisationalAuditSubmissionPeriod,
     OrganisationalAuditSubmission,
     Trust,
     LocalHealthBoard

--- a/epilepsy12/organisational_audit.py
+++ b/epilepsy12/organisational_audit.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from django.forms.fields import TypedChoiceField
 
 from multiselectfield.forms.fields import MultiSelectFormField 
@@ -11,11 +13,79 @@ from .models import (
 
 from .forms_folder import OrganisationalAuditSubmissionForm
 
+MULTISELECT_FIELD_MAPPINGS = {
+    'S01ESNFunctions': {
+        "1": 'S01ESNEDVisit',
+        "2": 'S01ESNHomeVisit',
+        "3": 'S01ESNIndividualHealthcare',
+        "4": 'S01ESNNurseLedClinic',
+        "5": 'S01ESNNursePrescribing',
+        "6": 'S01ESNRescueMedicationParent',
+        "7": 'S01ESNRescueMedicationSchool',
+        "8": 'S01ESNSchoolMeetings',
+        "9": 'S01ESNWardVisits',
+        "10": 'S01ESNNoneOfTheAbove'
+    },
+    'S06ProfessionalsRoutinelyInvolvedInTransition': {
+        "1": 'S06ProfessionalsRoutinelyInvolvedInTransitionAdultESN',
+        "2": 'S06ProfessionalsRoutinelyInvolvedInTransitionAdultLDESN',
+        "3": 'S06ProfessionalsRoutinelyInvolvedInTransitionAdultNeuro',
+        "4": 'S06ProfessionalsRoutinelyInvolvedInTransitionYouthWorker',
+        "5": 'S06ProfessionalsRoutinelyInvolvedInTransitionOther'
+        # The "other" free text field is handled as a normal single value field
+    },
+    # TODO MRB: should there be an explicit none option?
+    'S07MentalHealthQuestionnaire': {
+        "1": 'S07MentalHealthQuestionnaireBDI',
+        "2": "S07MentalHealthQuestionnaireConnors",
+        "3": 'S07MentalHealthQuestionnaireETT',
+        "4": 'S07MentalHealthQuestionnaireGAD',
+        "5": 'S07MentalHealthQuestionnaireGAD2',
+        "6": 'S07MentalHealthQuestionnaireGAD7',
+        "7": 'S07MentalHealthQuestionnaireHADS',
+        "8": 'S07MentalHealthQuestionnaireMFQ',
+        "9": 'S07MentalHealthQuestionnaireNDDI',
+        "10": 'S07MentalHealthQuestionnairePHQ',
+        "11": 'S07MentalHealthQuestionnaireSDQ',
+        "12": 'S07MentalHealthQuestionnaireOther'
+    },
+    "S07MentalHealthAgreedPathway": {
+        "1": 'S07MentalHealthAgreedPathwayAnxiety',
+        # 2: 'S07MentalHealthAgreedPathwayDepression' doesn't appear to have a corresponding column in the CSV,
+        "3": 'S07MentalHealthAgreedPathwayMoodDisorders',
+        "4": 'S07MentalHealthAgreedPathwayNonEpilepticAttackDisorders',
+        "5": 'S07MentalHealthAgreedPathwayOtherDetails'
+    },
+    "S07DoesThisComprise": {
+        "1": 'S07DoesThisCompriseEpilepsyClinics',
+        "2": 'S07DoesThisCompriseMDT',
+        "3": 'S07DoesThisCompriseOther'
+    },
+    "S07TrustAchieve": {
+        "1": 'S07TrustAchieveClinicalPsychology',
+        "2": 'S07TrustAchieveEducationalPsychology',
+        "3": 'S07TrustAchieveFormalDevelopmental',
+        "4": 'S07TrustAchieveNeuropyschology',
+        "5": 'S07TrustAchievePsychiatricAssessment',
+        "6": 'S07TrustAchieveNone'
+    },
+    "S08AgreedReferralCriteriaChildrenNeurodevelopmental": {
+        "1": 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalADHD',
+        "2": 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalASD',
+        "3": 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalBehaviour',
+        "4": 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalDCD',
+        "5": 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalIntellectualDisability',
+        "6": 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalLearningDisabilities',
+        "7": 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalOtherDetails'
+    }
+}
 
 def adapt_multiselect_field(row, choices_to_column):
     return [key for key, value in choices_to_column.items() if row[value] == 1]
 
-def import_submissions_from_csv(submission_period, df):
+def import_submissions_from_csv(submission_period, file):
+    data = pd.read_csv(file)
+
     for _, row in data.iterrows():
         ods_code = row["SiteCode"]
 
@@ -51,81 +121,24 @@ def import_submissions_from_csv(submission_period, df):
         # Multiselect fields #
         ######################      
 
-        submission.S01ESNFunctions = adapt_multiselect_field(row, {
-            1: 'S01ESNEDVisit',
-            2: 'S01ESNHomeVisit',
-            3: 'S01ESNIndividualHealthcare',
-            4: 'S01ESNNurseLedClinic',
-            5: 'S01ESNNursePrescribing',
-            6: 'S01ESNRescueMedicationParent',
-            7: 'S01ESNRescueMedicationSchool',
-            8: 'S01ESNSchoolMeetings',
-            9: 'S01ESNWardVisits',
-            10: 'S01ESNNoneOfTheAbove'
-        })
-
-        submission.S06ProfessionalsRoutinelyInvolvedInTransition = adapt_multiselect_field(row, {
-            1: 'S06ProfessionalsRoutinelyInvolvedInTransitionAdultESN',
-            2: 'S06ProfessionalsRoutinelyInvolvedInTransitionAdultLDESN',
-            3: 'S06ProfessionalsRoutinelyInvolvedInTransitionAdultNeuro',
-            4: 'S06ProfessionalsRoutinelyInvolvedInTransitionYouthWorker',
-            5: 'S06ProfessionalsRoutinelyInvolvedInTransitionOther'
-            # The other free text field is handled as a normal single value field earlier
-        })
-
-        # TODO MRB: should there be an explicit none option?
-        submission.S07MentalHealthQuestionnaire = adapt_multiselect_field(row, {
-            1: 'S07MentalHealthQuestionnaireBDI',
-            2: "S07MentalHealthQuestionnaireConnors",
-            3: 'S07MentalHealthQuestionnaireETT',
-            4: 'S07MentalHealthQuestionnaireGAD',
-            5: 'S07MentalHealthQuestionnaireGAD2',
-            6: 'S07MentalHealthQuestionnaireGAD7',
-            7: 'S07MentalHealthQuestionnaireHADS',
-            8: 'S07MentalHealthQuestionnaireMFQ',
-            9: 'S07MentalHealthQuestionnaireNDDI',
-            10: 'S07MentalHealthQuestionnairePHQ',
-            11: 'S07MentalHealthQuestionnaireSDQ',
-            12: 'S07MentalHealthQuestionnaireOther'
-        })
-
-        submission.S07MentalHealthAgreedPathway = adapt_multiselect_field(row, {
-            1: 'S07MentalHealthAgreedPathwayAnxiety',
-            # 2: 'S07MentalHealthAgreedPathwayDepression' doesn't appear to have a corresponding column in the CSV,
-            3: 'S07MentalHealthAgreedPathwayMoodDisorders',
-            4: 'S07MentalHealthAgreedPathwayNonEpilepticAttackDisorders',
-            5: 'S07MentalHealthAgreedPathwayOtherDetails'
-        })
-
-        submission.S07DoesThisComprise = adapt_multiselect_field(row, {
-            1: 'S07DoesThisCompriseEpilepsyClinics',
-            2: 'S07DoesThisCompriseMDT',
-            3: 'S07DoesThisCompriseOther'
-        })
-
-        submission.S07TrustAchieve = adapt_multiselect_field(row, {
-            1: 'S07TrustAchieveClinicalPsychology',
-            2: 'S07TrustAchieveEducationalPsychology',
-            3: 'S07TrustAchieveFormalDevelopmental',
-            4: 'S07TrustAchieveNeuropyschology',
-            5: 'S07TrustAchievePsychiatricAssessment',
-            6: 'S07TrustAchieveNone'
-        })
-
-        submission.S08AgreedReferralCriteriaChildrenNeurodevelopmental = adapt_multiselect_field(row, {
-            1: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalADHD',
-            2: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalASD',
-            3: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalBehaviour',
-            4: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalDCD',
-            5: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalIntellectualDisability',
-            6: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalLearningDisabilities',
-            7: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalOtherDetails'
-        })
+        for field, mapping in MULTISELECT_FIELD_MAPPINGS.items():
+            values = adapt_multiselect_field(row, mapping)
+            setattr(submission, field, values)
 
         submission.save()
 
 def export_submission_period_as_csv(submission_period):
+    columns = ['SiteName', 'SiteCode']
     rows = []
+
+    for field in OrganisationalAuditSubmissionForm():
+        if type(field.field) is MultiSelectFormField:
+            columns.extend(MULTISELECT_FIELD_MAPPINGS[field.name].values())
+        else:
+            columns.append(field.name)
+
+    rows = []
+
     submissions = OrganisationalAuditSubmission.objects.filter(submission_period=submission_period)
 
     for submission in submissions:
@@ -142,9 +155,19 @@ def export_submission_period_as_csv(submission_period):
         }
 
         for field in OrganisationalAuditSubmissionForm():
-            if type(field.field) is not MultiSelectFormField:
-                row[field.name] = getattr(submission, field.name)
+            value = getattr(submission, field.name)
+
+            if type(field.field) is MultiSelectFormField:
+                selected_choices = list(value)
+
+                for choice, column in MULTISELECT_FIELD_MAPPINGS[field.name].items():
+                    row[column] = "1" if choice in selected_choices else "2"
+            else:
+                row[field.name] = value
 
         rows.append(row)
 
-    return rows
+    df = pd.DataFrame(data=rows, columns=columns)
+    csv = df.to_csv(index=False)
+
+    return csv

--- a/epilepsy12/organisational_audit.py
+++ b/epilepsy12/organisational_audit.py
@@ -1,2 +1,150 @@
+from django.forms.fields import TypedChoiceField
+
+from multiselectfield.forms.fields import MultiSelectFormField 
+
+from .models import (
+    OrganisationalAuditSubmissionPeriod,
+    OrganisationalAuditSubmission,
+    Trust,
+    LocalHealthBoard
+)
+
+from .forms_folder import OrganisationalAuditSubmissionForm
+
+
+def adapt_multiselect_field(row, choices_to_column):
+    return [key for key, value in choices_to_column.items() if row[value] == 1]
+
+def import_submissions_from_csv(submission_period, df):
+    for _, row in data.iterrows():
+        ods_code = row["SiteCode"]
+
+        submission = OrganisationalAuditSubmission()
+        submission.submission_period = submission_period
+
+        try:
+            submission.trust = Trust.objects.get(ods_code=row["SiteCode"])
+        except Trust.DoesNotExist:
+            submission.local_health_board = LocalHealthBoard.objects.get(ods_code=row["SiteCode"])
+        
+        field_types = { field.name: type(field.field) for field in OrganisationalAuditSubmissionForm() }
+
+        #######################
+        # Single value fields #
+        #######################
+
+        for column, raw_value in row.to_dict().items():
+            if column in field_types and field_types[column] is not MultiSelectFormField:
+                value = None if pd.isnull(raw_value) else raw_value
+
+                # Special case - choice fields need integer values not decimal
+                if type(value) == float and field_types[column] == TypedChoiceField:
+                    value = int(value)
+
+                # Special case - NA parses as NaN
+                if column == "S02TFC223" and pd.isna(raw_value):
+                    value = 'NA'
+
+                setattr(submission, column, value)
+
+        ######################
+        # Multiselect fields #
+        ######################      
+
+        submission.S01ESNFunctions = adapt_multiselect_field(row, {
+            1: 'S01ESNEDVisit',
+            2: 'S01ESNHomeVisit',
+            3: 'S01ESNIndividualHealthcare',
+            4: 'S01ESNNurseLedClinic',
+            5: 'S01ESNNursePrescribing',
+            6: 'S01ESNRescueMedicationParent',
+            7: 'S01ESNRescueMedicationSchool',
+            8: 'S01ESNSchoolMeetings',
+            9: 'S01ESNWardVisits',
+            10: 'S01ESNNoneOfTheAbove'
+        })
+
+        submission.S06ProfessionalsRoutinelyInvolvedInTransition = adapt_multiselect_field(row, {
+            1: 'S06ProfessionalsRoutinelyInvolvedInTransitionAdultESN',
+            2: 'S06ProfessionalsRoutinelyInvolvedInTransitionAdultLDESN',
+            3: 'S06ProfessionalsRoutinelyInvolvedInTransitionAdultNeuro',
+            4: 'S06ProfessionalsRoutinelyInvolvedInTransitionYouthWorker',
+            5: 'S06ProfessionalsRoutinelyInvolvedInTransitionOther'
+            # The other free text field is handled as a normal single value field earlier
+        })
+
+        # TODO MRB: should there be an explicit none option?
+        submission.S07MentalHealthQuestionnaire = adapt_multiselect_field(row, {
+            1: 'S07MentalHealthQuestionnaireBDI',
+            2: "S07MentalHealthQuestionnaireConnors",
+            3: 'S07MentalHealthQuestionnaireETT',
+            4: 'S07MentalHealthQuestionnaireGAD',
+            5: 'S07MentalHealthQuestionnaireGAD2',
+            6: 'S07MentalHealthQuestionnaireGAD7',
+            7: 'S07MentalHealthQuestionnaireHADS',
+            8: 'S07MentalHealthQuestionnaireMFQ',
+            9: 'S07MentalHealthQuestionnaireNDDI',
+            10: 'S07MentalHealthQuestionnairePHQ',
+            11: 'S07MentalHealthQuestionnaireSDQ',
+            12: 'S07MentalHealthQuestionnaireOther'
+        })
+
+        submission.S07MentalHealthAgreedPathway = adapt_multiselect_field(row, {
+            1: 'S07MentalHealthAgreedPathwayAnxiety',
+            # 2: 'S07MentalHealthAgreedPathwayDepression' doesn't appear to have a corresponding column in the CSV,
+            3: 'S07MentalHealthAgreedPathwayMoodDisorders',
+            4: 'S07MentalHealthAgreedPathwayNonEpilepticAttackDisorders',
+            5: 'S07MentalHealthAgreedPathwayOtherDetails'
+        })
+
+        submission.S07DoesThisComprise = adapt_multiselect_field(row, {
+            1: 'S07DoesThisCompriseEpilepsyClinics',
+            2: 'S07DoesThisCompriseMDT',
+            3: 'S07DoesThisCompriseOther'
+        })
+
+        submission.S07TrustAchieve = adapt_multiselect_field(row, {
+            1: 'S07TrustAchieveClinicalPsychology',
+            2: 'S07TrustAchieveEducationalPsychology',
+            3: 'S07TrustAchieveFormalDevelopmental',
+            4: 'S07TrustAchieveNeuropyschology',
+            5: 'S07TrustAchievePsychiatricAssessment',
+            6: 'S07TrustAchieveNone'
+        })
+
+        submission.S08AgreedReferralCriteriaChildrenNeurodevelopmental = adapt_multiselect_field(row, {
+            1: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalADHD',
+            2: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalASD',
+            3: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalBehaviour',
+            4: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalDCD',
+            5: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalIntellectualDisability',
+            6: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalLearningDisabilities',
+            7: 'S08AgreedReferralCriteriaChildrenNeurodevelopmentalOtherDetails'
+        })
+
+        submission.save()
+
 def export_submission_period_as_csv(submission_period):
-    return ''
+    header = ['SiteName', "SiteCode"]
+    rows = []
+
+    for field in OrganisationalAuditSubmissionForm():
+        if type(field.field) is not MultiSelectFormField:
+            header.append(field.name)
+
+    submissions = OrganisationalAuditSubmission.objects.filter(submission_period=submission_period)
+
+    for submission in submissions:
+        if submission.local_health_board:
+            site_name = submission.local_health_board.name
+            site_code = submission.local_health_board.ods_code
+        else:
+            site_name = submission.trust.name
+            site_code = submission.trust.ods_code
+
+        rows.append({
+            'SiteName': site_name,
+            'SiteCode': site_code
+        })
+
+    return rows

--- a/epilepsy12/organisational_audit.py
+++ b/epilepsy12/organisational_audit.py
@@ -125,13 +125,7 @@ def import_submissions_from_csv(submission_period, df):
         submission.save()
 
 def export_submission_period_as_csv(submission_period):
-    header = ['SiteName', "SiteCode"]
     rows = []
-
-    for field in OrganisationalAuditSubmissionForm():
-        if type(field.field) is not MultiSelectFormField:
-            header.append(field.name)
-
     submissions = OrganisationalAuditSubmission.objects.filter(submission_period=submission_period)
 
     for submission in submissions:
@@ -142,9 +136,15 @@ def export_submission_period_as_csv(submission_period):
             site_name = submission.trust.name
             site_code = submission.trust.ods_code
 
-        rows.append({
+        row = {
             'SiteName': site_name,
             'SiteCode': site_code
-        })
+        }
+
+        for field in OrganisationalAuditSubmissionForm():
+            if type(field.field) is not MultiSelectFormField:
+                row[field.name] = getattr(submission, field.name)
+
+        rows.append(row)
 
     return rows

--- a/epilepsy12/organisational_audit.py
+++ b/epilepsy12/organisational_audit.py
@@ -1,0 +1,2 @@
+def export_submission_period_as_csv(submission_period):
+    return ''


### PR DESCRIPTION
Closes #1054 

Implement a custom Django admin action so you can download a submission period as CSV. The format is the same as the old import format for consistency, including expanding out multiselect fields into separate columns.