### PR TITLE
Show validation errors in UI

### DIFF
--- a/epilepsy12/models_folder/organisational_audit.py
+++ b/epilepsy12/models_folder/organisational_audit.py
@@ -1,4 +1,4 @@
-from django.core.validators import MaxValueValidator
+from django.core.validators import MinValueValidator, MaxValueValidator
 from django.contrib.gis.db import models
 
 from simple_history.models import HistoricalRecords
@@ -11,7 +11,13 @@ from .time_and_user_abstract_base_classes import TimeStampAbstractBaseClass, Use
 
 
 def DecimalField():
-    return models.DecimalField(null=True, blank=True, max_digits=7, decimal_places=3)
+    return models.DecimalField(
+        null=True, 
+        blank=True,
+        max_digits=7,
+        decimal_places=3,
+        validators=[MinValueValidator(0)]
+    )
 
 def TextField():
     return models.CharField(null=True, blank=True)

--- a/epilepsy12/views/organisational_audit_views.py
+++ b/epilepsy12/views/organisational_audit_views.py
@@ -177,15 +177,15 @@ def get_submission(submission_period, group, group_field):
 def get_submission_form(submission, last_submission):
     data = {}
     
-    if submission:
-        for field in OrganisationalAuditSubmission._meta.fields:
-            if field.name != "id" and not field.name in OrganisationalAuditSubmissionForm.Meta.exclude:
-                field_value = getattr(submission, field.name)
-                
-                if not field_value and last_submission:
-                    field_value = getattr(last_submission, field.name)
+    for field in OrganisationalAuditSubmission._meta.fields:
+        if field.name != "id" and not field.name in OrganisationalAuditSubmissionForm.Meta.exclude:
+            field_value = getattr(submission, field.name) if submission else None
+            
+            if not field_value and last_submission:
+                field_value = getattr(last_submission, field.name)
 
-                data[field.name] = field_value
+            data[field.name] = field_value
+        
 
     return OrganisationalAuditSubmissionForm(data, instance=submission)
 

--- a/epilepsy12/views/organisational_audit_views.py
+++ b/epilepsy12/views/organisational_audit_views.py
@@ -84,7 +84,7 @@ def group_form_fields(form):
     total_questions = 0
 
     for field in form:
-        if field.value() is not None and field.value() != "" and field.value() != []:
+        if field.value() is not None and field.value() != "" and field.value() != [] and not field.errors:
             completed = True
             number_completed += 1
         else:

--- a/epilepsy12/views/organisational_audit_views.py
+++ b/epilepsy12/views/organisational_audit_views.py
@@ -172,19 +172,21 @@ def get_submission(submission_period, group, group_field):
     ).first()
 
 
+# Avoid saving errors to the DB by reconstructing the form from the data
+# Allows us to also mix in answers from the previous years submission
 def get_submission_form(submission, last_submission):
-    submission = submission or OrganisationalAuditSubmission()
+    data = {}
     
-    if last_submission:
-        for field in OrganisationalAuditSubmission._meta.fields:
-            if field.name != "id" and not field.name in OrganisationalAuditSubmissionForm.Meta.exclude:
-                current_field_value = getattr(submission, field.name)
-                last_field_value = getattr(last_submission, field.name)
-                
-                if not current_field_value and last_field_value:
-                    setattr(submission, field.name, last_field_value)
-    
-    return OrganisationalAuditSubmissionForm(instance=submission)
+    for field in OrganisationalAuditSubmission._meta.fields:
+        if field.name != "id" and not field.name in OrganisationalAuditSubmissionForm.Meta.exclude:
+            field_value = getattr(submission, field.name)
+            
+            if not field_value and last_submission:
+                field_value = getattr(last_submission, field.name)
+
+            data[field.name] = field_value
+
+    return OrganisationalAuditSubmissionForm(data, instance=submission)
 
 
 def _organisational_audit(request, group_id, group_model, group_field):
@@ -231,11 +233,12 @@ def _organisational_audit(request, group_id, group_model, group_field):
         context["percentage_completed"] = int(
             (number_completed / total_questions) * 100
         )
+        context["form"] = form
 
