### PR TITLE
Fix org audit bug where you can't submit because you have more answers than the total

### DIFF
--- a/epilepsy12/views/organisational_audit_views.py
+++ b/epilepsy12/views/organisational_audit_views.py
@@ -87,11 +87,7 @@ def group_form_fields(form):
         if field.name == "submitted":
             continue
 
-        if field.value() is not None and field.value() != "" and field.value() != [] and not field.errors:
-            completed = True
-            number_completed += 1
-        else:
-            completed = False
+        completed = field.value() is not None and field.value() != "" and field.value() != [] and not field.errors
 
         help_text = field.help_text or {}
 
@@ -129,6 +125,9 @@ def group_form_fields(form):
 
             if not hidden:
                 total_questions += 1
+            
+            if not hidden and completed:
+                number_completed += 1
 
             child = {
                 "section": section,
@@ -147,6 +146,9 @@ def group_form_fields(form):
 
         else:
             total_questions += 1
+
+            if completed:
+                number_completed += 1
 
             fields_by_question_number[question_number] = {
                 "section": section,


### PR DESCRIPTION
Fixes #1081 

We were incorrectly including hidden answers in the answered count but correctly not including them in the total.

This meant if you changed a parent question from yes to no, you couldn't submit as the answer count was greater than the total.