### PR TITLE
no-location-data

### DIFF
--- a/epilepsy12/common_view_functions/filter_cases_for_geography.py
+++ b/epilepsy12/common_view_functions/filter_cases_for_geography.py
@@ -18,6 +18,9 @@ def filter_all_registered_cases_by_active_lead_site_and_cohort_and_level_of_abst
     filtered_cases = (
         Case.objects.filter(
             ~Q(postcode__in=UNKNOWN_POSTCODES_NO_SPACES),
+            location_wgs84__isnull=False,  # Ensure location is not null
+            site__organisation__longitude__isnull=False,  # Ensure location is not null
+            site__organisation__latitude__isnull=False,  # Ensure location is not null
             registration__isnull=False,
             registration__cohort=cohort,
             site__organisation=organisation,

--- a/epilepsy12/common_view_functions/scatterplot_from_cases.py
+++ b/epilepsy12/common_view_functions/scatterplot_from_cases.py
@@ -88,6 +88,9 @@ def generate_dataframe_and_aggregated_distance_data_from_cases(filtered_cases):
 
     if not geo_df.empty:
         if "location_wgs84" in geo_df.columns:
+            # Filter out rows where location_wgs84 is None - this should have been filtered out in the query in any case
+            geo_df = geo_df[geo_df["location_wgs84"].notnull()]
+
             geo_df["longitude"] = geo_df["location_wgs84"].apply(lambda loc: loc.x)
             geo_df["latitude"] = geo_df["location_wgs84"].apply(lambda loc: loc.y)
             geo_df["distance_km"] = geo_df["distance_from_lead_organisation"].apply(
@@ -97,12 +100,12 @@ def generate_dataframe_and_aggregated_distance_data_from_cases(filtered_cases):
                 lambda d: d.mi
             )
 
-            max_distance_travelled_km = geo_df["distance_km"].min()
+            max_distance_travelled_km = geo_df["distance_km"].max()
             mean_distance_travelled_km = geo_df["distance_km"].mean()
             median_distance_travelled_km = geo_df["distance_km"].median()
             std_distance_travelled_km = geo_df["distance_km"].std()
 
-            max_distance_travelled_mi = geo_df["distance_mi"].min()
+            max_distance_travelled_mi = geo_df["distance_mi"].max()
             mean_distance_travelled_mi = geo_df["distance_mi"].mean()
             median_distance_travelled_mi = geo_df["distance_mi"].median()
             std_distance_travelled_mi = geo_df["distance_mi"].std()

--- a/epilepsy12/tests/common_view_functions_tests/scatterplot_tests.py
+++ b/epilepsy12/tests/common_view_functions_tests/scatterplot_tests.py
@@ -1,0 +1,121 @@
+"""
+Test the generate_dataframe_and_aggregated_distance_data_from_cases
+"""
+
+# python imports
+import pytest
+
+# Django imports
+from django.contrib.gis.geos import Point
+
+# E12 imports
+from epilepsy12.common_view_functions import (
+    generate_dataframe_and_aggregated_distance_data_from_cases,
+    filter_all_registered_cases_by_active_lead_site_and_cohort_and_level_of_abstraction,
+)
+from epilepsy12.tests.common_view_functions_tests.aggregate_by_tests.helpers import (
+    _clean_cases_from_test_db,
+    _register_cases_in_organisation,
+)
+from epilepsy12.models import (
+    Case,
+    Organisation,
+)
+
+
+@pytest.mark.django_db
+def test_generate_dataframe_and_aggregated_distance_data_from_cases(e12_case_factory):
+    """Tests the generate_dataframe_and_aggregated_distance_data_from_cases fn returns correct count.
+
+    NOTE: There is already 1 seeded Case in the test db. In this test setup, we seed 10 cases with location_wgs84
+    and distance_from_lead_organisation fields.
+
+    Thus expected total count is 10.
+    """
+
+    # removes some of the cases which are seeded earlier in the test db
+    _clean_cases_from_test_db()
+
+    # define constants
+    GOSH = Organisation.objects.get(
+        ods_code="RP401",
+        trust__ods_code="RP4",
+    )
+
+    GOSH.latitude = 51.525493
+    GOSH.longitude = -0.127568
+    MAX_DISTANCE_KM = 5
+
+    points_within_5km = [
+        {"latitude": 51.5518, "longitude": -0.1457, "distance": 3.19},
+        {"latitude": 51.5025, "longitude": -0.1698, "distance": 3.89},
+        {"latitude": 51.5679, "longitude": -0.1156, "distance": 4.79},
+        {"latitude": 51.5417, "longitude": -0.0866, "distance": 3.37},
+        {"latitude": 51.5169, "longitude": -0.1098, "distance": 1.56},
+        {"latitude": 51.5178, "longitude": -0.0893, "distance": 2.79},
+        {"latitude": 51.5558, "longitude": -0.1164, "distance": 3.46},
+        {"latitude": 51.5303, "longitude": -0.1630, "distance": 2.52},
+        {"latitude": 51.5014, "longitude": -0.1304, "distance": 2.69},
+        {"latitude": 51.5391, "longitude": -0.1136, "distance": 1.80},
+    ]
+
+    # Create 10 cases with location_wgs84 and distance_from_lead_organisation
+    _register_cases_in_organisation(["RP401"], e12_case_factory, n_cases=10)
+
+    # Generate case locations within 5 km of GOSH
+    # centre_point = Point(GOSH.longitude, GOSH.latitude)
+    for count, case in enumerate(Case.objects.all()):
+        case.location_wgs84 = Point(
+            points_within_5km[count]["longitude"],
+            points_within_5km[count]["latitude"],
+        )
+        case.save()
+
+    filtered_cases = filter_all_registered_cases_by_active_lead_site_and_cohort_and_level_of_abstraction(
+        organisation=GOSH, cohort=6
+    )
+
+    cases_queryset, geo_df = generate_dataframe_and_aggregated_distance_data_from_cases(
+        filtered_cases=filtered_cases
+    )
+
+    assert len(geo_df) == 10
+    assert cases_queryset["max_distance_travelled_km"] == "4.79"
+    assert cases_queryset["mean_distance_travelled_km"] == "3.00"
+    assert cases_queryset["median_distance_travelled_km"] == "2.98"
+    assert cases_queryset["std_distance_travelled_km"] == "0.96"
+    assert cases_queryset["max_distance_travelled_mi"] == "2.97"
+    assert cases_queryset["mean_distance_travelled_mi"] == "1.86"
+    assert cases_queryset["median_distance_travelled_mi"] == "1.85"
+    assert cases_queryset["std_distance_travelled_mi"] == "0.60"
+
+    # Test with no location data
+    for case in Case.objects.all():
+        case.location_wgs84 = None
+        case.save()
+
+    filtered_cases = filter_all_registered_cases_by_active_lead_site_and_cohort_and_level_of_abstraction(
+        organisation=GOSH, cohort=6
+    )
+
+    assert (
+        filtered_cases.count() == 0
+    ), "Filtered cases length should be 0 cases as no location data"
+
+    distances_object, geo_df = (
+        generate_dataframe_and_aggregated_distance_data_from_cases(
+            filtered_cases=filtered_cases
+        )
+    )
+
+    assert (
+        len(geo_df) == 0
+    ), "Filtered geodataframe of cases with distances should be 0 cases as no location data"
+    assert distances_object["max_distance_travelled_km"] == "~"
+    assert distances_object["mean_distance_travelled_km"] == "~"
+    assert distances_object["median_distance_travelled_km"] == "~"
+    assert distances_object["std_distance_travelled_km"] == "~"
+    assert distances_object["max_distance_travelled_mi"] == "~"
+    assert distances_object["mean_distance_travelled_mi"] == "~"
+    assert distances_object["median_distance_travelled_mi"] == "~"
+    assert distances_object["std_distance_travelled_mi"] == "~"


### PR DESCRIPTION
Fixes #1150

### Overview

A recent 500 error was reported when a patient with a valid postcode was saved without creating a value in the `location_wgs84` field. It is not clear how this happened, but likely occured when the postcodes api was down at some point. This meant no location data was available for the child and the dataframe that calculates distances from the lead centre threw an error.

This PR filters out those children where there is no location data prior to creating the dataframe and running the distance calculations. 

In addition, an incidental finding that the max distance returned was actually the min distance, so this has been fixed.

A test for this function has been added

closes #1150