### PR TITLE
optional-causes

### DIFF
--- a/epilepsy12/common_view_functions/recalculate_form_generate_response.py
+++ b/epilepsy12/common_view_functions/recalculate_form_generate_response.py
@@ -197,9 +197,9 @@ def total_fields_expected(model_instance):
         # if a cause for the epilepsy is know other essential fields must be included
         if model_instance.epilepsy_cause_known:
             # essential fields include
-            # epilepsy_cause
+            # epilepsy_cause (# nolonger scored - issue #1125)
             # epilepsy_cause_categories - this is an array, length must be greater than one
-            cumulative_score += 2
+            cumulative_score += 1
 
         if model_instance.relevant_impairments_behavioural_educational:
             # there are comorbidities - add essential comorbidities
@@ -373,6 +373,7 @@ def avoid_fields(model_instance):
             "episodes",
             "syndromes",
             "comorbidities",
+            "epilepsy_cause",  # Nolonger scored - issue #1125
         ]
 
     elif model_class_name == "Management":

--- a/epilepsy12/common_view_functions/validate_form_update_model.py
+++ b/epilepsy12/common_view_functions/validate_form_update_model.py
@@ -76,12 +76,15 @@ def validate_and_update_model(
             )
             field_value = syndrome_entity  # note field name here is syndrome
         elif request.htmx.trigger_name == "epilepsy_cause":
-            try:
-                epilepsy_cause_entity = EpilepsyCause.objects.get(
-                    pk=request.POST.get(request.htmx.trigger_name)
-                )
-            except Exception as e:
-                raise Exception("Unable to save epilepsy cause. ", e)
+            if request.POST.get(request.htmx.trigger_name) == "empty":
+                epilepsy_cause_entity = None
+            else:
+                try:
+                    epilepsy_cause_entity = EpilepsyCause.objects.get(
+                        pk=request.POST.get(request.htmx.trigger_name)
+                    )
+                except Exception as e:
+                    raise Exception("Unable to save epilepsy cause. ", e)
             field_value = (
                 epilepsy_cause_entity  # note field name here is epilepsy_cause
             )

