### PR TITLE
Better handling of submission grace period

### DIFF
--- a/epilepsy12/general_functions/cohort_number.py
+++ b/epilepsy12/general_functions/cohort_number.py
@@ -29,6 +29,11 @@ def cohort_number_from_first_paediatric_assessment_date(
     is the second Tuesday in January after the closing date 1 YEAR ON. So if the cohort closes on 30 Nov 22, the submission date is
     the second Tuesday after 30/11/23, which is 9 Jan 24
 
+    Cohorts are defined as follows:
+    currently recruiting cohort: this is the cohort that is currently recruiting patients
+    currently submitting cohort: this is the cohort that is no longer recruiting patients but is still collecting data to complete a fully year of care
+    grace cohort: this cohort is also nolonger recruiting patients but is still collecting data to complete a fully year of care. This cohort is the cohort before the submitting cohort.
+
     * Time zone is not explicity supplied. Since this is a UK audit, time zone is assumed always to be UK.
 
     #### Examples of cohort numbers:
@@ -36,6 +41,7 @@ def cohort_number_from_first_paediatric_assessment_date(
     Cohort 5: 1 December 2021 - 30 November 2022: submission 9 January 2024
     Cohort 6: 1 December 2022 - 30 November 2023: submission 14 January 2025
     Cohort 7: 1 December 2023 - 30 November 2024: submission 13 January 2026
+    Cohort 8: 1 December 2024 - 30 November 2025: submission 12 January 2027
     """
 
     if first_paediatric_assessment_date < date(year=2020, month=12, day=1):
@@ -108,6 +114,18 @@ def cohorts_and_dates(first_paediatric_assessment_date: date):
         submitting_cohort_number = None
         submitting_cohort = {}
 
+    if date.today().month >= 12 or date.today() < nth_tuesday_of_year(
+        date.today().year, n=2
+    ):
+        # if today is in or after December and before the second Tuesday of the year - during this period
+        # a new cohort has started recruiting, the previous cohort has stopped recruiting but is still collecting data
+        # and the cohort before that is in the grace period.
+        # After the second Tuesday of the year, the grace period cohort is closed, the submitting cohort is closed to recruitment but still collecting data, the currently recruiting cohort is recruiting.
+
+        within_grace_period = True
+    else:
+        within_grace_period = False
+
     return {
         "currently_recruiting_cohort": currently_recruiting_cohort_number,
         "currently_recruiting_cohort_start_date": currently_recruiting_cohort.get(
@@ -133,5 +151,7 @@ def cohorts_and_dates(first_paediatric_assessment_date: date):
         "submitting_cohort_days_remaining": submitting_cohort.get(
             "days_remaining", None
         ),
+        "grace_cohort": dates_for_cohort(cohort=submitting_cohort_number - 1),
+        "within_grace_period": within_grace_period,
         "today": date.today(),
     }

--- a/epilepsy12/general_functions/cohort_number.py
+++ b/epilepsy12/general_functions/cohort_number.py
@@ -31,8 +31,8 @@ def cohort_number_from_first_paediatric_assessment_date(
 
     Cohorts are defined as follows:
     currently recruiting cohort: this is the cohort that is currently recruiting patients
-    currently submitting cohort: this is the cohort that is no longer recruiting patients but is still collecting data to complete a fully year of care
-    grace cohort: this cohort is also nolonger recruiting patients but is still collecting data to complete a fully year of care. This cohort is the cohort before the submitting cohort.
+    currently submitting cohort: this is the cohort that is no longer recruiting patients but is still collecting data to complete a full year of care
+    grace cohort: this cohort is also no longer recruiting patients but is still collecting data to complete a full year of care. This cohort is the one before the submitting cohort.
 
     * Time zone is not explicity supplied. Since this is a UK audit, time zone is assumed always to be UK.
 

--- a/epilepsy12/tests/general_functions_tests/test_cohort_calculations.py
+++ b/epilepsy12/tests/general_functions_tests/test_cohort_calculations.py
@@ -6,13 +6,11 @@ from datetime import date
 
 # RCPCH imports
 
+# def test_cohort_number_from_enrolment_date_returns_correct_num(e12_case_factory):
+#     """
+#     Test that cohort_number_from_enrolment_date() returns correct num, given different Date of First Paediatric Assessment (DoFPAs).
 
-@pytest.skip("Not implemented")
-def test_cohort_number_from_enrolment_date_returns_correct_num(e12_case_factory):
-    """
-    Test that cohort_number_from_enrolment_date() returns correct num, given different Date of First Paediatric Assessment (DoFPAs).
+#     The latest DoFPA for a cohort is 30th Nov of a given year. For 2023, it will be Cohort 6 until 30th Nov 2023, then Cohort 7 1st Dec 2023-30th Nov 2024.
+#     """
 
-    The latest DoFPA for a cohort is 30th Nov of a given year. For 2023, it will be Cohort 6 until 30th Nov 2023, then Cohort 7 1st Dec 2023-30th Nov 2024.
-    """
-
-    expected_cohort_for_dates = ((date(2023, 11, 30), 5),)
+#     expected_cohort_for_dates = ((date(2023, 11, 30), 5),)

--- a/epilepsy12/tests/general_functions_tests/test_cohort_calculations.py
+++ b/epilepsy12/tests/general_functions_tests/test_cohort_calculations.py
@@ -5,11 +5,9 @@ from datetime import date
 # Third party imports
 
 # RCPCH imports
-from epilepsy12.general_functions import (
-    cohort_number_from_first_paediatric_assessment_date,
-)
 
 
+@pytest.skip("Not implemented")
 def test_cohort_number_from_enrolment_date_returns_correct_num(e12_case_factory):
     """
     Test that cohort_number_from_enrolment_date() returns correct num, given different Date of First Paediatric Assessment (DoFPAs).

--- a/epilepsy12/views/organisation_views.py
+++ b/epilepsy12/views/organisation_views.py
@@ -79,7 +79,7 @@ def selected_organisation_summary(request, organisation_id):
     # get submitting_cohort number - in future will be selectable
     cohort_data = cohorts_and_dates(first_paediatric_assessment_date=date.today())
 
-    cohort_number = cohort_data["submitting_cohort"]
+    cohort_number = cohort_data["grace_cohort"]["cohort"] if cohort_data["within_grace_period"] else cohort_data["submitting_cohort"]
 
     # thes are all registered cases for the current cohort at the selected organisation to be plotted in the map
     cases_to_plot = filter_all_registered_cases_by_active_lead_site_and_cohort_and_level_of_abstraction(

--- a/epilepsy12/views/registration_views.py
+++ b/epilepsy12/views/registration_views.py
@@ -604,16 +604,14 @@ def first_paediatric_assessment_date(request, case_id):
         earliest_allowable_date = case.date_of_birth
     else:
         # registering a new child in the audit by a clinical team
-        # sets the minimum allowable date to the currently submitting cohort start date
-        # earliest_allowable_date = cohorts_and_dates(
-            # first_paediatric_assessment_date=date.today()
-        # )["submitting_cohort_start_date"]
-
-        # HOTFIX - this check did not account for the submission grace period after the cohort closes
-        # 
-        # We have removed it to allow users to continue to submit.
-        # https://github.com/rcpch/rcpch-audit-engine/issues/1117 will put it back correctly.
-        earliest_allowable_date = None
+        # sets the minimum allowable date to the currently submitting cohort start date or the start of the previous cohort if it is still within its grace period
+        cohort_dates = cohorts_and_dates(first_paediatric_assessment_date=date.today())
+        if cohort_dates["within_grace_period"]:
+            earliest_allowable_date = cohort_dates["grace_cohort"]["cohort_start_date"]
+        else:
+            earliest_allowable_date = cohort_dates["submitting_cohort"][
+                "cohort_start_date"
+            ]
 
     try:
         error_message = None

--- a/static/styles/cards.css
+++ b/static/styles/cards.css
@@ -45,41 +45,6 @@
     margin: 1em auto;
   }
 
-  /* .ui.rcpch_dark_blue.card {
-    background-color: var(--rcpch_dark_blue);
-    border-radius: 0%;
-    font-family: var(--rcpch_standard_font);
-    font-weight: 400;
-    color: white;
-    width: auto;
-  }
-  
-  .ui.rcpch_dark_blue.card .content .header {
-    background-color: var(--rcpch_dark_blue);
-    border-radius: 0%;
-    font-family: var(--rcpch_standard_font);
-    font-weight: 400;
-    color: white;
-  } */
-  
-  /* .ui.rcpch_dark_blue.card .content i {
-    color: white;
-  }
-  
-  .ui.rcpch_dark_blue.card .category {
-    background-color: var(--rcpch_dark_blue);
-    border-radius: 0%;
-    font-family: var(--rcpch_standard_font);
-    font-weight: 400;
-    color: white;
-  }
-  
-  .ui.white.card {
-    border-radius: 0%;
-    font-family: var(--rcpch_standard_font);
-    font-weight: 400;
-  } */
-
 .cohorts_dates_grid{
   display: grid;
   grid-template-columns: 48% 4% 48%;
@@ -102,16 +67,20 @@
 
 .ui.centered.header.cohort_card_header {
   margin-top: 0;
-  margin-bottom: 0;
+  border-radius: 0%;
 }
   /* cards for organisation details */
 .organisation_details {
     padding: 0.5em 0.5em;
-    margin: 0em auto;
+    margin: auto;
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
+  }
+
+  .ui.card{
+    border-radius: 0%;
   }
   
   .ui.rcpch.organisation.icon {
@@ -210,53 +179,4 @@
     font-weight: 400;
     align-content: center;
   }
-  
-  /* .ui.rcpch_individual_kpi_fixed.card {
-    display: flex;
-    flex-direction: column;
-    background-color: white !important;
-    font-family: var(--rcpch_standard_font);
-    color: white;
-    text-align: center;
-    font-weight: 400;
-    align-content: center;
-  }
-  
-  .ui.rcpch_individual_kpi_fixed.card .content {
-    background-color: var(--rcpch_mid_grey);
-    width: 100%;
-    border-radius: 0% !important;
-  }
-  
-  .ui.rcpch_individual_kpi.card .content {
-    background-color: var(--rcpch_strong_blue);
-    width: 100%;
-    border-radius: 0% !important;
-  }
-  
-  .ui.rcpch_individual_kpi.card:hover .content {
-    background-color: var(--rcpch_light_blue);
-  }
-  
-  .ui.rcpch_individual_kpi.card .content.summary_kpi_pie_title h3 {
-    color: white;
-  }
-  
-  .ui.rcpch_individual_kpi_fixed.card .content.summary_kpi_pie_title h3 {
-    color: white;
-  }
-  
-  .ui.rcpch_individual_kpi.card .description {
-    padding-top: 10px;
-    color: var(--rcpch_charcoal);
-    text-align: left;
-    margin: 10px;
-  }
-  
-  .ui.rcpch_individual_kpi_fixed.card .description {
-    padding-top: 10px;
-    color: var(--rcpch_charcoal);
-    text-align: left;
-    margin: 10px;
-  } */
   

--- a/static/styles/cards.css
+++ b/static/styles/cards.css
@@ -85,6 +85,11 @@
   grid-template-columns: 48% 4% 48%;
 }
 
+.cohorts_dates_three_grid {
+  display: grid;
+  grid-template-columns: 30% 5% 30% 5% 30%;
+}
+
 .grid_line {
     height: 90%;
     width: 1px;

--- a/templates/epilepsy12/partials/organisation/cohort_card.html
+++ b/templates/epilepsy12/partials/organisation/cohort_card.html
@@ -1,58 +1,94 @@
 <div class="ui card">
-    <div class='cohorts_dates_grid'>
-        <div class="content">
-            <div class="rcpch_summary_stats">
-
-                <div class="ui centered header cohort_card_header">
-                    <h3>SUBMITTING COHORT</h3>
-                </div>
-
-                <div class="rcpch_summary_stats_row">
-                    <h1>{{cohort_data.submitting_cohort}}</h1>
-                    <h3>
-                        {% if cohort_data.submitting_cohort_end_date > cohort_data.today %}
-                            Actively recruiting and submitting data
-                        {% else %}
-                            Recruitment closed - data collection ongoing until {{cohort_data.submitting_cohort_submission_date}}
-                        {% endif %}
-                    </h3>
-                    <h4>{{cohort_data.submitting_cohort_start_date}} - {{cohort_data.submitting_cohort_end_date}}</h4>
-                </div>
-
-                <div class="rcpch_summary_stats_row">
-                    <h1>{{cohort_data.submitting_cohort_days_remaining}}</h1>
-                    <h2>Days remaining</h2>
-                    <h3>until latest submission date</h3>
-                    <h4>({{cohort_data.submitting_cohort_submission_date}})</h4>
-                </div>
-            </div>
+  {% if cohort_data.within_grace_period %}<div class="cohorts_dates_three_grid">{% else %}<div class="cohorts_dates_grid">{% endif %}
+    {% if cohort_data.within_grace_period %}
+    <div class="content">
+      <div class="rcpch_summary_stats">
+        <div class="ui centered header cohort_card_header">
+          <h3>COHORT</h3>
         </div>
-        <div class='grid_line'>
-        </div>
-        <div class="content">
-            <div class='rcpch_summary_stats'>
-                <div class="ui centered header cohort_card_header">
-                    <h3>ACTIVE <br> COHORT</h3>
-                </div>
-                <div class="rcpch_summary_stats_row">
-                    <h1>{{cohort_data.currently_recruiting_cohort}}</h1>
-                    <h3>
-                        {% if cohort_data.currently_recruiting_cohort_end_date > cohort_data.today %}
-                            Actively recruiting
-                        {% else %}
-                        Recruitment closed - data collection ongoing until {{cohort_data.currently_recruiting_cohort_end_date}}
-                        {% endif %}
-                    </h3>
-                    <h4>{{cohort_data.currently_recruiting_cohort_start_date}} - {{cohort_data.currently_recruiting_cohort_submission_date}}</h4>
-                </div>
 
-                <div class="rcpch_summary_stats_row">
-                    <h1>{{cohort_data.currently_recruiting_cohort_days_remaining}}</h1>
-                    <h2>Days remaining</h2>
-                    <h3>until latest submission date</h3>
-                    <h4>({{cohort_data.currently_recruiting_cohort_submission_date}})</h4>
-                </div>
-            </div>
+        <div class="rcpch_summary_stats_row">
+          <h1>{{cohort_data.grace_cohort.cohort}}</h1>
+          <h3>
+            {% if cohort_data.grace_cohort > cohort_data.today %} Actively
+            recruiting and submitting data {% else %} Recruitment closed - data
+            collection ongoing until
+            {{cohort_data.grace_cohort.submission_date}} {% endif %}
+          </h3>
+          <h4>
+            {{cohort_data.grace_cohort.cohort_start_date}} -
+            {{cohort_data.grace_cohort.cohort_end_date}}
+          </h4>
         </div>
+
+        <div class="rcpch_summary_stats_row">
+          <h1>{{cohort_data.grace_cohort.days_remaining}}</h1>
+          <h2>Days remaining</h2>
+          <h3>until latest submission date</h3>
+          <h4>({{cohort_data.grace_cohort.submission_date}})</h4>
+        </div>
+      </div>
     </div>
+    {% endif %}
+
+    <div class="grid_line"></div>
+
+    <div class="content">
+      <div class="rcpch_summary_stats">
+        <div class="ui centered header cohort_card_header">
+          <h3>COHORT</h3>
+        </div>
+
+        <div class="rcpch_summary_stats_row">
+          <h1>{{cohort_data.submitting_cohort}}</h1>
+          <h3>
+            {% if cohort_data.submitting_cohort_end_date > cohort_data.today %}
+            Actively recruiting and submitting data {% else %} Recruitment
+            closed - data collection ongoing until
+            {{cohort_data.submitting_cohort_submission_date}} {% endif %}
+          </h3>
+          <h4>
+            {{cohort_data.submitting_cohort_start_date}} -
+            {{cohort_data.submitting_cohort_end_date}}
+          </h4>
+        </div>
+
+        <div class="rcpch_summary_stats_row">
+          <h1>{{cohort_data.submitting_cohort_days_remaining}}</h1>
+          <h2>Days remaining</h2>
+          <h3>until latest submission date</h3>
+          <h4>({{cohort_data.submitting_cohort_submission_date}})</h4>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid_line"></div>
+
+    <div class="content">
+      <div class="rcpch_summary_stats">
+        <div class="ui centered header cohort_card_header">
+          <h3>COHORT</h3>
+        </div>
+        <div class="rcpch_summary_stats_row">
+          <h1>{{cohort_data.currently_recruiting_cohort}}</h1>
+          <h3>
+            {% if cohort_data.currently_recruiting_cohort_end_date > cohort_data.today %} Actively recruiting {% else %} Recruitment
+            closed - data collection ongoing until
+            {{cohort_data.currently_recruiting_cohort_end_date}} {% endif %}
+          </h3>
+          <h4>
+            {{cohort_data.currently_recruiting_cohort_start_date}} -
+            {{cohort_data.currently_recruiting_cohort_submission_date}}
+          </h4>
+        </div>
+
+        <div class="rcpch_summary_stats_row">
+          <h1>{{cohort_data.currently_recruiting_cohort_days_remaining}}</h1>
+          <h2>Days remaining</h2>
+          <h3>until latest submission date</h3>
+          <h4>({{cohort_data.currently_recruiting_cohort_submission_date}})</h4>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/templates/epilepsy12/partials/organisation/cohort_card.html
+++ b/templates/epilepsy12/partials/organisation/cohort_card.html
@@ -1,6 +1,6 @@
-<div class="ui card">
-  {% if cohort_data.within_grace_period %}<div class="cohorts_dates_three_grid">{% else %}<div class="cohorts_dates_grid">{% endif %}
-    {% if cohort_data.within_grace_period %}
+<div>
+  <div class="cohorts_dates_three_grid">
+    
     <div class="content">
       <div class="rcpch_summary_stats">
         <div class="ui centered header cohort_card_header">
@@ -8,12 +8,12 @@
         </div>
 
         <div class="rcpch_summary_stats_row">
-          <h1>{{cohort_data.grace_cohort.cohort}}</h1>
+          <h1 {% if cohort_data.within_grace_period %} style="color: var(--rcpch_pink)"{% endif %}>{{cohort_data.grace_cohort.cohort}}</h1>
           <h3>
-            {% if cohort_data.grace_cohort > cohort_data.today %} Actively
-            recruiting and submitting data {% else %} Recruitment closed - data
-            collection ongoing until
-            {{cohort_data.grace_cohort.submission_date}} {% endif %}
+            {% if cohort_data.grace_cohort.submission_date > cohort_data.today %} 
+            Recruitment closed - data collection ongoing until {{cohort_data.grace_cohort.submission_date}} {% else %} 
+            Recruitment closed - data collection complete
+            {% endif %}
           </h3>
           <h4>
             {{cohort_data.grace_cohort.cohort_start_date}} -
@@ -22,14 +22,13 @@
         </div>
 
         <div class="rcpch_summary_stats_row">
-          <h1>{{cohort_data.grace_cohort.days_remaining}}</h1>
+          <h1 style="color: var(--rcpch_pink)">{{cohort_data.grace_cohort.days_remaining}}</h1>
           <h2>Days remaining</h2>
           <h3>until latest submission date</h3>
           <h4>({{cohort_data.grace_cohort.submission_date}})</h4>
         </div>
       </div>
     </div>
-    {% endif %}
 
     <div class="grid_line"></div>
 
@@ -40,7 +39,11 @@
         </div>
 
         <div class="rcpch_summary_stats_row">
-          <h1>{{cohort_data.submitting_cohort}}</h1>
+          {% if cohort_data.submitting_cohort_end_date > cohort_data.today %}
+            <h1 style="color: var(--rcpch_pink)">{{cohort_data.submitting_cohort}}</h1>
+          {% else %}
+            <h1>{{cohort_data.submitting_cohort}}</h1>
+          {% endif %}
           <h3>
             {% if cohort_data.submitting_cohort_end_date > cohort_data.today %}
             Actively recruiting and submitting data {% else %} Recruitment

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -183,7 +183,7 @@
                 <div class="ui  card">
                     <div class="content">
                         <div class="ui centered header">
-                            <h3>Completed Patient Records</h3>
+                            <h3>Cohort {{cohort}} Completed Patient Records</h3>
                         </div>
                         <div class="">
 

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -144,9 +144,7 @@
                         </div>
                 </div>
 
-
                 {% include 'epilepsy12/partials/organisation/cohort_card.html' with cohort_data=cohort_data %}
-
 
                 <div class="ui  card">
                     <div class="content">

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -94,6 +94,10 @@
                 {% endif %}
         </div>
 
+        <div class="fluid centered row">
+        {% include 'epilepsy12/partials/organisation/cohort_card.html' with cohort_data=cohort_data %}
+        </div>
+
         <div class='sixteen wide fluid column'>
 
 
@@ -101,9 +105,9 @@
 
                 <div class="ui card">
                     <div class="content">
-                            <div class="ui centered header">
-                                <h3>{{ selected_organisation.name }}</h3>
-                            </div>
+                        <div class="ui centered header">
+                            <h3>{{ selected_organisation.name }}</h3>
+                        </div>
                             <h4 class="ui horizontal divider">
                                 <i class="ui  rcpch  small organisation icon "></i>Address
                             </h4>
@@ -144,7 +148,37 @@
                         </div>
                 </div>
 
-                {% include 'epilepsy12/partials/organisation/cohort_card.html' with cohort_data=cohort_data %}
+                <div class="ui card">
+                    <div class="content">
+                        <div class="ui centered header">
+                            <h3>Memberships</h3>
+                        </div>
+                        <div class="organisation_details">
+                            <h4 class="ui horizontal divider">
+                                <i class="ui  rcpch  small map signs icon "></i>Open UK Network
+                            </h4>
+                            <div class="organisation_details ">
+                            {{ selected_organisation.openuk_network }}
+                            </div>
+                            {% if selected_organisation.trust %}
+                                <h4 class="ui horizontal divider">
+                                    <i class="ui  rcpch  small organisation icon "></i>Integrated Care Board
+                                </h4>
+                                <div class="organisation_details ">
+                                    {{ selected_organisation.integrated_care_board }}
+                                </div>
+                                <h4 class="ui horizontal divider">
+                                    <i class="ui  rcpch  small map outline icon "></i> NHS England Region
+                                </h4>
+                                <div class="organisation_details ">
+                                    {{ selected_organisation.nhs_england_region }}
+                                </div>
+                            {% endif %}
+
+
+                        </div>
+                    </div>
+                </div>
 
                 <div class="ui  card">
                     <div class="content">
@@ -179,7 +213,7 @@
 
                         </div>
                     </div>
-                </div>
+            </div>
 
 
 


### PR DESCRIPTION
### Overview

Cohorts are surprisingly complicated. The rules are:
1. The recruitment dates for each cohort run sequentially - 1st Dec-30th Nov
2. After recruitment has closed, data collection continues for a full year, plus a grace period which ends on the second Tuesday of the following year.

At any one time, there are two cohorts ongoing, the current cohort which is still recruiting, and the previous cohort which has finished recruiting but is still collecting data.

The gotcha here is that between 1st December and the second week of January, there are actually 3 cohorts actively collecting data - the  current and the previous, but also the cohort before that which is still in its grace period.

The first paediatric assessment earliest date therefore, for most of the year, will be the first day of the previous cohort. However, between December and January, the earliest date must be the first day of the cohort before that.

for example, using this table
Cohort 4: 1 December 2020 - 30 November 2021: submission 10 January 2023
Cohort 5: 1 December 2021 - 30 November 2022: submission 9 January 2024
Cohort 6: 1 December 2022 - 30 November 2023: submission 14 January 2025
Cohort 7: 1 December 2023 - 30 November 2024: submission 13 January 2026
Cohort 8: 1 December 2024 - 30 November 2025: submission 12 January 2027

1. on 3/3/24, cohort 7 is actively recruiting, cohort 6 is closed but still collecting data, cohort 5 is closed and grace period has passed
2. on 1/1/24, cohort 7 is actively recruiting, cohort 6 has closed but is still collecting data, but cohort 5 is in still in it's grace period until 14/1/24

The earliest allowable date for first paediatric assessment therefore in case one is the onset of cohort 6 (1/12/22)
The earliest allowable date for first paediatric assessment however in case 2 (which falls between December and Jan) is the onset of cohort 5 (1/12/2021)


### Code changes

To address this, the `cohorts_and_dates` function adds a new dict for `grace_cohort` with a flag `within_grace_period` which is `True` between the first of December and the second Tuesday of the following January.

This function now applies **only** to the first paediatric assessment date, as all other dates have the date of birth as their lower bound. This is because items such as EEG / ECG and so on may have happened before the first paediatric assessment date.

This PR also updates the dashboard to show all cohorts, including those still in the submission grace period. It also shows the chart data for the grace cohort.

![Screenshot 2024-12-04 11 44 38](https://github.com/user-attachments/assets/ced5625d-12f3-4e76-afd6-7f14ea0d3f73)



### Documentation changes (done or required as a result of this PR)

The methodology around cohorts is already documented.

### Related Issues

closes #1117
closes #1120 