### PR TITLE
Email admins on error

### DIFF
--- a/envs/env-template
+++ b/envs/env-template
@@ -48,6 +48,8 @@ EMAIL_HOST_USER= # username for SMTP service
 SMTP_EMAIL_ENABLED=True # To output emails to console, set SMTP_EMAIL_ENABLED=False
 # Password reset link expires after (in seconds)
 PASSWORD_RESET_TIMEOUT=259200
+# Error reporting when DEBUG=False. Format: <name>:<email>,<name>:<email>...
+# ADMINS="admin:admin@rcpch.ac.uk"
 
 
 # HERMES (SNOMED CT)

--- a/rcpch-audit-engine/logging_settings.py
+++ b/rcpch-audit-engine/logging_settings.py
@@ -14,7 +14,7 @@ FILE_LOG_LEVEL = os.getenv("FILE_LOG_LEVEL", "DEBUG")
 # Define the default django logger settings
 django_loggers = {
     logger_name: {
-        "handlers": ["django_console", "epilepsy12_logfile"],
+        "handlers": ["django_console", "epilepsy12_logfile", "mail_admin"],
         "level": CONSOLE_DJANGO_LOG_LEVEL,
         "propagate": False,
         "formatter": "simple_django",
@@ -32,7 +32,11 @@ django_loggers = {
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "filters": {},
+    "filters": {
+        "require_debug_false": {
+            "()": "django.utils.log.RequireDebugFalse",
+        },
+    },
     "formatters": {
         "django.server": {
             "()": "django.utils.log.ServerFormatter",
@@ -100,21 +104,24 @@ LOGGING = {
             "backupCount": 10,
             "formatter": "file",
         },
+        "mail_admins": {
+            "level": "ERROR",
+            "filters": ["require_debug_false"],
+            "class": "django.utils.log.AdminEmailHandler",
+        },
     },
     "loggers": {
         "django": {
-            "handlers": ["django_console", "epilepsy12_logfile"],
+            "handlers": ["django_console", "epilepsy12_logfile", "mail_admins"],
             "level": CONSOLE_DJANGO_LOG_LEVEL,
-
         },
-        **django_loggers,  # this injects the default django logger settings defined above
         "epilepsy12": {
-            "handlers": ["epilepsy12_console", "epilepsy12_logfile"],
+            "handlers": ["epilepsy12_console", "epilepsy12_logfile", "mail_admins"],
             "propagate": False,
             "level": CONSOLE_LOG_LEVEL,
         },
         "two_factor": {
-            "handlers": ["epilepsy12_console", "epilepsy12_logfile"],
+            "handlers": ["epilepsy12_console", "epilepsy12_logfile", "mail_admins"],
         },
     },
 }

--- a/rcpch-audit-engine/settings.py
+++ b/rcpch-audit-engine/settings.py
@@ -243,6 +243,7 @@ OTP_EMAIL_TOKEN_VALIDITY = 60 * 5  # default N(seconds) email token valid for
 
 # EMAIL SETTINGS (SMTP)
 DEFAULT_FROM_EMAIL = os.environ.get("EMAIL_DEFAULT_FROM_EMAIL")
+SERVER_EMAIL = os.environ.get("EMAIL_DEFAULT_FROM_EMAIL")
 SMTP_EMAIL_ENABLED = os.getenv("SMTP_EMAIL_ENABLED", "False") == "True"
 logger.info("SMTP_EMAIL_ENABLED: %s", SMTP_EMAIL_ENABLED)
 if SMTP_EMAIL_ENABLED is True:
@@ -267,6 +268,9 @@ PASSWORD_RESET_TIMEOUT = os.environ.get(
 
 SITE_CONTACT_EMAIL = os.environ.get("SITE_CONTACT_EMAIL")
 
+ADMINS = os.environ.get("ADMINS", '')
+if ADMINS:
+    ADMINS = [e.split(":") for e in  ADMINS.split(",")]
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.2/topics/i18n/


### PR DESCRIPTION
Re-add the default Django behaviour of emailing errors to ADMINS if DEBUG=False.

I'm going to use this as a lightweight error reporting system to try and proactively investigate errors like #1150 before users report them. It may also destroy my inbox with noise, in which case I'll turn it off again! But ideally we'd triage errors and fix or suppress.