### PR TITLE
Django 5.1.4

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,7 @@ requests==2.32.3
 # third party imports
 ## django and misc
 dj_database_url==2.2.0
-django==5.1.2
+django==5.1.4
 django-auto-logout==0.5.1
 django-filter==24.3
 django-htmx==1.19.0


### PR DESCRIPTION
Fix Dependabot warnings. Neither of them are critical to apply but better to get them out of the way than let them build up.

- https://github.com/rcpch/rcpch-audit-engine/security/dependabot/18
- https://github.com/rcpch/rcpch-audit-engine/security/dependabot/17