### PR TITLE
Don't crash on user_logged_out without user

### DIFF
--- a/epilepsy12/signals.py
+++ b/epilepsy12/signals.py
@@ -56,10 +56,13 @@ def log_user_login_failed(sender, request, user=None, **kwargs):
 
 @receiver(user_logged_out)
 def log_user_logout(sender, request, user, **kwargs):
-    logger.info(f"{user} ({user.email}) logged out from {get_client_ip(request)}.")
-    VisitActivity.objects.create(
-        activity=3, ip_address=get_client_ip(request), epilepsy12user=user
-    )
+    if user:
+        logger.info(f"{user} ({user.email}) logged out from {get_client_ip(request)}.")
+        VisitActivity.objects.create(
+            activity=3, ip_address=get_client_ip(request), epilepsy12user=user
+        )
+    else:
+        logger.info(f"Anonymous user logged out from {get_client_ip(request)}.")
 
 
 # Epilepsy12User Signal handlers


### PR DESCRIPTION
Since I enabled error reporting (#1152) I've seen a couple of crashes on `/account/login`:

```
Internal Server Error: /account/logout/

AttributeError at /account/logout/
'NoneType' object has no attribute 'email'

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/views/generic/base.py", line 104, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/utils/decorators.py", line 48, in _wrapper
    return bound_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/utils/decorators.py", line 188, in _view_wrapper
    result = _process_exception(request, e)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/utils/decorators.py", line 186, in _view_wrapper
    response = view_func(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/utils/decorators.py", line 48, in _wrapper
    return bound_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/views/decorators/cache.py", line 80, in _view_wrapper
    response = view_func(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/contrib/auth/views.py", line 137, in dispatch
    return super().dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/views/generic/base.py", line 143, in dispatch
    return handler(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/contrib/auth/views.py", line 141, in post
    auth_logout(request)
    ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/contrib/auth/__init__.py", line 170, in logout
    user_logged_out.send(sender=user.__class__, request=request, user=user)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/dispatch/dispatcher.py", line 189, in send
    response = receiver(signal=self, sender=sender, **named)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/epilepsy12/signals.py", line 59, in log_user_logout
    logger.info(f"{user} ({user.email}) logged out from {get_client_ip(request)}.")
```

I've tested logging out manually and it doesn't trigger the error. So it's likely to be something related to auto logout. I've traced a session in the logs and there's a 2h15 gap between the last request and the error.

I don't really understand how the user ends up anonymous but the docs for the signal do mention that `user` can be `None`: https://docs.djangoproject.com/en/5.1/ref/contrib/auth/#django.contrib.auth.signals.user_logged_out.

I'm confident the user is actually logged out so this PR just changes the error to a log message so it doesn't trigger an email.