-        if not form.errors:
-            form.save()
-        else:
-            context["errors"] = form.errors
+        # Validate all the data to pull through the values
+        form.is_valid()
+        # but save regardless of errors - we save as we go
+        form.instance.save()
 
         return render(
             request, "epilepsy12/partials/organisational_audit_form.html", context

--- a/epilepsy12/views/organisational_audit_views.py
+++ b/epilepsy12/views/organisational_audit_views.py
@@ -177,14 +177,15 @@ def get_submission(submission_period, group, group_field):
 def get_submission_form(submission, last_submission):
     data = {}
     
-    for field in OrganisationalAuditSubmission._meta.fields:
-        if field.name != "id" and not field.name in OrganisationalAuditSubmissionForm.Meta.exclude:
-            field_value = getattr(submission, field.name)
-            
-            if not field_value and last_submission:
-                field_value = getattr(last_submission, field.name)
+    if submission:
+        for field in OrganisationalAuditSubmission._meta.fields:
+            if field.name != "id" and not field.name in OrganisationalAuditSubmissionForm.Meta.exclude:
+                field_value = getattr(submission, field.name)
+                
+                if not field_value and last_submission:
+                    field_value = getattr(last_submission, field.name)
 
-            data[field.name] = field_value
+                data[field.name] = field_value
 
     return OrganisationalAuditSubmissionForm(data, instance=submission)
 

--- a/templates/epilepsy12/partials/organisational_audit_form.html
+++ b/templates/epilepsy12/partials/organisational_audit_form.html
@@ -8,10 +8,6 @@
     </div>
 </div>
 
-{% if form.errors %}
-    {{form.errors}}
-{% endif %}
-
 {% for section, questions in questions_by_section.items %}
     <div>
         <h3 class="org-audit-section-title">
@@ -23,14 +19,13 @@
                     <div class="org-audit-cell">
                         <label>
                             <em>{{parent.question_number}}</em>
-                            <span data-tooltip="Some helpful information will be found here...">
-                                {{parent.label}}
-                                <i class="rcpch question circle icon"></i>
-                            </span>
+                            {{parent.label}}
                         </label>
                         <div class="field icon-text">
                             <span class="inline-icon-text">
-                                {% if parent.completed %}
+                                {% if parent.field.errors %}
+                                    <i class="rcpch_red exclamation circle icon"></i>
+                                {% elif parent.completed %}
                                     <span data-tooltip="Scored field">
                                         <i class="rcpch_pink check circle outline icon"></i>
                                     </span>
@@ -42,6 +37,9 @@
                                 {{parent.field}}
                             </span>
                         </div>
+                        {% if parent.field.errors %}
+                            {{parent.field.errors}}
+                        {% endif %}
                     </div>
                     {% if parent.reference %}
                         <dfn class="org-audit-cell org-audit-reference">
@@ -66,11 +64,13 @@
                                 </label>
                                 <div class="field">
                                     <span class="inline-icon-text">
-                                        {% if child.completed %}
+                                        {% if child.field.errors %}
+                                            <i class="rcpch_red exclamation circle icon"></i>
+                                        {% elif child.completed %}
                                             <span data-tooltip="Scored field">
                                                 <i class="rcpch_pink check circle outline icon"></i>
                                             </span>
-                                        {% else %}
+                                        {% elif "completed" in child %}
                                             <span data-tooltip="Unscored field">
                                                 <i class="rcpch_light_blue dot circle outline icon"></i>
                                             </span>
@@ -78,6 +78,9 @@
                                         {{child.field}}
                                     </span>
                                 </div>
+                                {% if child.field.errors %}
+                                    {{child.field.errors}}
+                                {% endif %}
                             </div>
                         {% endif %}
                     {% endfor %}

--- a/templates/epilepsy12/partials/organisational_audit_form.html
+++ b/templates/epilepsy12/partials/organisational_audit_form.html
@@ -8,8 +8,8 @@
     </div>
 </div>
 
-{% if errors %}
-    {{errors}}
+{% if form.errors %}
+    {{form.errors}}
 {% endif %}
 
 {% for section, questions in questions_by_section.items %}


### PR DESCRIPTION

![Screenshot from 2024-10-11 14-25-08](https://github.com/user-attachments/assets/e0288bbc-da19-4e41-91c2-79abff8d63ce)
Fixes #1055 



Show form errors inline against the field. On GET not POST reconstruct the errors by filling in the form data rather than just passing the instance.
