### PR TITLE
select-model-extra-div

### DIFF
--- a/templates/epilepsy12/forms/multiaxial_diagnosis_form.html
+++ b/templates/epilepsy12/forms/multiaxial_diagnosis_form.html
@@ -1,6 +1,5 @@
 {% load epilepsy12_template_tags %}
 <form class="ui form" method="post">
-    {% csrf_token %}
 
     <div class="ui rcpch_pink segment">
 
@@ -26,8 +25,7 @@
         </div>
 
         <div class='ui rcpch_info message'>
-
-        A child or young person's epilepsy may comprise one or more episodes. Add or review all episodes, completing the initial D, E, S stages of the DESSCRIBE tool. There must be at least one episode which is considered to be epilepsy for this section to be included.
+            A child or young person's epilepsy may comprise one or more episodes. Add or review all episodes, completing the initial D, E, S stages of the DESSCRIBE tool. There must be at least one episode which is considered to be epilepsy for this section to be included.
         </div>
 
         <div id='episodes' class='fade-out fade-in field'>
@@ -56,11 +54,8 @@
             </div>
         </div>
 
-
         <div class="field" id='syndrome_section'>
-            
             {% include 'epilepsy12/partials/multiaxial_diagnosis/syndrome_section.html' with multiaxial_diagnosis=multiaxial_diagnosis %}
-
         </div>
 
     </div>
@@ -115,11 +110,11 @@
         <div id='comorbidity_section' class='field'>
             {% include 'epilepsy12/partials/multiaxial_diagnosis/comorbidities/comorbidity_section.html' with comorbidities=comorbidities %}
         </div>
-
+    
         <div id='mental_health_section' class='field'>
             {% include 'epilepsy12/partials/multiaxial_diagnosis/mental_health_section.html' with multiaxial_diagnosis=multiaxial_diagnosis mental_health_issues_choices=mental_health_issues_choices global_developmental_delay_or_learning_difficulties_severity_choices=global_developmental_delay_or_learning_difficulties_severity_choices %}
         </div>
         
-    </div>
+    </div
 
 </form>

--- a/templates/epilepsy12/multiaxial_diagnosis.html
+++ b/templates/epilepsy12/multiaxial_diagnosis.html
@@ -3,7 +3,7 @@
 Multiaxial diagnosis
 {% endblock %}
 {% block audit_section_form %}
-{% include './forms/multiaxial_diagnosis_form.html' with multiaxial_diagnosis=multiaxial_diagnosis %}
+    {% include './forms/multiaxial_diagnosis_form.html' with multiaxial_diagnosis=multiaxial_diagnosis episodes=episodes there_are_epileptic_episodes=there_are_epileptic_episodes multiaxial_diagnosis=multiaxial_diagnosis comorbidities=comorbidities mental_health_issues_choices=mental_health_issues_choices global_developmental_delay_or_learning_difficulties_severity_choices=global_developmental_delay_or_learning_difficulties_severity_choices%}
 {% endblock %}
 {% block audit_section_instructions %}
 The classification of epilepsy is multiaxial and can be described in five different ways. Work through the DESSCRIBE tool to classify the episodes.

--- a/templates/epilepsy12/partials/multiaxial_diagnosis/comorbidities/comorbidities.html
+++ b/templates/epilepsy12/partials/multiaxial_diagnosis/comorbidities/comorbidities.html
@@ -1,4 +1,5 @@
 {% load epilepsy12_template_tags %}
+{% csrf_token %}
 <div>
     {% if comorbidities|length > 0 %}
         <table class="ui rcpch basic table">

--- a/templates/epilepsy12/partials/multiaxial_diagnosis/comorbidities/comorbidity.html
+++ b/templates/epilepsy12/partials/multiaxial_diagnosis/comorbidities/comorbidity.html
@@ -1,5 +1,6 @@
 
 
+{% csrf_token %}
 <div class="ui pink message" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
 
     <div class="ui rcpch_pink segment">

--- a/templates/epilepsy12/partials/multiaxial_diagnosis/comorbidities/comorbidity_section.html
+++ b/templates/epilepsy12/partials/multiaxial_diagnosis/comorbidities/comorbidity_section.html
@@ -1,5 +1,5 @@
 {% load epilepsy12_template_tags %}
-
+{% csrf_token %}
 <div class="ui rcpch_info message">
     {% url 'relevant_impairments_behavioural_educational' multiaxial_diagnosis_id=multiaxial_diagnosis.pk as hx_post %}
     {% include 'epilepsy12/partials/page_elements/toggle_button.html' with hx_post=hx_post hx_target='#comorbidity_section' hx_trigger='click' hx_swap='innerHTML' test_positive=multiaxial_diagnosis.relevant_impairments_behavioural_educational tooltip_id='relevant_impairments_behavioural_educational_tooltip' label=multiaxial_diagnosis.get_relevant_impairments_behavioural_educational_help_label_text reference=multiaxial_diagnosis.get_relevant_impairments_behavioural_educational_help_reference_text data_position='top left' enabled=perms.epilepsy12.change_comorbidity %}

--- a/templates/epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_cause_categories.html
+++ b/templates/epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_cause_categories.html
@@ -1,4 +1,5 @@
 {% load epilepsy12_template_tags %}
