### PR TITLE
medicine-choices

### DIFF
--- a/epilepsy12/common_view_functions/__init__.py
+++ b/epilepsy12/common_view_functions/__init__.py
@@ -25,6 +25,7 @@ from .aggregate_by import (
     _seed_all_aggregation_models,
     _calculate_all_kpis,
 )
+from .medicine_choices import get_medicine_choices
 from .report_queries import (
     all_registered_cases_for_cohort_and_abstraction_level,
     get_all_nhs_regions,

--- a/epilepsy12/common_view_functions/medicine_choices.py
+++ b/epilepsy12/common_view_functions/medicine_choices.py
@@ -1,0 +1,32 @@
+from django.apps import apps
+
+
+def get_medicine_choices(management, antiepilepsy_medicine_id=None, is_rescue=False):
+    """
+    Returns list of comorbidities to populate dropdown lists
+    Removes any items that have already been selected
+    Accepts a multiaxial diagnosis instance
+    """
+
+    AntiEpilepsyMedicine = apps.get_model("epilepsy12", "AntiEpilepsyMedicine")
+    Medicine = apps.get_model("epilepsy12", "Medicine")
+
+    # Get all comorbidity entities that have been selected for this multiaxial diagnosis except the current one
+    all_selected_medicines = (
+        AntiEpilepsyMedicine.objects.filter(management=management)
+        .exclude(pk=antiepilepsy_medicine_id)
+        .values_list("medicine_entity", flat=True)
+    )
+
+    # Filter out None values from all_selected_medicines
+    all_selected_medicineentities = [
+        entity for entity in all_selected_medicines if entity is not None
+    ]
+
+    comorbidity_choices = (
+        Medicine.objects.filter(is_rescue=is_rescue)
+        .exclude(pk__in=all_selected_medicineentities)
+        .order_by("preferredTerm")
+    )
+
+    return comorbidity_choices

--- a/epilepsy12/views/management_views.py
+++ b/epilepsy12/views/management_views.py
@@ -14,6 +14,7 @@ from epilepsy12.models import (
 from ..common_view_functions import (
     validate_and_update_model,
     recalculate_form_generate_response,
+    get_medicine_choices,
 )
 from ..decorator import user_may_view_this_child, login_and_otp_required
 
@@ -160,16 +161,11 @@ def add_antiepilepsy_medicine(request, management_id, is_rescue_medicine):
 
     # get all medicines excluding those already selected, and excluding this medicine
     management = antiepilepsy_medicine.management
-    all_selected_antiepilepsymedicines = (
-        AntiEpilepsyMedicine.objects.filter(management=management)
-        .exclude(pk=antiepilepsy_medicine.pk)
-        .values_list("medicine_entity", flat=True)
-    )
 
-    choices = (
-        Medicine.objects.filter(is_rescue=antiepilepsy_medicine.is_rescue_medicine)
-        .exclude(pk__in=all_selected_antiepilepsymedicines)
-        .order_by("medicine_name")
+    choices = get_medicine_choices(
+        antiepilepsy_medicine_id=antiepilepsy_medicine.pk,
+        is_rescue=is_rescue,
+        management=management,
     )
 
     context = {
@@ -344,16 +340,11 @@ def medicine_id(request, antiepilepsy_medicine_id):
 
     # get all medicines excluding those already selected, and excluding this medicine
     management = antiepilepsy_medicine.management
-    all_selected_antiepilepsymedicines = (
-        AntiEpilepsyMedicine.objects.filter(management=management)
-        .exclude(pk=antiepilepsy_medicine_id)
-        .values_list("medicine_entity", flat=True)
-    )
 
-    choices = (
-        Medicine.objects.filter(is_rescue=antiepilepsy_medicine.is_rescue_medicine)
-        .exclude(pk__in=all_selected_antiepilepsymedicines)
-        .order_by("medicine_name")
+    choices = get_medicine_choices(
+        antiepilepsy_medicine_id=antiepilepsy_medicine.pk,
+        is_rescue=antiepilepsy_medicine.is_rescue_medicine,
+        management=management,
     )
 
     # get id of medicine entity


### PR DESCRIPTION
### Overview

The medicine dropdowns were not populating correctly so a `get_medicine_choices` function has been created to exclude all previously selected medicines except the one currently selected. It accepts an `is_rescue` flag to differentiate between the two different lists.

fixes #1141