--- a/epilepsy12/tests/view_tests/form_calculations/test_total_fields_expected.py
+++ b/epilepsy12/tests/view_tests/form_calculations/test_total_fields_expected.py
@@ -347,8 +347,8 @@ def test_total_fields_expected_multiaxial_diagnosis_general_fields(
 
     multiaxial_diagnosis = CASE.registration.multiaxialdiagnosis
 
-    # Initial value because Multiaxial diagnosis fields minimum == 7; ++ no episodes == 5; ++ general_fields all true == 6;
-    expected_value = 23
+    # Initial value because Multiaxial diagnosis fields minimum == 6; ++ no episodes == 5; ++ general_fields all true == 6;
+    expected_value = 22  # see issue #1125: epilepsy_cause nolonger mandatory
 
     return_value = total_fields_expected(multiaxial_diagnosis)
 

--- a/templates/epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_causes.html
+++ b/templates/epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_causes.html
@@ -1,9 +1,8 @@
 {% load epilepsy12_template_tags %}
-<div class="field" id='epilepsy_cause_categories'>
-    {% include 'epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_cause_categories.html' with choices=epilepsy_cause_selection multiaxial_diagnosis=multiaxial_diagnosis %}
+<div class="field" id="epilepsy_cause_categories">
+  {% include 'epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_cause_categories.html' with choices=epilepsy_cause_selection multiaxial_diagnosis=multiaxial_diagnosis %}
 </div>
 
 <div class="field">
-    {% url "epilepsy_cause" multiaxial_diagnosis_id=multiaxial_diagnosis.pk as hx_post %}
-    {% include 'epilepsy12/partials/page_elements/select_model.html' with choices=epilepsy_causes field_name='preferredTerm' field_name2='term' hx_post=hx_post hx_name='epilepsy_cause' hx_default_text='Select a cause' hx_swap='innerHTML' hx_target='#epilepsy_causes' hx_trigger='change' test_positive=multiaxial_diagnosis.epilepsy_cause.pk label=multiaxial_diagnosis.get_epilepsy_cause_help_label_text reference=multiaxial_diagnosis.get_epilepsy_cause_help_reference_text enabled=perms.epilepsy12.change_multiaxialdiagnosis %}
+  {% url "epilepsy_cause" multiaxial_diagnosis_id=multiaxial_diagnosis.pk as hx_post %} {% include 'epilepsy12/partials/page_elements/select_model.html' with choices=epilepsy_causes field_name='preferredTerm' field_name2='term' hx_post=hx_post hx_name='epilepsy_cause' hx_default_text='Select a cause' hx_swap='innerHTML' hx_target='#epilepsy_causes' hx_trigger='change' test_positive=multiaxial_diagnosis.epilepsy_cause.pk label=multiaxial_diagnosis.get_epilepsy_cause_help_label_text reference=multiaxial_diagnosis.get_epilepsy_cause_help_reference_text enabled=perms.epilepsy12.change_multiaxialdiagnosis allow_none=True %}
 </div>

--- a/templates/epilepsy12/partials/page_elements/select_model.html
+++ b/templates/epilepsy12/partials/page_elements/select_model.html
@@ -1,74 +1,80 @@
-{% load epilepsy12_template_tags %}
-{% comment %}
-        This is a single choice select which is reused in multiple places.
-        It accepts only django models as lookup
-        Note requires jquery to work.
-        This select accepts the following parameters:
-            choices: these are the choices available
-            hx_post: the url posted to including parameters
-            hx_target: the id of the html element to target the server response
-            hx_trigger: usually 'change' but can be any event
-            hx_swap: usually 'innerHTML'
-            hx_name: the model field to update
-            field_name: the name of the field returning the value to go in the dropdown
-            field_name2: the name of the field returning the value to go in the dropdown
-            test_positive: the model boolean field 
-            label: this is the label text
-            hx_default_text: default text of an unselected element
-            data_position: this is the position of the popup label (js independent) ['top left', 'top center', 'top right', 'bottom left', 'bottom center', 'bottom right', 'right center', 'left center']
-            enabled: this is set to false if a view only user sees the form
-        The chosen value is stored as the name of the button and accessed in the view as request.htmx.trigger_name
-        Which choices are selected from is obvious because the endpoint posted to is specific to the choices.
-    {% endcomment %}
-    <div class="field" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
-
-        <h5 class='rcpch_plain_label'>
-            {{label|safe}}&nbsp;
-            <span 
-                id="{{hx_name}}"
-                data-title="Reference"
-                data-content="{{reference|safe}}"
-                data-position="{{data_position}}"
-                data-variation="basic"
-                _="init js $('#{{hx_name}}').popup(); end"
+{% load epilepsy12_template_tags %} {% comment %} This is a single choice select
+which is reused in multiple places. It accepts only django models as lookup Note
+requires jquery to work. This select accepts the following parameters: choices:
+these are the choices available hx_post: the url posted to including parameters
+hx_target: the id of the html element to target the server response hx_trigger:
+usually 'change' but can be any event hx_swap: usually 'innerHTML' hx_name: the
+model field to update field_name: the name of the field returning the value to
+go in the dropdown field_name2: the name of the field returning the value to go
+in the dropdown test_positive: the model boolean field label: this is the label
+text hx_default_text: default text of an unselected element data_position: this
+is the position of the popup label (js independent) ['top left', 'top center',
+'top right', 'bottom left', 'bottom center', 'bottom right', 'right center',
+'left center'] enabled: this is set to false if a view only user sees the form
+allow_none: if this is not a mandatory field, it can default to None The chosen
+value is stored as the name of the button and accessed in the view as
+request.htmx.trigger_name Which choices are selected from is obvious because the
+endpoint posted to is specific to the choices. {% endcomment %}
+<div class="field" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+  <h5 class="rcpch_plain_label">
+    {{label|safe}}&nbsp;
+    <span
+      id="{{hx_name}}"
+      data-title="Reference"
+      data-content="{{reference|safe}}"
+      data-position="{{data_position}}"
+      data-variation="basic"
+      _="init js $('#{{hx_name}}').popup(); end"
+    >
+      <i class="rcpch question circle icon"></i>
+    </span>
+  </h5>
+  {% if enabled %}
+  <div class="ui rcpch_light_blue fluid search selection dropdown">
+    {% else %}
+        <div class="ui rcpch_light_blue fluid search selection disabled dropdown">
+    {% endif %} 
+    {% if test_positive %}
+      <i class="rcpch_pink check circle outline icon"></i>
+    {% else %}
+        {% if not allow_none %}
+            <span
+                data-tooltip="Incomplete field. This must be scored to complete the record."
+                data-inverted=""
+                data-position="top left"
             >
-                <i class="rcpch question circle icon"></i>
+                <i class="rcpch_light_blue dot circle outline icon"></i>
             </span>
-        </h5>
-            {% if enabled %}
-                <div class="ui rcpch_light_blue fluid search selection dropdown">
-            {% else %}
-                <div class="ui rcpch_light_blue fluid search selection disabled dropdown">
-            {% endif %}
-            
-                {% if test_positive %}
-                    <i class="rcpch_pink check circle outline icon"></i>
-                {% else %}
-                    <span data-tooltip="Incomplete field. This must be scored to complete the record." data-inverted="" data-position="top left">
-                        <i class="rcpch_light_blue dot circle outline icon"></i>
-                    </span>
-                {% endif %}
+        {% endif %}
+      {% endif %}
 
-                <i class="dropdown icon"></i>
-                <input type="hidden"
-                    _="init js $('.ui.rcpch_light_blue.fluid.search.selection.dropdown').dropdown({ fullTextSearch: true }); end"
-                    name={{hx_name}}
-                    hx-post="{{hx_post}}"
-                    hx-target="{{hx_target}}"
-                    hx-swap="{{hx_swap}}"
-                    hx-trigger="{{hx_trigger}}"
-                    value="{{test_positive}}"
-                >
-                <div class="default text">{{hx_default_text}}</div>
-                <div class="menu" >
-                    {% for item in choices %}
-                        <div class="item" data-value="{{item.pk}}">{% value_for_field_name item field_name False %} {% value_for_field_name item field_name2 True %}</div>
-                    {% endfor %}
-                </div>
-                
-            </div>
-            {% if not enabled %}
-                <small class='rcpch_warning_label'>You do not have permission to update this field</small>
-            {% endif %}
-
+      <i class="dropdown icon"></i>
+      <input
+        type="hidden"
+        _="init js $('.ui.rcpch_light_blue.fluid.search.selection.dropdown').dropdown({ fullTextSearch: true }); end"
+        name="{{hx_name}}"
+        hx-post="{{hx_post}}"
+        hx-target="{{hx_target}}"
+        hx-swap="{{hx_swap}}"
+        hx-trigger="{{hx_trigger}}"
+        value="{{test_positive}}"
+      />
+      <div class="default text">{{hx_default_text}}</div>
+      <div class="menu">
+        {% if allow_none %}
+        <div class="item" data-value="empty">No choice made</div>
+        {% endif %} {% for item in choices %}
+        <div class="item" data-value="{{item.pk}}">
+          {% value_for_field_name item field_name False %} {%
+          value_for_field_name item field_name2 True %}
+        </div>
+        {% endfor %}
+      </div>
     </div>
+    {% if not enabled %}
+    <small class="rcpch_warning_label"
+      >You do not have permission to update this field</small
+    >
+    {% endif %}
+  </div>
+</div>


### PR DESCRIPTION
### Overview

This makes the epilepsy cause drop down an optional field.

It adds epilepsy_cause to the list of fields that are nonessential and removes it from being included in the form calculation.
It also removes the blue target implying it is an essential unfilled field by introducing a new `allow_none` field in the `model_select` partial html element. This adds a `No choice made` choice in the select that returns an `empty` value in the htmx response that is used to save None to that field.

closes #1125