### PR TITLE
HOTFIX: remove cohort check for first paediatric assessment date

### DIFF
--- a/epilepsy12/views/registration_views.py
+++ b/epilepsy12/views/registration_views.py
@@ -605,9 +605,15 @@ def first_paediatric_assessment_date(request, case_id):
     else:
         # registering a new child in the audit by a clinical team
         # sets the minimum allowable date to the currently submitting cohort start date
-        earliest_allowable_date = cohorts_and_dates(
-            first_paediatric_assessment_date=date.today()
-        )["submitting_cohort_start_date"]
+        # earliest_allowable_date = cohorts_and_dates(
+            # first_paediatric_assessment_date=date.today()
+        # )["submitting_cohort_start_date"]
+
+        # HOTFIX - this check did not account for the submission grace period after the cohort closes
+        # 
+        # We have removed it to allow users to continue to submit.
+        # https://github.com/rcpch/rcpch-audit-engine/issues/1117 will put it back correctly.
+        earliest_allowable_date = None
 
     try:
         error_message = None


### PR DESCRIPTION
It does not correctly account for the submission grace period (Cohort 6 ends on 30 November 2024 but submission doesn't until 14 January 2025). https://github.com/rcpch/rcpch-audit-engine/issues/1116

The fastest way to get users back up and submitting is to remove it entirely.

I've raised https://github.com/rcpch/rcpch-audit-engine/issues/1117 to put it back properly.