### PR TITLE
cohort-capers

### DIFF
--- a/epilepsy12/views/organisation_views.py
+++ b/epilepsy12/views/organisation_views.py
@@ -79,7 +79,11 @@ def selected_organisation_summary(request, organisation_id):
     # get submitting_cohort number - in future will be selectable
     cohort_data = cohorts_and_dates(first_paediatric_assessment_date=date.today())
 
-    cohort_number = cohort_data["grace_cohort"]["cohort"] if cohort_data["within_grace_period"] else cohort_data["submitting_cohort"]
+    cohort_number = (
+        cohort_data["grace_cohort"]["cohort"]
+        if cohort_data["within_grace_period"]
+        else cohort_data["submitting_cohort"]
+    )
 
     # thes are all registered cases for the current cohort at the selected organisation to be plotted in the map
     cases_to_plot = filter_all_registered_cases_by_active_lead_site_and_cohort_and_level_of_abstraction(
@@ -213,7 +217,8 @@ def selected_organisation_summary(request, organisation_id):
 
     context = {
         "user": request.user,
-        "cohort": cohort_number,
+        "cohort_number": cohort_number,  # the number of the cohort that should be highlighted as imminently submitting
+        "cohort_data": cohort_data,  # the cohort data object for the cohort_card
         "selected_organisation": selected_organisation,
         "organisation_list": organisation_list,
         "cases_aggregated_by_ethnicity": cases_aggregated_by_ethnicity(
@@ -244,7 +249,6 @@ def selected_organisation_summary(request, organisation_id):
         "count_of_current_cohort_registered_completed_cases_in_this_organisation": count_of_current_cohort_registered_completed_cases_in_this_organisation,
         "count_of_all_current_cohort_registered_cases_in_this_trust": count_of_all_current_cohort_registered_cases_in_this_trust,
         "count_of_current_cohort_registered_completed_cases_in_this_trust": count_of_current_cohort_registered_completed_cases_in_this_trust,
-        "cohort_data": cohort_data,
         "individual_kpi_choices": INDIVIDUAL_KPI_MEASURES,
         "organisation_cases_map": scatterplot_of_cases_for_selected_organisation,
         "aggregated_distances": aggregated_distances,
@@ -298,7 +302,7 @@ def selected_trust_kpis(request, organisation_id, access):
     """
     HTMX get request returning kpis.html 'Real-time Key Performance Indicator (KPI) Metrics' table.
 
-    This aggregates all KPI measures asynchronously at different levels of abstraction related to the selected organisation
+    This aggregates all KPI measures synchronously at different levels of abstraction related to the selected organisation
     Organisation level, Trust level, ICB level, NHS Region, OPEN UK level, country level and national level.
 
     It then presents each abstraction level's KPIAggregation model.
@@ -316,6 +320,11 @@ def selected_trust_kpis(request, organisation_id, access):
 
     # Get all relevant data for submission cohort
     cohort_data = cohorts_and_dates(first_paediatric_assessment_date=date.today())
+    cohort_number = (
+        cohort_data["grace_cohort"]["cohort"]
+        if cohort_data["within_grace_period"]
+        else cohort_data["submitting_cohort"]
+    )
     organisation = Organisation.objects.get(pk=organisation_id)
 
     if logged_in_user_may_access_this_organisation(request.user, organisation):
@@ -323,14 +332,12 @@ def selected_trust_kpis(request, organisation_id, access):
 
         if access == "private":
             # perform aggregations and update all the KPIAggregation models only for clinicians
-            update_all_kpi_agg_models(
-                cohort=cohort_data["submitting_cohort"], open_access=False
-            )
+            update_all_kpi_agg_models(cohort=cohort_number, open_access=False)
 
         # Gather relevant data specific for this view - still show only published data if this is public view
         all_data = get_all_kpi_aggregation_data_for_view(
             organisation=organisation,
-            cohort=cohort_data["submitting_cohort"],
+            cohort=cohort_number,
             open_access=access == "open",
         )
 
@@ -339,7 +346,7 @@ def selected_trust_kpis(request, organisation_id, access):
         # Gather relevant open access data specific for this view
         all_data = get_all_kpi_aggregation_data_for_view(
             organisation=organisation,
-            cohort=cohort_data["submitting_cohort"],
+            cohort=cohort_number,
             open_access=True,
         )
 
@@ -371,7 +378,7 @@ def selected_trust_kpis(request, organisation_id, access):
         ),  # for public view dropdown
         "last_published_date": last_published_date,
         "publish_success": False,
-        "cohort_data": cohort_data,
+        "cohort_number": cohort_number,
     }
 
     return render(
@@ -446,19 +453,22 @@ def selected_trust_select_kpi(request, organisation_id):
         # on page load there may be no kpi_name - default to paediatrician_with_experise_in_epilepsy
         kpi_name = INDIVIDUAL_KPI_MEASURES[0][0]
     kpi_name_title_case = value_from_key(key=kpi_name, choices=INDIVIDUAL_KPI_MEASURES)
-    cohort = cohorts_and_dates(first_paediatric_assessment_date=date.today())[
-        "submitting_cohort"
-    ]
+    cohort_data = cohorts_and_dates(first_paediatric_assessment_date=date.today())
+    cohort_number = (
+        cohort_data["grace_cohort"]["cohort"]
+        if cohort_data["within_grace_period"]
+        else cohort_data["submitting_cohort"]
+    )
 
     all_data = get_all_kpi_aggregation_data_for_view(
-        organisation=organisation, cohort=cohort, open_access=False
+        organisation=organisation, cohort=cohort_number, open_access=False
     )
 
     all_data = update_all_data_with_charts(
         all_data=all_data,
         kpi_name=kpi_name,
         kpi_name_title_case=kpi_name_title_case,
-        cohort=cohort,
+        cohort=cohort_number,
     )
 
     context = {

--- a/templates/epilepsy12/organisation.html
+++ b/templates/epilepsy12/organisation.html
@@ -2,7 +2,7 @@
 {% csrf_token %} {% block content %}
 <div class="ui rcpch container main_content">
   <div id="rcpch_organisation_select">
-    {% include 'epilepsy12/partials/selected_organisation_summary.html' with organisation_list=organisation_list selected_organisation=selected_organisation organisation_list=organisation_list cases_aggregated_by_ethnicity=cases_aggregated_by_ethnicity cases_aggregated_by_sex=cases_aggregated_by_sex cases_aggregated_by_deprivation=cases_aggregated_by_deprivation percent_completed_registrations=percent_completed_registrations total_registrations=total_registrations total_cases=total_cases cohort_data=cohort_data total_referred_to_neurology=total_referred_to_neurology total_referred_to_surgery=total_referred_to_surgery %}
+    {% include 'epilepsy12/partials/selected_organisation_summary.html' with organisation_list=organisation_list selected_organisation=selected_organisation organisation_list=organisation_list cases_aggregated_by_ethnicity=cases_aggregated_by_ethnicity cases_aggregated_by_sex=cases_aggregated_by_sex cases_aggregated_by_deprivation=cases_aggregated_by_deprivation percent_completed_registrations=percent_completed_registrations total_registrations=total_registrations total_cases=total_cases cohort_number=cohort_number cohort_data=cohort_data total_referred_to_neurology=total_referred_to_neurology total_referred_to_surgery=total_referred_to_surgery %}
   </div>
 
   {% if request.user.epilepsy12_audit_team_full_access %}

--- a/templates/epilepsy12/partials/kpis/kpis.html
+++ b/templates/epilepsy12/partials/kpis/kpis.html
@@ -10,7 +10,7 @@ Currently the aggregation queries are run with every page load.
         <div class="ui top attached inverted clearing segment" id="audit_top_attached_segment">
             <div class='ui header'>
                 <div class='content kpi_header'>
-                    <p>Real-time Key Performance Indicator (KPI) Metrics for Cohort {{cohort_data.submitting_cohort}}</p>
+                    <p>Real-time Key Performance Indicator (KPI) Metrics for Cohort {{cohort_number}}</p>
 
                     <p>{{organisation.name}}
                         (

--- a/templates/epilepsy12/partials/organisation/individual_metrics.html
+++ b/templates/epilepsy12/partials/organisation/individual_metrics.html
@@ -3,7 +3,7 @@
   <div class="ui top attached inverted clearing segment" id="audit_top_attached_segment">
     <div class='ui header'>
       <div class='content kpi_header'>
-        <p>Real-time Individual Key Performance Indicator (KPI) Metrics for Cohort {{ cohort }}</p>
+        <p>Real-time Individual Key Performance Indicator (KPI) Metrics for Cohort {{ cohort_number }}</p>
         {% if selected_organisation.trust %}
         <p>{{selected_organisation.name}} ({{ selected_organisation.trust.name }})</p>
         {% else %}

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -183,7 +183,7 @@
                 <div class="ui  card">
                     <div class="content">
                         <div class="ui centered header">
-                            <h3>Cohort {{cohort}} Completed Patient Records</h3>
+                            <h3>Cohort {{cohort_number}} Completed Patient Records</h3>
                         </div>
                         <div class="">
 
@@ -340,7 +340,7 @@
                                     class="info circle icon"
                                     id='organisation_cases_help'
                                     data-title='Epilepsy12 Cases Distribution'
-                                    data-content="Distribution of children with epilepsy registered within cohort {{cohort}} at {{selected_organisation}} in the Epilepsy12 audit."
+                                    data-content="Distribution of children with epilepsy registered within Cohort {{cohort_number}} at {{selected_organisation}} in the Epilepsy12 audit."
                                     data-position='top right'
                                     _="init js $('#organisation_cases_help').popup(); end"
                                 ></i>
@@ -386,7 +386,7 @@
                                     class="info circle icon"
                                     id='icb_help'
                                     data-title='Epilepsy12 Cases Distribution'
-                                    data-content="Density of children with epilepsy across ICBs, registered within cohort {{cohort}} only and who have completed one year of care at {{selected_organisation}} in the Epilepsy12 audit."
+                                    data-content="Density of children with epilepsy across ICBs, registered within Cohort {{cohort_number}} only and who have completed one year of care at {{selected_organisation}} in the Epilepsy12 audit."
                                     data-position='top right'
                                     _="init js $('#icb_help').popup(); end"
                                 ></i>
@@ -424,7 +424,7 @@
                                 class="info circle icon"
                                 id='nhsregion_help'
                                 data-title='Epilepsy12 Cases Distribution'
-                                data-content="Density of children with epilepsy across NHS England Regions, registered within cohort {{cohort}} only and who have completed one year of care at {{selected_organisation}} in the Epilepsy12 audit."
+                                data-content="Density of children with epilepsy across NHS England Regions, registered within Cohort {{cohort_number}} only and who have completed one year of care at {{selected_organisation}} in the Epilepsy12 audit."
                                 data-position='top right'
                                 _="init js $('#nhsregion_help').popup(); end"
                             ></i>
@@ -448,7 +448,7 @@
                                 class="info circle icon"
                                 id='country_help'
                                 data-title='Epilepsy12 Cases Distribution'
-                                data-content="Density of children with epilepsy across countries, registered within cohort {{cohort}} only and who have completed one year of care at {{selected_organisation}} in the Epilepsy12 audit."
+                                data-content="Density of children with epilepsy across countries, registered within Cohort {{cohort_number}} only and who have completed one year of care at {{selected_organisation}} in the Epilepsy12 audit."
                                 data-position='top right'
                                 _="init js $('#country_help').popup(); end"
                             ></i>
@@ -480,7 +480,7 @@
                 </div>
             </div>
 
-            {% include 'epilepsy12/partials/organisation/individual_metrics.html' with organisation_id=selected_organisation.pk cohort=cohort_data.submitting_cohort %}
+            {% include 'epilepsy12/partials/organisation/individual_metrics.html' with organisation_id=selected_organisation.pk cohort_number=cohort_number %}
 
         {% else %}
         
@@ -490,7 +490,7 @@
                     <div class="header">
                         No data
                     </div>
-                    <p>There is no data for cohort {{cohort_data.submitting_cohort}} at {{selected_organisation.name}}. For further information on publication dates, please check <a href="www.epilepsy12.rcpch.ac.uk">our Epilepsy12 website</a></p>
+                    <p>There is no data for Cohort {{cohort_number}} at {{selected_organisation.name}}. For further information on publication dates, please check <a href="www.epilepsy12.rcpch.ac.uk">our Epilepsy12 website</a></p>
                 </div>
             </div>
 


### PR DESCRIPTION
Fixes #1129

### Overview

Notsomuch a hotfix - more a kind of fairly warm one
We are currently in the grace period between December and the second week of January when weird things happen.

This means the next cohort to submit is actually not the currently submitting cohort (7), but 6. This has been fixed and the top half of the Organisation View but the kpi tables actually are still pulling data from cohort 7. 

This PR fixes that.

### Code changes
Refactors `cohort` to `cohort_number` in all the templates and the views. `cohort_data` (the object containing all cohort dates) remains and is used only in the `kpi_card`.

closes #1129

Thank you to Maidstone and Tunbridge Wells for picking this up