### PR TITLE
Fix a crash if no submission periods exist

### DIFF
--- a/epilepsy12/views/organisational_audit_views.py
+++ b/epilepsy12/views/organisational_audit_views.py
@@ -199,6 +199,7 @@ def _organisational_audit(request, group_id, group_model, group_field):
 
     if not submission_periods:
         submission_period = None
+        last_submission_period = None
     elif len(submission_periods) == 1:
         submission_period = submission_periods[0]
         last_submission_period = None


### PR DESCRIPTION
Ronseal

Go to fill in the org audit `/trust/1/audit`. If no submission periods are configured it crashed as `last_submission_period` was not bound.