+{% csrf_token %}
 <div class="field">
     {% url 'epilepsy_cause_categories' multiaxial_diagnosis_id=multiaxial_diagnosis.pk as hx_post %}
     {% include 'epilepsy12/partials/page_elements/multiple_choice_multiple_toggle_button.html' with choices=epilepsy_cause_selection hx_post=hx_post hx_target="#epilepsy_cause_categories" hx_trigger="click" hx_swap="innerHTML" test_positive=multiaxial_diagnosis.epilepsy_cause_categories tooltip_id='epilepsy_cause_categories_tooltip' label=multiaxial_diagnosis.get_epilepsy_cause_categories_help_label_text reference=multiaxial_diagnosis.get_epilepsy_cause_categories_help_reference_text data_position="top left" enabled=perms.epilepsy12.change_multiaxialdiagnosis %}

--- a/templates/epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_cause_section.html
+++ b/templates/epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_cause_section.html
@@ -1,4 +1,5 @@
 {% load epilepsy12_template_tags %}
+{% csrf_token %}
 <div class='field'>
     {% url 'epilepsy_cause_known' multiaxial_diagnosis_id=multiaxial_diagnosis.pk as hx_post %}
     {% include 'epilepsy12/partials/page_elements/toggle_button.html' with hx_post=hx_post hx_target='#epilepsy_cause_section' hx_trigger='click' hx_swap='innerHTML' test_positive=multiaxial_diagnosis.epilepsy_cause_known tooltip_id='epilepsy_cause_known_tooltip' label=multiaxial_diagnosis.get_epilepsy_cause_known_help_label_text reference=multiaxial_diagnosis.get_epilepsy_cause_known_help_reference_text data_position='top left' enabled=perms.epilepsy12.change_multiaxialdiagnosis %}

--- a/templates/epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_causes.html
+++ b/templates/epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_causes.html
@@ -4,5 +4,6 @@
 </div>
 
 <div class="field">
-  {% url "epilepsy_cause" multiaxial_diagnosis_id=multiaxial_diagnosis.pk as hx_post %} {% include 'epilepsy12/partials/page_elements/select_model.html' with choices=epilepsy_causes field_name='preferredTerm' field_name2='term' hx_post=hx_post hx_name='epilepsy_cause' hx_default_text='Select a cause (optional field)' hx_swap='innerHTML' hx_target='#epilepsy_causes' hx_trigger='change' test_positive=multiaxial_diagnosis.epilepsy_cause.pk label=multiaxial_diagnosis.get_epilepsy_cause_help_label_text reference=multiaxial_diagnosis.get_epilepsy_cause_help_reference_text enabled=perms.epilepsy12.change_multiaxialdiagnosis allow_none=True %}
+  {% url "epilepsy_cause" multiaxial_diagnosis_id=multiaxial_diagnosis.pk as hx_post %}
+  {% include 'epilepsy12/partials/page_elements/select_model.html' with choices=epilepsy_causes field_name='preferredTerm' field_name2='term' hx_post=hx_post hx_name='epilepsy_cause' hx_default_text='Select a cause (optional field)' hx_swap='innerHTML' hx_target='#epilepsy_causes' hx_trigger='change' test_positive=multiaxial_diagnosis.epilepsy_cause.pk label=multiaxial_diagnosis.get_epilepsy_cause_help_label_text reference=multiaxial_diagnosis.get_epilepsy_cause_help_reference_text enabled=perms.epilepsy12.change_multiaxialdiagnosis allow_none=True %}
 </div>

--- a/templates/epilepsy12/partials/page_elements/select_model.html
+++ b/templates/epilepsy12/partials/page_elements/select_model.html
@@ -62,20 +62,19 @@ endpoint posted to is specific to the choices. {% endcomment %}
       <div class="default text">{{hx_default_text}}</div>
       <div class="menu">
         {% if allow_none %}
-        <div class="item" data-value="empty">Not available in the list (defaults to empty on selection)</div>
+          <div class="item" data-value="empty">Not available in the list (defaults to empty on selection)</div>
         {% endif %} 
-        {% for item in choices %}
-            <div class="item" data-value="{{item.pk}}">
-              {% value_for_field_name item field_name False %} 
-              {% value_for_field_name item field_name2 True %}
-            </div>
-        {% endfor %}
-      </div>
-    </div>
+          {% for item in choices %}
+              <div class="item" data-value="{{item.pk}}">
+                {% value_for_field_name item field_name False %} 
+                {% value_for_field_name item field_name2 True %}
+              </div>
+          {% endfor %}
+      </div><!--menu-->
+    
+
     {% if not enabled %}
-    <small class="rcpch_warning_label"
-      >You do not have permission to update this field</small
-    >
+      <small class="rcpch_warning_label">You do not have permission to update this field</small>
     {% endif %}
-  </div>
-</div>
+  </div><!--dropdown-->
+</div><!--field-->


### PR DESCRIPTION
### Overview

This fixes the template rendering errors leading to the multiaxial diagnosis form not encompassing all the fields. This is because the latest changes to the `select_model` partial introduced an extra `</div>` tag having a knock on effect on the comorbidity section
