### PR TITLE
kpi-1

### DIFF
--- a/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_1.py
+++ b/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_1.py
@@ -29,40 +29,45 @@ def score_kpi_1(registration_instance) -> int:
         return KPI_SCORE["FAIL"]
 
     # check all fields complete for either consultant or neurologist
-    all_consultant_paediatrician_fields_complete = (
-        (assessment.consultant_paediatrician_referral_made is not None)
-        and (assessment.consultant_paediatrician_referral_date is not None)
-        and (assessment.consultant_paediatrician_input_date is not None)
-    )
-    all_paediatric_neurologist_fields_complete = (
-        (assessment.paediatric_neurologist_referral_made is not None)
-        and (assessment.paediatric_neurologist_referral_date is not None)
-        and (assessment.paediatric_neurologist_input_date is not None)
-    )
+    all_consultant_paediatrician_date_fields_complete = (
+        assessment.consultant_paediatrician_referral_date is not None
+    ) and (assessment.consultant_paediatrician_input_date is not None)
+    all_paediatric_neurologist_date_fields_complete = (
+        assessment.paediatric_neurologist_referral_date is not None
+    ) and (assessment.paediatric_neurologist_input_date is not None)
 
     # incomplete
-    if (not all_consultant_paediatrician_fields_complete) and (
-        not all_paediatric_neurologist_fields_complete
+    if (not all_consultant_paediatrician_date_fields_complete) and (
+        not all_paediatric_neurologist_date_fields_complete
     ):
         return KPI_SCORE["NOT_SCORED"]
 
     # score KPI
-    if all_consultant_paediatrician_fields_complete:
+    did_pass_paediatrician = None
+    did_pass_neurologist = None
+    if all_consultant_paediatrician_date_fields_complete:
         passed_metric = (
             assessment.consultant_paediatrician_input_date
             - assessment.consultant_paediatrician_referral_date
         ).days <= 14
         if passed_metric:
-            return KPI_SCORE["PASS"]
+            did_pass_paediatrician = True
         else:
-            return KPI_SCORE["FAIL"]
+            did_pass_paediatrician = False
 
-    elif all_paediatric_neurologist_fields_complete:
+    if all_paediatric_neurologist_date_fields_complete:
         passed_metric = (
             assessment.paediatric_neurologist_input_date
             - assessment.paediatric_neurologist_referral_date
         ).days <= 14
         if passed_metric:
-            return KPI_SCORE["PASS"]
+            did_pass_neurologist = True
         else:
-            return KPI_SCORE["FAIL"]
+            did_pass_neurologist = False
+
+    if did_pass_paediatrician or did_pass_neurologist:
+        return KPI_SCORE["PASS"]
+    elif did_pass_paediatrician is False or did_pass_neurologist:
+        return KPI_SCORE["FAIL"]
+    else:
+        return KPI_SCORE["NOT_SCORED"]

--- a/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_1.py
+++ b/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_1.py
@@ -22,28 +22,39 @@ def score_kpi_1(registration_instance) -> int:
 
     assessment = registration_instance.assessment
 
-    # never saw a consultant OR neurologist!
-    if (assessment.consultant_paediatrician_referral_made == False) and (
-        assessment.paediatric_neurologist_referral_made == False
-    ):
-        return KPI_SCORE["FAIL"]
-
-    # check all fields complete for either consultant or neurologist dates only
+    # set variables which check if date fields complete for either consultant or neurologist
+    # It is important to use the dates only because the achieved fields were introduced later so it is possible that the achieved fields are not filled in but two dates are still present.
     all_consultant_paediatrician_date_fields_complete = (
         assessment.consultant_paediatrician_referral_date is not None
-    ) and (assessment.consultant_paediatrician_input_date is not None)
+        and assessment.consultant_paediatrician_input_date is not None
+    )
+
+    all_consultant_paediatrician_date_fields_empty = (
+        assessment.consultant_paediatrician_referral_date is None
+        and assessment.consultant_paediatrician_input_date is None
+    )
+
+    some_consultant_paediatrician_date_fields_empty = (
+        assessment.consultant_paediatrician_referral_date is None
+        or assessment.consultant_paediatrician_input_date is None
+    )
+
     all_paediatric_neurologist_date_fields_complete = (
         assessment.paediatric_neurologist_referral_date is not None
-    ) and (assessment.paediatric_neurologist_input_date is not None)
+        and assessment.paediatric_neurologist_input_date is not None
+    )
 
-    # incomplete
-    if (not all_consultant_paediatrician_date_fields_complete) and (
-        not all_paediatric_neurologist_date_fields_complete
-    ):
-        return KPI_SCORE["NOT_SCORED"]
-
-    # score KPI
+    all_paediatric_neurologist_date_fields_empty = (
+        assessment.paediatric_neurologist_referral_date is None
+        and assessment.paediatric_neurologist_input_date is None
+    )
+    some_paediatric_neurologist_date_fields_empty = (
+        assessment.paediatric_neurologist_referral_date is None
+        or assessment.paediatric_neurologist_input_date is None
+    )
     did_pass = None
+
+    # all all doubled date events
     if all_consultant_paediatrician_date_fields_complete:
         passed_metric = (
             assessment.consultant_paediatrician_input_date
@@ -62,6 +73,20 @@ def score_kpi_1(registration_instance) -> int:
         if passed_metric:
             return KPI_SCORE["PASS"]
         else:
+            did_pass = False
+
+    # leaves options where some fields are empty
+    if some_consultant_paediatrician_date_fields_empty:
+        if (
+            assessment.consultant_paediatrician_referral_made is False
+            or assessment.consultant_paediatrician_input_achieved is False
+        ):
+            did_pass = False
+    if some_paediatric_neurologist_date_fields_empty:
+        if (
+            assessment.paediatric_neurologist_referral_made is False
+            or assessment.paediatric_neurologist_input_achieved is False
+        ):
             did_pass = False
 
     if did_pass is False:

--- a/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_1.py
+++ b/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_1.py
@@ -28,7 +28,7 @@ def score_kpi_1(registration_instance) -> int:
     ):
         return KPI_SCORE["FAIL"]
 
-    # check all fields complete for either consultant or neurologist
+    # check all fields complete for either consultant or neurologist dates only
     all_consultant_paediatrician_date_fields_complete = (
         assessment.consultant_paediatrician_referral_date is not None
     ) and (assessment.consultant_paediatrician_input_date is not None)
@@ -43,17 +43,16 @@ def score_kpi_1(registration_instance) -> int:
         return KPI_SCORE["NOT_SCORED"]
 
     # score KPI
-    did_pass_paediatrician = None
-    did_pass_neurologist = None
+    did_pass = None
     if all_consultant_paediatrician_date_fields_complete:
         passed_metric = (
             assessment.consultant_paediatrician_input_date
             - assessment.consultant_paediatrician_referral_date
         ).days <= 14
         if passed_metric:
-            did_pass_paediatrician = True
+            return KPI_SCORE["PASS"]
         else:
-            did_pass_paediatrician = False
+            did_pass = False
 
     if all_paediatric_neurologist_date_fields_complete:
         passed_metric = (
@@ -61,13 +60,11 @@ def score_kpi_1(registration_instance) -> int:
             - assessment.paediatric_neurologist_referral_date
         ).days <= 14
         if passed_metric:
-            did_pass_neurologist = True
+            return KPI_SCORE["PASS"]
         else:
-            did_pass_neurologist = False
+            did_pass = False
 
-    if did_pass_paediatrician or did_pass_neurologist:
-        return KPI_SCORE["PASS"]
-    elif did_pass_paediatrician is False or did_pass_neurologist:
+    if did_pass is False:
         return KPI_SCORE["FAIL"]
     else:
         return KPI_SCORE["NOT_SCORED"]

--- a/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_1.py
+++ b/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_1.py
@@ -32,107 +32,151 @@ FAIL_INPUT_DATE = REFERRAL_DATE + relativedelta(days=15)
 
 
 @pytest.mark.parametrize(
-    "consultant_paediatrician_referral_made,consultant_paediatrician_referral_date,consultant_paediatrician_input_date,paediatric_neurologist_referral_made,paediatric_neurologist_referral_date,paediatric_neurologist_input_date,expected_score",
+    "consultant_paediatrician_referral_made,consultant_paediatrician_referral_date, consultant_paediatrician_input_achieved, consultant_paediatrician_input_date,paediatric_neurologist_referral_made,paediatric_neurologist_referral_date,paediatric_neurologist_input_achieved,paediatric_neurologist_input_date,expected_score",
     [
         (
             True,
             REFERRAL_DATE,
+            True,
             PASS_INPUT_DATE,
+            False,
             None,
             None,
             None,
             KPI_SCORE["PASS"],
-        ),  # Paediatrician seen within 14 days, neurologist not involved
+        ),
         (
-            True,
-            REFERRAL_DATE,
-            PASS_INPUT_DATE,
-            True,
-            None,
-            None,
-            KPI_SCORE["PASS"],
-        ),  # Paediatrician seen within 14 days, neurologist involved but not referred
-        (
-            True,
-            REFERRAL_DATE,
-            PASS_INPUT_DATE,
             True,
             REFERRAL_DATE,
             None,
+            PASS_INPUT_DATE,
+            False,
+            None,
+            None,
+            None,
             KPI_SCORE["PASS"],
-        ),  # Paediatrician seen within 14 days, neurologist involved,  referred but not seen
+        ),
         (
             True,
             REFERRAL_DATE,
+            True,
             PASS_INPUT_DATE,
             True,
             REFERRAL_DATE,
+            True,
             PASS_INPUT_DATE,
             KPI_SCORE["PASS"],
-        ),  # Paediatrician seen within 14 days, neurologist seen within 14 days
+        ),
         (
             True,
             REFERRAL_DATE,
+            True,
             PASS_INPUT_DATE,
             True,
             REFERRAL_DATE,
+            None,
+            PASS_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),
+        (
+            True,
+            REFERRAL_DATE,
+            True,
+            PASS_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            True,
             FAIL_INPUT_DATE,
             KPI_SCORE["PASS"],
-        ),  # Paediatrician seen within 14 days, neurologist seen after 14 days - Note only one has to be seen within 14 days
+        ),
         (
             True,
             REFERRAL_DATE,
+            None,
             PASS_INPUT_DATE,
-            False,
-            REFERRAL_DATE,
-            PASS_INPUT_DATE,
-            KPI_SCORE["PASS"],
-        ),  # Paediatrician seen within 14 days, neurologist not declared referred but seen and referred within 14 days - Note only one has to be seen within 14 days
-        (
             True,
             REFERRAL_DATE,
-            PASS_INPUT_DATE,
-            False,
-            REFERRAL_DATE,
+            True,
             FAIL_INPUT_DATE,
             KPI_SCORE["PASS"],
-        ),  # Paediatrician seen within 14 days, neurologist not declared referred but seen after 14 days of referral. Note only one has to be seen within 14 days
+        ),
         (
             True,
             REFERRAL_DATE,
+            True,
             PASS_INPUT_DATE,
-            False,
+            True,
+            REFERRAL_DATE,
             None,
             FAIL_INPUT_DATE,
             KPI_SCORE["PASS"],
-        ),  # Paediatrician seen within 14 days, neurologist not declared referred, no referral date but seen after 14 days of referral - Note only one has to be seen within 14 days
+        ),
         (
             True,
             REFERRAL_DATE,
+            None,
             PASS_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            None,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),
+        (
+            True,
+            REFERRAL_DATE,
+            True,
+            PASS_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            True,
+            None,
+            KPI_SCORE["PASS"],
+        ),
+        (
             False,
+            None,
+            None,
+            None,
+            True,
+            REFERRAL_DATE,
+            True,
+            PASS_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),
+        (
+            False,
+            None,
+            None,
+            None,
+            True,
             REFERRAL_DATE,
             None,
+            PASS_INPUT_DATE,
             KPI_SCORE["PASS"],
-        ),  # Paediatrician seen within 14 days, neurologist not declared referred but referral date made but not seen
+        ),
         (
             True,
             REFERRAL_DATE,
-            PASS_INPUT_DATE,
             None,
+            None,
+            True,
             REFERRAL_DATE,
-            None,
+            True,
+            PASS_INPUT_DATE,
             KPI_SCORE["PASS"],
-        ),  # Paediatrician seen within 14 days, neurologist referral none with referral date but not seen
+        ),
         (
             True,
             REFERRAL_DATE,
-            PASS_INPUT_DATE,
             None,
+            None,
+            True,
+            REFERRAL_DATE,
             None,
             PASS_INPUT_DATE,
             KPI_SCORE["PASS"],
-        ),  # Paediatrician seen within 14 days, neurologist referral none with no input date but seen
+        ),
     ],
 )
 @pytest.mark.django_db
@@ -140,9 +184,11 @@ def test_measure_1_should_pass_seen_paediatrician(
     e12_case_factory,
     consultant_paediatrician_referral_made,
     consultant_paediatrician_referral_date,
+    consultant_paediatrician_input_achieved,
     consultant_paediatrician_input_date,
     paediatric_neurologist_referral_made,
     paediatric_neurologist_referral_date,
+    paediatric_neurologist_input_achieved,
     paediatric_neurologist_input_date,
     expected_score,
 ):
@@ -150,9 +196,11 @@ def test_measure_1_should_pass_seen_paediatrician(
     case = e12_case_factory(
         registration__assessment__consultant_paediatrician_referral_made=consultant_paediatrician_referral_made,
         registration__assessment__consultant_paediatrician_referral_date=consultant_paediatrician_referral_date,
+        registration__assessment__consultant_paediatrician_input_achieved=consultant_paediatrician_input_achieved,
         registration__assessment__consultant_paediatrician_input_date=consultant_paediatrician_input_date,
         registration__assessment__paediatric_neurologist_referral_made=paediatric_neurologist_referral_made,
         registration__assessment__paediatric_neurologist_referral_date=paediatric_neurologist_referral_date,
+        registration__assessment__paediatric_neurologist_input_achieved=paediatric_neurologist_input_achieved,
         registration__assessment__paediatric_neurologist_input_date=paediatric_neurologist_input_date,
     )
 
@@ -168,110 +216,132 @@ def test_measure_1_should_pass_seen_paediatrician(
 
     assert (
         kpi_score == expected_score
-    ), f"Patient saw a Paediatrician IN {PASS_INPUT_DATE - REFERRAL_DATE} after referral, but did not pass measure. measures - (paediatrician - referral_made: {consultant_paediatrician_referral_made}, referral date: {consultant_paediatrician_referral_date} input_date: {consultant_paediatrician_input_date}, neurologist - referral_made: {paediatric_neurologist_referral_made}, referral_date: {paediatric_neurologist_referral_date} input_date: {paediatric_neurologist_input_date}"
+    ), f"Patient saw a Paediatrician IN {PASS_INPUT_DATE - REFERRAL_DATE} after referral, but did not pass measure.\nScores\npaediatrician\n- referral_made: {consultant_paediatrician_referral_made}\n- referral date: {consultant_paediatrician_referral_date}\n- achieved: {consultant_paediatrician_input_achieved}\n- input_date: {consultant_paediatrician_input_date},\n neurologist\n- referral_made: {paediatric_neurologist_referral_made}\n- referral_date: {paediatric_neurologist_referral_date}\n- achieved: {paediatric_neurologist_input_achieved}\n- input_date: {paediatric_neurologist_input_date})\n"
 
 
 @pytest.mark.parametrize(
-    "consultant_paediatrician_referral_made,consultant_paediatrician_referral_date,consultant_paediatrician_input_date,paediatric_neurologist_referral_made,paediatric_neurologist_referral_date,paediatric_neurologist_input_date,expected_score",
+    "consultant_paediatrician_referral_made,consultant_paediatrician_referral_date, consultant_paediatrician_input_achieved, consultant_paediatrician_input_date,paediatric_neurologist_referral_made,paediatric_neurologist_referral_date,paediatric_neurologist_input_achieved,paediatric_neurologist_input_date,expected_score",
     [
         (
-            None,
-            None,
-            None,
-            True,
-            REFERRAL_DATE,
-            PASS_INPUT_DATE,
-            KPI_SCORE["PASS"],
+            None,  # consultant_paediatrician_referral_made
+            None,  # consultant_paediatrician_referral_date
+            False,  # consultant_paediatrician_input_achieved
+            None,  # consultant_paediatrician_input_date
+            True,  # paediatric_neurologist_referral_made
+            REFERRAL_DATE,  # paediatric_neurologist_referral_date
+            True,  # paediatric_neurologist_input_achieved
+            PASS_INPUT_DATE,  # paediatric_neurologist_input_date
+            KPI_SCORE["PASS"],  # expected_score
         ),  # Neurologist seen within 14 days, paediatrician not involved
         (
-            True,
-            None,
-            None,
-            True,
-            REFERRAL_DATE,
-            PASS_INPUT_DATE,
-            KPI_SCORE["PASS"],
+            True,  # consultant_paediatrician_referral_made
+            None,  # consultant_paediatrician_referral_date
+            None,  # consultant_paediatrician_input_achieved
+            None,  # consultant_paediatrician_input_date
+            True,  # paediatric_neurologist_referral_made
+            REFERRAL_DATE,  # paediatric_neurologist_referral_date
+            True,  # paediatric_neurologist_input_achieved
+            PASS_INPUT_DATE,  # paediatric_neurologist_input_date
+            KPI_SCORE["PASS"],  # expected_score
         ),  # Neurologist seen within 14 days, paediatrician involved but not referred
         (
-            True,
-            REFERRAL_DATE,
-            None,
-            True,
-            REFERRAL_DATE,
-            PASS_INPUT_DATE,
-            KPI_SCORE["PASS"],
+            True,  # consultant_paediatrician_referral_made
+            REFERRAL_DATE,  # consultant_paediatrician_referral_date
+            False,  # consultant_paediatrician_input_achieved
+            None,  # consultant_paediatrician_input_date
+            True,  # paediatric_neurologist_referral_made
+            REFERRAL_DATE,  # paediatric_neurologist_referral_date
+            True,  # paediatric_neurologist_input_achieved
+            PASS_INPUT_DATE,  # paediatric_neurologist_input_date
+            KPI_SCORE["PASS"],  # expected_score
         ),  # Neurologist seen within 14 days, paediatrician involved but not referred
         (
-            True,
-            REFERRAL_DATE,
-            PASS_INPUT_DATE,
-            True,
-            REFERRAL_DATE,
-            PASS_INPUT_DATE,
-            KPI_SCORE["PASS"],
+            True,  # consultant_paediatrician_referral_made
+            REFERRAL_DATE,  # consultant_paediatrician_referral_date
+            True,  # consultant_paediatrician_input_achieved
+            PASS_INPUT_DATE,  # consultant_paediatrician_input_date
+            True,  # paediatric_neurologist_referral_made
+            REFERRAL_DATE,  # paediatric_neurologist_referral_date
+            True,  # paediatric_neurologist_input_achieved
+            PASS_INPUT_DATE,  # paediatric_neurologist_input_date
+            KPI_SCORE["PASS"],  # expected_score
         ),  # Neurologist seen within 14 days, paediatrician seen within 14 days - both seen within 14 days so pass
         (
-            True,
-            REFERRAL_DATE,
-            FAIL_INPUT_DATE,
-            True,
-            REFERRAL_DATE,
-            PASS_INPUT_DATE,
-            KPI_SCORE["PASS"],
+            True,  # consultant_paediatrician_referral_made
+            REFERRAL_DATE,  # consultant_paediatrician_referral_date
+            True,  # consultant_paediatrician_input_achieved
+            FAIL_INPUT_DATE,  # consultant_paediatrician_input_date
+            True,  # paediatric_neurologist_referral_made
+            REFERRAL_DATE,  # paediatric_neurologist_referral_date
+            True,  # paediatric_neurologist_input_achieved
+            PASS_INPUT_DATE,  # paediatric_neurologist_input_date
+            KPI_SCORE["PASS"],  # expected_score
         ),  # Neurologist seen within 14 days, paediatrician seen after 14 days - only one has to be seen within 14 days
         (
-            False,
-            REFERRAL_DATE,
-            PASS_INPUT_DATE,
-            True,
-            REFERRAL_DATE,
-            PASS_INPUT_DATE,
-            KPI_SCORE["PASS"],
+            False,  # consultant_paediatrician_referral_made
+            REFERRAL_DATE,  # consultant_paediatrician_referral_date
+            True,  # consultant_paediatrician_input_achieved
+            PASS_INPUT_DATE,  # consultant_paediatrician_input_date
+            True,  # paediatric_neurologist_referral_made
+            REFERRAL_DATE,  # paediatric_neurologist_referral_date
+            True,  # paediatric_neurologist_input_achieved
+            PASS_INPUT_DATE,  # paediatric_neurologist_input_date
+            KPI_SCORE["PASS"],  # expected_score
         ),  # Neurologist seen within 14 days, paediatrician not declared referred but seen and referred within 14 days: both seen within 14 days so pass
         (
-            False,
-            REFERRAL_DATE,
-            FAIL_INPUT_DATE,
-            True,
-            REFERRAL_DATE,
-            PASS_INPUT_DATE,
-            KPI_SCORE["PASS"],
+            False,  # consultant_paediatrician_referral_made
+            REFERRAL_DATE,  # consultant_paediatrician_referral_date
+            True,  # consultant_paediatrician_input_achieved
+            FAIL_INPUT_DATE,  # consultant_paediatrician_input_date
+            True,  # paediatric_neurologist_referral_made
+            REFERRAL_DATE,  # paediatric_neurologist_referral_date
+            True,  # paediatric_neurologist_input_achieved
+            PASS_INPUT_DATE,  # paediatric_neurologist_input_date
+            KPI_SCORE["PASS"],  # expected_score
         ),  # Neurologist seen within 14 days, paediatrician not declared referred but seen after 14 days of referral: only one has to be seen within 14 days
         (
-            False,
-            None,
-            FAIL_INPUT_DATE,
-            True,
-            REFERRAL_DATE,
-            PASS_INPUT_DATE,
-            KPI_SCORE["PASS"],
+            False,  # consultant_paediatrician_referral_made
+            None,  # consultant_paediatrician_referral_date
+            True,  # consultant_paediatrician_input_achieved
+            FAIL_INPUT_DATE,  # consultant_paediatrician_input_date
+            True,  # paediatric_neurologist_referral_made
+            REFERRAL_DATE,  # paediatric_neurologist_referral_date
+            True,  # paediatric_neurologist_input_achieved
+            PASS_INPUT_DATE,  # paediatric_neurologist_input_date
+            KPI_SCORE["PASS"],  # expected_score
         ),  # Neurologist seen within 14 days, paediatrician not declared referred, no referral date but seen after 14 days of referral
         (
-            False,
-            REFERRAL_DATE,
-            None,
-            True,
-            REFERRAL_DATE,
-            PASS_INPUT_DATE,
-            KPI_SCORE["PASS"],
+            False,  # consultant_paediatrician_referral_made
+            REFERRAL_DATE,  # consultant_paediatrician_referral_date
+            False,  # consultant_paediatrician_input_achieved
+            None,  # consultant_paediatrician_input_date
+            True,  # paediatric_neurologist_referral_made
+            REFERRAL_DATE,  # paediatric_neurologist_referral_date
+            True,  # paediatric_neurologist_input_achieved
+            PASS_INPUT_DATE,  # paediatric_neurologist_input_date
+            KPI_SCORE["PASS"],  # expected_score
         ),  # Neurologist seen within 14 days, paediatrician not declared referred but referral date made but not seen
         (
-            None,
-            REFERRAL_DATE,
-            None,
-            True,
-            REFERRAL_DATE,
-            PASS_INPUT_DATE,
-            KPI_SCORE["PASS"],
+            None,  # consultant_paediatrician_referral_made
+            REFERRAL_DATE,  # consultant_paediatrician_referral_date
+            False,  # consultant_paediatrician_input_achieved
+            None,  # consultant_paediatrician_input_date
+            True,  # paediatric_neurologist_referral_made
+            REFERRAL_DATE,  # paediatric_neurologist_referral_date
+            True,  # paediatric_neurologist_input_achieved
+            PASS_INPUT_DATE,  # paediatric_neurologist_input_date
+            KPI_SCORE["PASS"],  # expected_score
         ),  # Neurologist seen within 14 days, paediatrician referral none with referral date but not seen
         (
-            None,
-            None,
-            PASS_INPUT_DATE,
-            True,
-            REFERRAL_DATE,
-            PASS_INPUT_DATE,
-            KPI_SCORE["PASS"],
+            None,  # consultant_paediatrician_referral_made
+            None,  # consultant_paediatrician_referral_date
+            True,  # consultant_paediatrician_input_achieved
+            PASS_INPUT_DATE,  # consultant_paediatrician_input_date
+            True,  # paediatric_neurologist_referral_made
+            REFERRAL_DATE,  # paediatric_neurologist_referral_date
+            True,  # paediatric_neurologist_input_achieved
+            PASS_INPUT_DATE,  # paediatric_neurologist_input_date
+            KPI_SCORE["PASS"],  # expected_score
         ),  # Neurologist seen within 14 days, paediatrician referral none with no input date but seen
     ],
 )
@@ -280,9 +350,11 @@ def test_measure_1_should_pass_seen_neurologist(
     e12_case_factory,
     consultant_paediatrician_referral_made,
     consultant_paediatrician_referral_date,
+    consultant_paediatrician_input_achieved,
     consultant_paediatrician_input_date,
     paediatric_neurologist_referral_made,
     paediatric_neurologist_referral_date,
+    paediatric_neurologist_input_achieved,
     paediatric_neurologist_input_date,
     expected_score,
 ):
@@ -291,9 +363,11 @@ def test_measure_1_should_pass_seen_neurologist(
     case = e12_case_factory(
         registration__assessment__consultant_paediatrician_referral_made=consultant_paediatrician_referral_made,
         registration__assessment__consultant_paediatrician_referral_date=consultant_paediatrician_referral_date,
+        registration__assessment__consultant_paediatrician_input_achieved=consultant_paediatrician_input_achieved,
         registration__assessment__consultant_paediatrician_input_date=consultant_paediatrician_input_date,
         registration__assessment__paediatric_neurologist_referral_made=paediatric_neurologist_referral_made,
         registration__assessment__paediatric_neurologist_referral_date=paediatric_neurologist_referral_date,
+        registration__assessment__paediatric_neurologist_input_achieved=paediatric_neurologist_input_achieved,
         registration__assessment__paediatric_neurologist_input_date=paediatric_neurologist_input_date,
     )
 
@@ -309,93 +383,90 @@ def test_measure_1_should_pass_seen_neurologist(
 
     assert (
         kpi_score == expected_score
-    ), f"Patient saw a Neurologist in {PASS_INPUT_DATE - REFERRAL_DATE} after referral, but did not pass measure: measures - (paediatrician - referral_made: {consultant_paediatrician_referral_made}, referral date: {consultant_paediatrician_referral_date} input_date: {consultant_paediatrician_input_date}, neurologist - referral_made: {paediatric_neurologist_referral_made}, referral_date: {paediatric_neurologist_referral_date} input_date: {paediatric_neurologist_input_date}"
+    ), f"Patient saw a Neurologist in {PASS_INPUT_DATE - REFERRAL_DATE} after referral, but did not pass measure\nScores\npaediatrician\n- referral_made: {consultant_paediatrician_referral_made}\n- referral date: {consultant_paediatrician_referral_date}\n- achieved: {consultant_paediatrician_input_achieved}\n- input_date: {consultant_paediatrician_input_date},\n neurologist\n- referral_made: {paediatric_neurologist_referral_made}\n- referral_date: {paediatric_neurologist_referral_date}\n- achieved: {paediatric_neurologist_input_achieved}\n- input_date: {paediatric_neurologist_input_date})\n"
 
 
 @pytest.mark.parametrize(
-    "consultant_paediatrician_referral_made,consultant_paediatrician_referral_date,consultant_paediatrician_input_date,paediatric_neurologist_referral_made,paediatric_neurologist_referral_date,paediatric_neurologist_input_date,expected_score",
+    "consultant_paediatrician_referral_made,consultant_paediatrician_referral_date, consultant_paediatrician_input_achieved, consultant_paediatrician_input_date,paediatric_neurologist_referral_made,paediatric_neurologist_referral_date,paediatric_neurologist_input_achieved,paediatric_neurologist_input_date,expected_score",
     [
+        (True, REFERRAL_DATE, False, None, False, None, None, None, KPI_SCORE["FAIL"]),
         (
             True,
             REFERRAL_DATE,
-            FAIL_INPUT_DATE,
-            None,
-            None,
-            None,
-            KPI_SCORE["FAIL"],
-        ),  # Paediatrician seen within 14 days, neurologist not involved
-        (
             True,
-            REFERRAL_DATE,
-            FAIL_INPUT_DATE,
-            True,
-            None,
-            None,
-            KPI_SCORE["FAIL"],
-        ),  # Paediatrician seen within 14 days, neurologist involved but not referred
-        (
-            True,
-            REFERRAL_DATE,
-            FAIL_INPUT_DATE,
-            True,
-            REFERRAL_DATE,
-            None,
-            KPI_SCORE["FAIL"],
-        ),  # Paediatrician seen within 14 days, neurologist involved but not referred
-        (
-            True,
-            REFERRAL_DATE,
-            FAIL_INPUT_DATE,
-            True,
-            REFERRAL_DATE,
-            FAIL_INPUT_DATE,
-            KPI_SCORE["FAIL"],
-        ),  # Paediatrician not seen within 14 days, neurologist not seen within 14 days# Paediatrician not seen within 14 days, neurologist seen within 14 days
-        (
-            True,
-            REFERRAL_DATE,
-            FAIL_INPUT_DATE,
-            False,
-            REFERRAL_DATE,
-            FAIL_INPUT_DATE,
-            KPI_SCORE["FAIL"],
-        ),  # Paediatrician seen within 14 days, neurologist not declared referred but seen and referred within 14 days
-        (
-            True,
-            REFERRAL_DATE,
             FAIL_INPUT_DATE,
             False,
             None,
-            FAIL_INPUT_DATE,
+            None,
+            None,
             KPI_SCORE["FAIL"],
-        ),  # Paediatrician seen within 14 days, neurologist not declared referred, no referral date but seen after 14 days of referral
+        ),
         (
             True,
             REFERRAL_DATE,
+            None,
             FAIL_INPUT_DATE,
             False,
-            REFERRAL_DATE,
+            None,
+            None,
             None,
             KPI_SCORE["FAIL"],
-        ),  # Paediatrician seen within 14 days, neurologist not declared referred but referral date made but not seen
+        ),
         (
             True,
             REFERRAL_DATE,
-            FAIL_INPUT_DATE,
             None,
+            FAIL_INPUT_DATE,
+            True,
             REFERRAL_DATE,
             None,
+            None,
             KPI_SCORE["FAIL"],
-        ),  # Paediatrician seen within 14 days, neurologist referral none with referral date but not seen
+        ),
+        (
+            False,
+            None,
+            None,
+            None,
+            True,
+            REFERRAL_DATE,
+            True,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["FAIL"],
+        ),
+        (
+            False,
+            None,
+            None,
+            None,
+            True,
+            REFERRAL_DATE,
+            None,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["FAIL"],
+        ),
         (
             True,
             REFERRAL_DATE,
-            FAIL_INPUT_DATE,
             None,
             None,
+            True,
+            REFERRAL_DATE,
+            False,
             FAIL_INPUT_DATE,
             KPI_SCORE["FAIL"],
-        ),  # Paediatrician seen within 14 days, neurologist referral none with no input date but seen
+        ),
+        (
+            False,  # consultant_paediatrician_referral_made
+            None,  # consultant_paediatrician_referral_date
+            None,  # consultant_paediatrician_input_achieved
+            None,  # consultant_paediatrician_input_date
+            True,  # paediatric_neurologist_referral_made
+            REFERRAL_DATE,  # paediatric_neurologist_referral_date
+            True,  # paediatric_neurologist_input_achieved
+            None,  # paediatric_neurologist_input_date
+            KPI_SCORE["FAIL"],  # expected_score
+        ),  # Paediatrician never referred, neurologist referred, input achieved but no date
     ],
 )
 @pytest.mark.django_db
@@ -403,9 +474,11 @@ def test_measure_1_should_fail_not_seen_paediatrician_or_neurologist_14_days_aft
     e12_case_factory,
     consultant_paediatrician_referral_made,
     consultant_paediatrician_referral_date,
+    consultant_paediatrician_input_achieved,
     consultant_paediatrician_input_date,
     paediatric_neurologist_referral_made,
     paediatric_neurologist_referral_date,
+    paediatric_neurologist_input_achieved,
     paediatric_neurologist_input_date,
     expected_score,
 ):
@@ -414,9 +487,11 @@ def test_measure_1_should_fail_not_seen_paediatrician_or_neurologist_14_days_aft
     case = e12_case_factory(
         registration__assessment__consultant_paediatrician_referral_made=consultant_paediatrician_referral_made,
         registration__assessment__consultant_paediatrician_referral_date=consultant_paediatrician_referral_date,
+        registration__assessment__consultant_paediatrician_input_achieved=consultant_paediatrician_input_achieved,
         registration__assessment__consultant_paediatrician_input_date=consultant_paediatrician_input_date,
         registration__assessment__paediatric_neurologist_referral_made=paediatric_neurologist_referral_made,
         registration__assessment__paediatric_neurologist_referral_date=paediatric_neurologist_referral_date,
+        registration__assessment__paediatric_neurologist_input_achieved=paediatric_neurologist_input_achieved,
         registration__assessment__paediatric_neurologist_input_date=paediatric_neurologist_input_date,
     )
 
@@ -432,18 +507,13 @@ def test_measure_1_should_fail_not_seen_paediatrician_or_neurologist_14_days_aft
 
     assert (
         kpi_score == expected_score
-    ), f"Patient did not see a Paediatrician/Neurologist within 14 days of referral (seen after {FAIL_INPUT_DATE - REFERRAL_DATE}), but did not fail measure: measures - (paediatrician - referral_made: {consultant_paediatrician_referral_made}, referral date: {consultant_paediatrician_referral_date} input_date: {consultant_paediatrician_input_date}, neurologist - referral_made: {paediatric_neurologist_referral_made}, referral_date: {paediatric_neurologist_referral_date} input_date: {paediatric_neurologist_input_date}"
+    ), f"Patient did not see a Paediatrician/Neurologist within 14 days of referral (seen after {FAIL_INPUT_DATE - REFERRAL_DATE}), but did not fail measure\nScores\npaediatrician\n- referral_made: {consultant_paediatrician_referral_made}\n- referral date: {consultant_paediatrician_referral_date}\n- achieved: {consultant_paediatrician_input_achieved}\n- input_date: {consultant_paediatrician_input_date},\n neurologist\n- referral_made: {paediatric_neurologist_referral_made}\n- referral_date: {paediatric_neurologist_referral_date}\n- achieved: {paediatric_neurologist_input_achieved}\n- input_date: {paediatric_neurologist_input_date})\n"
 
 
 @pytest.mark.django_db
 def test_measure_1_should_fail_no_doctor_involved(
     e12_case_factory,
 ):
-    """
-    *FAIL*
-    1)  consultant_paediatrician_referral_made = False
-        paediatric_neurologist_referral_made = False
-    """
 
     # creates a case with all audit values filled
     case = e12_case_factory(
@@ -463,290 +533,58 @@ def test_measure_1_should_fail_no_doctor_involved(
 
     assert (
         kpi_score == KPI_SCORE["FAIL"]
-    ), f"Patient did not see a Paediatrician/Neurologist, but did not fail measure"
+    ), f"Patient did not see a Paediatrician/Neurologist, but did not fail measure - no doctor involved in care"
 
 
 @pytest.mark.parametrize(
-    "consultant_paediatrician_referral_made,consultant_paediatrician_referral_date,consultant_paediatrician_input_date,paediatric_neurologist_referral_made,paediatric_neurologist_referral_date,paediatric_neurologist_input_date,expected_score",
+    "consultant_paediatrician_referral_made,consultant_paediatrician_referral_date, consultant_paediatrician_input_achieved, consultant_paediatrician_input_date,paediatric_neurologist_referral_made,paediatric_neurologist_referral_date,paediatric_neurologist_input_achieved,paediatric_neurologist_input_date,expected_score",
     [
         (
-            True,
-            REFERRAL_DATE,
-            None,
-            None,
-            None,
-            None,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Paediatrician seen within 14 days, neurologist not involved
+            True,  # consultant_paediatrician_referral_made
+            REFERRAL_DATE,  # consultant_paediatrician_referral_date
+            None,  # consultant_paediatrician_input_achieved
+            None,  # consultant_paediatrician_input_date
+            None,  # paediatric_neurologist_referral_made
+            None,  # paediatric_neurologist_referral_date
+            None,  # paediatric_neurologist_input_achieved
+            None,  # paediatric_neurologist_input_date
+            KPI_SCORE["NOT_SCORED"],  # expected_score
+        ),  # Paediatrician referred but no other dates
         (
-            True,
-            REFERRAL_DATE,
-            None,
-            True,
-            None,
-            None,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Paediatrician seen within 14 days, neurologist involved but not referred
-        (
-            True,
-            REFERRAL_DATE,
-            None,
-            True,
-            REFERRAL_DATE,
-            None,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Paediatrician seen within 14 days, neurologist involved but not referred
-        (
-            True,
-            REFERRAL_DATE,
-            None,
-            False,
-            None,
-            FAIL_INPUT_DATE,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Paediatrician seen within 14 days, neurologist not declared referred, no referral date but seen after 14 days of referral
-        (
-            True,
-            REFERRAL_DATE,
-            None,
-            False,
-            REFERRAL_DATE,
-            None,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Paediatrician seen within 14 days, neurologist not declared referred but referral date made but not seen
-        (
-            True,
-            REFERRAL_DATE,
-            None,
-            None,
-            REFERRAL_DATE,
-            None,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Paediatrician seen within 14 days, neurologist referral none with referral date but not seen
-        (
-            True,
-            REFERRAL_DATE,
-            None,
-            None,
-            None,
-            FAIL_INPUT_DATE,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Paediatrician seen within 14 days, neurologist referral none with no input date but seen
-        (
-            True,
-            None,
-            PASS_INPUT_DATE,
-            None,
-            None,
-            None,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Paediatrician seen within 14 days, neurologist not involved
-        (
-            True,
-            None,
-            PASS_INPUT_DATE,
-            True,
-            None,
-            None,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Paediatrician seen within 14 days, neurologist involved but not referred
-        (
-            True,
-            None,
-            PASS_INPUT_DATE,
-            True,
-            REFERRAL_DATE,
-            None,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Paediatrician seen within 14 days, neurologist involved but not referred
-        (
-            True,
-            None,
-            PASS_INPUT_DATE,
-            False,
-            None,
-            FAIL_INPUT_DATE,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Paediatrician seen within 14 days, neurologist not declared referred, no referral date but seen after 14 days of referral
-        (
-            True,
-            None,
-            PASS_INPUT_DATE,
-            False,
-            REFERRAL_DATE,
-            None,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Paediatrician seen within 14 days, neurologist not declared referred but referral date made but not seen
-        (
-            True,
-            None,
-            PASS_INPUT_DATE,
-            None,
-            REFERRAL_DATE,
-            None,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Paediatrician seen within 14 days, neurologist referral none with referral date but not seen
-        (
-            True,
-            None,
-            PASS_INPUT_DATE,
-            None,
-            None,
-            FAIL_INPUT_DATE,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Paediatrician seen within 14 days, neurologist referral none with no input date but seen
-        (
-            None,
-            None,
-            None,
-            True,
-            None,
-            PASS_INPUT_DATE,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Neurologist seen within 14 days, paediatrician not involved
-        (
-            True,
-            None,
-            None,
-            True,
-            None,
-            PASS_INPUT_DATE,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Neurologist seen within 14 days, paediatrician involved but not referred
-        (
-            True,
-            REFERRAL_DATE,
-            None,
-            True,
-            None,
-            PASS_INPUT_DATE,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Neurologist seen within 14 days, paediatrician involved but not referred
-        (
-            False,
-            None,
-            FAIL_INPUT_DATE,
-            True,
-            None,
-            PASS_INPUT_DATE,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Neurologist seen within 14 days, paediatrician not declared referred, no referral date but seen after 14 days of referral
-        (
-            False,
-            REFERRAL_DATE,
-            None,
-            True,
-            None,
-            PASS_INPUT_DATE,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Neurologist seen within 14 days, paediatrician not declared referred but referral date made but not seen
-        (
-            None,
-            REFERRAL_DATE,
-            None,
-            True,
-            None,
-            PASS_INPUT_DATE,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Neurologist seen within 14 days, paediatrician referral none with referral date but not seen
-        (
-            None,
-            None,
-            PASS_INPUT_DATE,
-            True,
-            None,
-            PASS_INPUT_DATE,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Neurologist seen within 14 days, paediatrician referral none with no input date but seen
-        (
-            None,
-            None,
-            None,
-            True,
-            REFERRAL_DATE,
-            None,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Neurologist seen within 14 days, paediatrician not involved
-        (
-            True,
-            None,
-            None,
-            True,
-            REFERRAL_DATE,
-            None,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Neurologist seen within 14 days, paediatrician involved but not referred
-        (
-            True,
-            REFERRAL_DATE,
-            None,
-            True,
-            REFERRAL_DATE,
-            None,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Neurologist seen within 14 days, paediatrician involved but not referred
-        (
-            False,
-            None,
-            FAIL_INPUT_DATE,
-            True,
-            REFERRAL_DATE,
-            None,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Neurologist seen within 14 days, paediatrician not declared referred, no referral date but seen after 14 days of referral
-        (
-            False,
-            REFERRAL_DATE,
-            None,
-            True,
-            REFERRAL_DATE,
-            None,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Neurologist seen within 14 days, paediatrician not declared referred but referral date made but not seen
-        (
-            None,
-            REFERRAL_DATE,
-            None,
-            True,
-            REFERRAL_DATE,
-            None,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Neurologist seen within 14 days, paediatrician referral none with referral date but not seen
-        (
-            None,
-            None,
-            PASS_INPUT_DATE,
-            True,
-            REFERRAL_DATE,
-            None,
-            KPI_SCORE["NOT_SCORED"],
-        ),  # Neurologist seen within 14 days, paediatrician referral none with no input date but seen
+            True,  # consultant_paediatrician_referral_made
+            REFERRAL_DATE,  # consultant_paediatrician_referral_date
+            True,  # consultant_paediatrician_input_achieved
+            None,  # consultant_paediatrician_input_date
+            True,  # paediatric_neurologist_referral_made
+            None,  # paediatric_neurologist_referral_date
+            None,  # paediatric_neurologist_input_achieved
+            None,  # paediatric_neurologist_input_date
+            KPI_SCORE["NOT_SCORED"],  # expected_score
+        ),  # Paediatrician referred, input achieved but no other dates
     ],
 )
 @pytest.mark.django_db
-def test_measure_1_not_eligible(
+def test_measure_1_not_scored(
     e12_case_factory,
     consultant_paediatrician_referral_made,
     consultant_paediatrician_referral_date,
+    consultant_paediatrician_input_achieved,
     consultant_paediatrician_input_date,
     paediatric_neurologist_referral_made,
     paediatric_neurologist_referral_date,
+    paediatric_neurologist_input_achieved,
     paediatric_neurologist_input_date,
     expected_score,
 ):
-    """
-    *NOT_SCORED*
-    1)  consultant_paediatrician_referral_made = False
-        paediatric_neurologist_referral_made = False
-    """
-
     # creates a case with all audit values filled
     case = e12_case_factory(
         registration__assessment__consultant_paediatrician_referral_made=consultant_paediatrician_referral_made,
         registration__assessment__consultant_paediatrician_referral_date=consultant_paediatrician_referral_date,
+        registration__assessment__consultant_paediatrician_input_achieved=consultant_paediatrician_input_achieved,
         registration__assessment__consultant_paediatrician_input_date=consultant_paediatrician_input_date,
         registration__assessment__paediatric_neurologist_referral_made=paediatric_neurologist_referral_made,
         registration__assessment__paediatric_neurologist_referral_date=paediatric_neurologist_referral_date,
+        registration__assessment__paediatric_neurologist_input_achieved=paediatric_neurologist_input_achieved,
         registration__assessment__paediatric_neurologist_input_date=paediatric_neurologist_input_date,
     )
 
@@ -762,4 +600,294 @@ def test_measure_1_not_eligible(
 
     assert (
         kpi_score == expected_score
-    ), f"Patient (paediatrician - referral_made: {consultant_paediatrician_referral_made}, referral date: {consultant_paediatrician_referral_date} input_date: {consultant_paediatrician_input_date}, neurologist - referral_made: {paediatric_neurologist_referral_made}, referral_date: {paediatric_neurologist_referral_date} input_date: {paediatric_neurologist_input_date} did not have enough criteria to pass or fail measure , but did not return NOT_SCORED"
+    ), f"Patient did not have enough criteria to pass or fail measure, but did not return NOT_SCORED\nScores\npaediatrician\n- referral_made: {consultant_paediatrician_referral_made}\n- referral date: {consultant_paediatrician_referral_date}\n- achieved: {consultant_paediatrician_input_achieved}\n- input_date: {consultant_paediatrician_input_date},\n neurologist\n- referral_made: {paediatric_neurologist_referral_made}\n- referral_date: {paediatric_neurologist_referral_date}\n- achieved: {paediatric_neurologist_input_achieved}\n- input_date: {paediatric_neurologist_input_date})\n"
+
+
+"""
+PASSES
+- [ ] Paediatrician seen withing 14 days, no neurology input or referral
+Paediatrician
+- consultant_paediatrician_referral_made               True
+- consultant_paediatrician_referral_date                 REFERRAL_DATE
+- consultant_paediatrician_input_achieved             True
+- consultant_paediatrician_input_date                     PASS_INPUT_DATE
+Neurologist
+- paediatric_neurologist_referral_made                   False
+- paediatric_neurologist_referral_date                     None
+- paediatric_neurologist_input_achieved                 None
+- paediatric_neurologist_input_date                         None
+# (True, REFERRAL_DATE, True, PASS_INPUT_DATE, False, None, None, None, KPI_SCORE["PASS"])
+
+- [ ] Paediatrician seen withing 14 days (input achieved None as before introduced), no neurology input or referral
+Paediatrician                                                               True
+- consultant_paediatrician_referral_made               REFERRAL_DATE
+- consultant_paediatrician_input_achieved             None
+- consultant_paediatrician_input_date                     PASS_INPUT_DATE
+Neurologist
+- paediatric_neurologist_referral_made                  False
+- paediatric_neurologist_referral_date                    None
+- paediatric_neurologist_input_achieved                None
+- paediatric_neurologist_input_date                        None
+# (True, REFERRAL_DATE, None, PASS_INPUT_DATE, False, None, None, None, KPI_SCORE["PASS"])
+
+- [ ] Paediatrician seen within 14 days, neurologist referred and seen in 14 days
+Paediatrician
+- consultant_paediatrician_referral_made              True
+- paediatric_neurologist_referral_date                    REFERRAL_DATE
+- consultant_paediatrician_input_achieved             True
+- consultant_paediatrician_input_date                   PASS_INPUT_DATE
+Neurologist
+- paediatric_neurologist_referral_made                   True
+- paediatric_neurologist_referral_date                      REFERRAL_DATE
+- paediatric_neurologist_input_achieved                   True
+- paediatric_neurologist_input_date                         PASS_INPUT_DATE
+# (True, REFERRAL_DATE, True, PASS_INPUT_DATE, True, REFERRAL_DATE, True, PASS_INPUT_DATE, KPI_SCORE["PASS"]))
+
+- [ ] Paediatrician seen within 14 days, neurologist referred and seen in 14 days (input achieved None as before introduced)
+Paediatrician
+- consultant_paediatrician_referral_made                True
+- paediatric_neurologist_referral_date                   REFERRAL_DATE
+- consultant_paediatrician_input_achieved           True
+- consultant_paediatrician_input_date                   PASS_INPUT_DATE
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                      REFERRAL_DATE
+- paediatric_neurologist_input_achieved                 None
+- paediatric_neurologist_input_date                         PASS_INPUT_DATE
+# (True, REFERRAL_DATE, True, PASS_INPUT_DATE, True, REFERRAL_DATE, None, PASS_INPUT_DATE, KPI_SCORE["PASS"]))
+
+- [ ] Paediatrician seen within 14 days, neurologist referred but not seen in 14 days 
+Paediatrician
+- consultant_paediatrician_referral_made                True
+- paediatric_neurologist_referral_date                   REFERRAL_DATE
+- consultant_paediatrician_input_achieved           True
+- consultant_paediatrician_input_date                   PASS_INPUT_DATE
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                      REFERRAL_DATE
+- paediatric_neurologist_input_achieved                 True
+- paediatric_neurologist_input_date                         FAIL_INPUT_DATE
+# (True, REFERRAL_DATE, True, PASS_INPUT_DATE, True, REFERRAL_DATE, True, FAIL_INPUT_DATE, KPI_SCORE["PASS"]))
+
+- [ ] Paediatrician seen within 14 days (input achieved None as before introduced), neurologist referred but not seen in 14 days 
+Paediatrician
+- consultant_paediatrician_referral_made                True
+- paediatric_neurologist_referral_date                   REFERRAL_DATE
+- consultant_paediatrician_input_achieved           None
+- consultant_paediatrician_input_date                   PASS_INPUT_DATE
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                      REFERRAL_DATE
+- paediatric_neurologist_input_achieved                 True
+- paediatric_neurologist_input_date                         FAIL_INPUT_DATE
+# (True,REFERRAL_DATE,None,PASS_INPUT_DATE,True,REFERRAL_DATE,True,FAIL_INPUT_DATE, KPI_SCORE["PASS"]))
+
+- [ ] Paediatrician seen within 14 days, neurologist referred but not seen in 14 days (input achieved None as before introduced)
+Paediatrician
+- consultant_paediatrician_referral_made                True
+- paediatric_neurologist_referral_date                   REFERRAL_DATE
+- consultant_paediatrician_input_achieved           True
+- consultant_paediatrician_input_date                   PASS_INPUT_DATE
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                      REFERRAL_DATE
+- paediatric_neurologist_input_achieved                 None
+- paediatric_neurologist_input_date                         FAIL_INPUT_DATE
+# (True, REFERRAL_DATE, True, PASS_INPUT_DATE, True, REFERRAL_DATE, None, FAIL_INPUT_DATE, KPI_SCORE["PASS"]))
+
+- [ ] Paediatrician seen within 14 days (input achieved None as before introduced), neurologist referred but not seen in 14 days (input achieved None as before introduced)
+Paediatrician
+- consultant_paediatrician_referral_made                True
+- paediatric_neurologist_referral_date                   REFERRAL_DATE
+- consultant_paediatrician_input_achieved           None
+- consultant_paediatrician_input_date                   PASS_INPUT_DATE
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                      REFERRAL_DATE
+- paediatric_neurologist_input_achieved                 None
+- paediatric_neurologist_input_date                         FAIL_INPUT_DATE
+# (True, REFERRAL_DATE, None, PASS_INPUT_DATE, True, REFERRAL_DATE, None, FAIL_INPUT_DATE, KPI_SCORE["PASS"]))
+
+- [ ] Paediatrician seen within 14 days, neurologist incomplete
+Paediatrician
+- consultant_paediatrician_referral_made                True
+- paediatric_neurologist_referral_date                   REFERRAL_DATE
+- consultant_paediatrician_input_achieved           True
+- consultant_paediatrician_input_date                   PASS_INPUT_DATE
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                      REFERRAL_DATE
+- paediatric_neurologist_input_achieved                 True
+- paediatric_neurologist_input_date                         None
+# (True, REFERRAL_DATE, True, PASS_INPUT_DATE, True, REFERRAL_DATE, True, None, KPI_SCORE["PASS"]))
+
+- [ ] Paediatrician not seen, neurologist seen within 14 days
+Paediatrician
+- consultant_paediatrician_referral_made             False
+- paediatric_neurologist_referral_date                   None
+- consultant_paediatrician_input_achieved           None
+- consultant_paediatrician_input_date                   None
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                     REFERRAL_DATE
+- paediatric_neurologist_input_achieved                 True
+- paediatric_neurologist_input_date                         PASS_INPUT_DATE
+# (False,None,None,None,True,REFERRAL_DATE,True,PASS_INPUT_DATE, KPI_SCORE["PASS"])
+
+- [ ] Paediatrician not seen, neurologist seen within 14 days (input achieved None as before introduced)
+Paediatrician
+- consultant_paediatrician_referral_made             False
+- paediatric_neurologist_referral_date                   None
+- consultant_paediatrician_input_achieved           None
+- consultant_paediatrician_input_date                   None
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                     REFERRAL_DATE
+- paediatric_neurologist_input_achieved                 None
+- paediatric_neurologist_input_date                         PASS_INPUT_DATE
+# (False,None,None,None,True,REFERRAL_DATE,None,PASS_INPUT_DATE, KPI_SCORE["PASS"])
+
+- [ ] Paediatrician incomplete, neurologist seen within 14 days
+Paediatrician
+- consultant_paediatrician_referral_made              True
+- paediatric_neurologist_referral_date                   REFERRAL_DATE
+- consultant_paediatrician_input_achieved           None
+- consultant_paediatrician_input_date                   None
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                    REFERRAL_DATE
+- paediatric_neurologist_input_achieved                True
+- paediatric_neurologist_input_date                         PASS_INPUT_DATE     
+# (True,REFERRAL_DATE,None,None,True,REFERRAL_DATE,True,PASS_INPUT_DATE, KPI_SCORE["PASS"]))
+
+- [ ] Paediatrician incomplete, neurologist seen within 14 days (input achieved None as before introduced)
+Paediatrician
+- consultant_paediatrician_referral_made              True
+- paediatric_neurologist_referral_date                   REFERRAL_DATE
+- consultant_paediatrician_input_achieved           None
+- consultant_paediatrician_input_date                   None
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                    REFERRAL_DATE
+- paediatric_neurologist_input_achieved                None
+- paediatric_neurologist_input_date                        PASS_INPUT_DATE
+# (True, REFERRAL_DATE, None, None, True, REFERRAL_DATE, None, PASS_INPUT_DATE, KPI_SCORE["PASS"]))
+
+(True, REFERRAL_DATE, True, PASS_INPUT_DATE, False, None, None, None, KPI_SCORE["PASS"]),
+(True, REFERRAL_DATE, None, PASS_INPUT_DATE, False, None, None, None, KPI_SCORE["PASS"]),
+(True, REFERRAL_DATE, True, PASS_INPUT_DATE, True, REFERRAL_DATE, True, PASS_INPUT_DATE, KPI_SCORE["PASS"])),
+(True, REFERRAL_DATE, True, PASS_INPUT_DATE, True, REFERRAL_DATE, None, PASS_INPUT_DATE, KPI_SCORE["PASS"])),
+(True, REFERRAL_DATE, True, PASS_INPUT_DATE, True, REFERRAL_DATE, True, FAIL_INPUT_DATE, KPI_SCORE["PASS"])),
+(True,REFERRAL_DATE,None,PASS_INPUT_DATE,True,REFERRAL_DATE,True,FAIL_INPUT_DATE, KPI_SCORE["PASS"])),
+(True, REFERRAL_DATE, True, PASS_INPUT_DATE, True, REFERRAL_DATE, None, FAIL_INPUT_DATE, KPI_SCORE["PASS"])),
+(True, REFERRAL_DATE, None, PASS_INPUT_DATE, True, REFERRAL_DATE, None, FAIL_INPUT_DATE, KPI_SCORE["PASS"])),
+(True, REFERRAL_DATE, True, PASS_INPUT_DATE, True, REFERRAL_DATE, True, None, KPI_SCORE["PASS"])),
+(False,None,None,None,True,REFERRAL_DATE,True,PASS_INPUT_DATE, KPI_SCORE["PASS"]),
+(False,None,None,None,True,REFERRAL_DATE,None,PASS_INPUT_DATE, KPI_SCORE["PASS"]),
+(True,REFERRAL_DATE,None,None,True,REFERRAL_DATE,True,PASS_INPUT_DATE, KPI_SCORE["PASS"])),
+(True, REFERRAL_DATE, None, None, True, REFERRAL_DATE, None, PASS_INPUT_DATE, KPI_SCORE["PASS"])),
+"""
+
+
+"""
+FAILS
+
+- [ ] Paediatrician not referred, no neurology input or referral
+Paediatrician
+- consultant_paediatrician_referral_made               False
+- consultant_paediatrician_referral_date                 None
+- consultant_paediatrician_input_achieved             None
+- consultant_paediatrician_input_date                     None
+Neurologist
+- paediatric_neurologist_referral_made                   False
+- paediatric_neurologist_referral_date                     None
+- paediatric_neurologist_input_achieved                 None
+- paediatric_neurologist_input_date                         None
+# (True, REFERRAL_DATE, False, None, False, None, None, None, KPI_SCORE["FAIL"])
+
+- [ ] Paediatrician not seen within 14 days, no neurology input or referral
+Paediatrician
+- consultant_paediatrician_referral_made               True
+- consultant_paediatrician_referral_date                 REFERRAL_DATE
+- consultant_paediatrician_input_achieved             True
+- consultant_paediatrician_input_date                     FAIL_INPUT_DATE
+Neurologist
+- paediatric_neurologist_referral_made                  False
+- paediatric_neurologist_referral_date                     None
+- paediatric_neurologist_input_achieved                 None
+- paediatric_neurologist_input_date                         None
+# (True,REFERRAL_DATE,True,FAIL_INPUT_DATE,False,None,None,None)
+
+- [ ] Paediatrician not seen within 14 days (Input achieved none as before introduced), no neurology input or referral
+Paediatrician
+- consultant_paediatrician_referral_made               True
+- consultant_paediatrician_referral_date                 REFERRAL_DATE
+- consultant_paediatrician_input_achieved             None
+- consultant_paediatrician_input_date                     FAIL_INPUT_DATE
+Neurologist
+- paediatric_neurologist_referral_made                  False
+- paediatric_neurologist_referral_date                     None
+- paediatric_neurologist_input_achieved                 None
+- paediatric_neurologist_input_date                         None
+# (True,REFERRAL_DATE,None,FAIL_INPUT_DATE,False,None,None,None)
+
+- [ ] Paediatrician not seen within 14 days, neurology incomplete
+Paediatrician
+- consultant_paediatrician_referral_made               True
+- consultant_paediatrician_referral_date                 REFERRAL_DATE
+- consultant_paediatrician_input_achieved             None
+- consultant_paediatrician_input_date                     FAIL_INPUT_DATE
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                     REFERRAL_DATE
+- paediatric_neurologist_input_achieved                 None
+- paediatric_neurologist_input_date                         None
+# (True,REFERRAL_DATE,None,FAIL_INPUT_DATE,rue,REFERRAL_DATE,None,None)
+
+- [ ] Paediatrician not referred, neurology seen but no input within 14 days
+Paediatrician
+- consultant_paediatrician_referral_made               False
+- consultant_paediatrician_referral_date                 None
+- consultant_paediatrician_input_achieved             None
+- consultant_paediatrician_input_date                     None
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                     REFERRAL_DATE
+- paediatric_neurologist_input_achieved                 True
+- paediatric_neurologist_input_date                         FAIL_INPUT_DATE
+# (False,None,None,None,True, REFERRAL_DATE,True,FAIL_INPUT_DATE)
+
+- [ ] Paediatrician not referred, neurology seen but no input within 14 days (input achieved None as before introduced)
+Paediatrician
+- consultant_paediatrician_referral_made               False
+- consultant_paediatrician_referral_date                 None
+- consultant_paediatrician_input_achieved             None
+- consultant_paediatrician_input_date                     None
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                     REFERRAL_DATE
+- paediatric_neurologist_input_achieved                 None
+- paediatric_neurologist_input_date                         FAIL_INPUT_DATE
+# (False,None,None,None,True, REFERRAL_DATE,None,FAIL_INPUT_DATE)
+
+- [ ] Paediatrician incomplete, neurology seen but no input within 14 days
+Paediatrician
+- consultant_paediatrician_referral_made               True
+- consultant_paediatrician_referral_date                 REFERRAL_DATE
+- consultant_paediatrician_input_achieved             None
+- consultant_paediatrician_input_date                     None
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                     REFERRAL_DATE
+- paediatric_neurologist_input_achieved                 FALSE
+- paediatric_neurologist_input_date                         FAIL_INPUT_DATE
+# (True,REFERRAL_DATE,None,None,True,REFERRAL_DATE,FALSE,FAIL_INPUT_DATE)
+
+(True, REFERRAL_DATE, False, None, False, None, None, None, KPI_SCORE["FAIL"]),
+(True,REFERRAL_DATE,True,FAIL_INPUT_DATE,False,None,None,None,KPI_SCORE["FAIL"]),
+(True,REFERRAL_DATE,None,FAIL_INPUT_DATE,False,None,None,None,KPI_SCORE["FAIL"]),
+(True,REFERRAL_DATE,None,FAIL_INPUT_DATE,rue,REFERRAL_DATE,None,None,KPI_SCORE["FAIL"]),
+(False,None,None,None,True, REFERRAL_DATE,True,FAIL_INPUT_DATE,KPI_SCORE["FAIL"]),
+(False,None,None,None,True, REFERRAL_DATE,None,FAIL_INPUT_DATE,KPI_SCORE["FAIL"]),
+(True,REFERRAL_DATE,None,None,True,REFERRAL_DATE,FALSE,FAIL_INPUT_DATE,KPI_SCORE["FAIL"]),
+"""

--- a/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_1.py
+++ b/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_1.py
@@ -467,6 +467,50 @@ def test_measure_1_should_pass_seen_neurologist(
             None,  # paediatric_neurologist_input_date
             KPI_SCORE["FAIL"],  # expected_score
         ),  # Paediatrician never referred, neurologist referred, input achieved but no date
+        (
+            True,
+            REFERRAL_DATE,
+            True,
+            FAIL_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            True,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["FAIL"],
+        ),
+        (
+            True,
+            REFERRAL_DATE,
+            None,
+            FAIL_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            True,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["FAIL"],
+        ),
+        (
+            True,
+            REFERRAL_DATE,
+            True,
+            FAIL_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            None,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["FAIL"],
+        ),
+        (
+            True,
+            REFERRAL_DATE,
+            None,
+            FAIL_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            None,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["FAIL"],
+        ),
     ],
 )
 @pytest.mark.django_db
@@ -879,9 +923,61 @@ Paediatrician
 Neurologist
 - paediatric_neurologist_referral_made                  True
 - paediatric_neurologist_referral_date                     REFERRAL_DATE
-- paediatric_neurologist_input_achieved                 FALSE
+- paediatric_neurologist_input_achieved                 False
 - paediatric_neurologist_input_date                         FAIL_INPUT_DATE
-# (True,REFERRAL_DATE,None,None,True,REFERRAL_DATE,FALSE,FAIL_INPUT_DATE)
+# (True,REFERRAL_DATE,None,None,True,REFERRAL_DATE,False,FAIL_INPUT_DATE)
+
+- [ ] Paediatrician complete and fail, neurology seen but no input within 14 days
+Paediatrician
+- consultant_paediatrician_referral_made               True
+- consultant_paediatrician_referral_date                 REFERRAL_DATE
+- consultant_paediatrician_input_achieved             True
+- consultant_paediatrician_input_date                     FAIL_INPUT_DATE
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                     REFERRAL_DATE
+- paediatric_neurologist_input_achieved                 True
+- paediatric_neurologist_input_date                         FAIL_INPUT_DATE
+# (True,REFERRAL_DATE,True,FAIL_INPUT_DATE,True,REFERRAL_DATE,True,FAIL_INPUT_DATE, KPI_SCORE["FAIL"]),
+
+- [ ] Paediatrician complete and fail (None for achieved), neurology seen but no input within 14 days
+Paediatrician
+- consultant_paediatrician_referral_made               True
+- consultant_paediatrician_referral_date                 REFERRAL_DATE
+- consultant_paediatrician_input_achieved             None
+- consultant_paediatrician_input_date                     FAIL_INPUT_DATE
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                     REFERRAL_DATE
+- paediatric_neurologist_input_achieved                 True
+- paediatric_neurologist_input_date                         FAIL_INPUT_DATE
+# (True,REFERRAL_DATE,None,FAIL_INPUT_DATE,True,REFERRAL_DATE,True,FAIL_INPUT_DATE, KPI_SCORE["FAIL"]),
+
+- [ ] Paediatrician complete and fail (None for achieved), neurology seen but no input within 14 days (None)
+Paediatrician
+- consultant_paediatrician_referral_made               True
+- consultant_paediatrician_referral_date                 REFERRAL_DATE
+- consultant_paediatrician_input_achieved             True
+- consultant_paediatrician_input_date                     FAIL_INPUT_DATE
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                     REFERRAL_DATE
+- paediatric_neurologist_input_achieved                 None
+- paediatric_neurologist_input_date                         FAIL_INPUT_DATE
+# (True,REFERRAL_DATE,None,FAIL_INPUT_DATE,True,REFERRAL_DATE,True,FAIL_INPUT_DATE, KPI_SCORE["FAIL"]),
+
+- [ ] Paediatrician complete and fail (None for achieved), neurology seen but no input within 14 days (None)
+Paediatrician
+- consultant_paediatrician_referral_made               True
+- consultant_paediatrician_referral_date                 REFERRAL_DATE
+- consultant_paediatrician_input_achieved             None
+- consultant_paediatrician_input_date                     FAIL_INPUT_DATE
+Neurologist
+- paediatric_neurologist_referral_made                  True
+- paediatric_neurologist_referral_date                     REFERRAL_DATE
+- paediatric_neurologist_input_achieved                 None
+- paediatric_neurologist_input_date                         FAIL_INPUT_DATE
+# (True,REFERRAL_DATE,None,FAIL_INPUT_DATE,True,REFERRAL_DATE,None,FAIL_INPUT_DATE, KPI_SCORE["FAIL"]),
 
 (True, REFERRAL_DATE, False, None, False, None, None, None, KPI_SCORE["FAIL"]),
 (True,REFERRAL_DATE,True,FAIL_INPUT_DATE,False,None,None,None,KPI_SCORE["FAIL"]),
@@ -890,4 +986,8 @@ Neurologist
 (False,None,None,None,True, REFERRAL_DATE,True,FAIL_INPUT_DATE,KPI_SCORE["FAIL"]),
 (False,None,None,None,True, REFERRAL_DATE,None,FAIL_INPUT_DATE,KPI_SCORE["FAIL"]),
 (True,REFERRAL_DATE,None,None,True,REFERRAL_DATE,FALSE,FAIL_INPUT_DATE,KPI_SCORE["FAIL"]),
+(True,REFERRAL_DATE,True,FAIL_INPUT_DATE,True,REFERRAL_DATE,True,FAIL_INPUT_DATE, KPI_SCORE["FAIL"]),
+(True,REFERRAL_DATE,None,FAIL_INPUT_DATE,True,REFERRAL_DATE,True,FAIL_INPUT_DATE, KPI_SCORE["FAIL"]),
+(True,REFERRAL_DATE,None,FAIL_INPUT_DATE,True,REFERRAL_DATE,True,FAIL_INPUT_DATE, KPI_SCORE["FAIL"]),
+(True,REFERRAL_DATE,None,FAIL_INPUT_DATE,True,REFERRAL_DATE,None,FAIL_INPUT_DATE, KPI_SCORE["FAIL"]),
 """

--- a/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_1.py
+++ b/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_1.py
@@ -60,7 +60,7 @@ FAIL_INPUT_DATE = REFERRAL_DATE + relativedelta(days=15)
             REFERRAL_DATE,
             None,
             KPI_SCORE["PASS"],
-        ),  # Paediatrician seen within 14 days, neurologist involved but not referred
+        ),  # Paediatrician seen within 14 days, neurologist involved,  referred but not seen
         (
             True,
             REFERRAL_DATE,
@@ -87,7 +87,7 @@ FAIL_INPUT_DATE = REFERRAL_DATE + relativedelta(days=15)
             REFERRAL_DATE,
             PASS_INPUT_DATE,
             KPI_SCORE["PASS"],
-        ),  # Paediatrician seen within 14 days, neurologist not declared referred but seen and referred within 14 days
+        ),  # Paediatrician seen within 14 days, neurologist not declared referred but seen and referred within 14 days - Note only one has to be seen within 14 days
         (
             True,
             REFERRAL_DATE,

--- a/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_1.py
+++ b/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_1.py
@@ -1,9 +1,5 @@
 """
 Measure 1 - paediatrician_with_expertise_in_epilepsies
-- [x] Measure 1 passed (registration.kpi.paediatrician_with_expertise_in_epilepsies = 1) are seen within 2 weeks of referral 
-registration_instance.assessment.epilepsy_specialist_nurse_input_date <= (registration_instance.assessment.epilepsy_specialist_nurse_referral_date + relativedelta(days=+14))
-- [x] Measure 1 failed (registration.assessment.paediatrician_with_expertise_in_epilepsies = 0) if paediatrician seen after two weeks from referral or not referred
-- [x] Measure 1 None if incomplete (assessment.consultant_paediatrician_referral_date or assessment.consultant_paediatrician_input_date or assessment.consultant_paediatrician_referral_made is None)
 
 Test Measure 2 - % of children and young people with epilepsy, with input by a ‘consultant paediatrician with expertise in epilepsies’ within 2 weeks of initial referral
 
@@ -30,26 +26,134 @@ from epilepsy12.models import (
 )
 from epilepsy12.constants import KPI_SCORE
 
+REFERRAL_DATE = date(2023, 1, 1)
+PASS_INPUT_DATE = REFERRAL_DATE + relativedelta(days=14)
+FAIL_INPUT_DATE = REFERRAL_DATE + relativedelta(days=15)
 
+
+@pytest.mark.parametrize(
+    "consultant_paediatrician_referral_made,consultant_paediatrician_referral_date,consultant_paediatrician_input_date,paediatric_neurologist_referral_made,paediatric_neurologist_referral_date,paediatric_neurologist_input_date,expected_score",
+    [
+        (
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            None,
+            None,
+            None,
+            KPI_SCORE["PASS"],
+        ),  # Paediatrician seen within 14 days, neurologist not involved
+        (
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            True,
+            None,
+            None,
+            KPI_SCORE["PASS"],
+        ),  # Paediatrician seen within 14 days, neurologist involved but not referred
+        (
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["PASS"],
+        ),  # Paediatrician seen within 14 days, neurologist involved but not referred
+        (
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),  # Paediatrician seen within 14 days, neurologist seen within 14 days
+        (
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),  # Paediatrician seen within 14 days, neurologist seen after 14 days - Note only one has to be seen within 14 days
+        (
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            False,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),  # Paediatrician seen within 14 days, neurologist not declared referred but seen and referred within 14 days
+        (
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            False,
+            REFERRAL_DATE,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),  # Paediatrician seen within 14 days, neurologist not declared referred but seen after 14 days of referral. Note only one has to be seen within 14 days
+        (
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            False,
+            None,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),  # Paediatrician seen within 14 days, neurologist not declared referred, no referral date but seen after 14 days of referral - Note only one has to be seen within 14 days
+        (
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            False,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["PASS"],
+        ),  # Paediatrician seen within 14 days, neurologist not declared referred but referral date made but not seen
+        (
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            None,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["PASS"],
+        ),  # Paediatrician seen within 14 days, neurologist referral none with referral date but not seen
+        (
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            None,
+            None,
+            PASS_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),  # Paediatrician seen within 14 days, neurologist referral none with no input date but seen
+    ],
+)
 @pytest.mark.django_db
 def test_measure_1_should_pass_seen_paediatrician(
     e12_case_factory,
+    consultant_paediatrician_referral_made,
+    consultant_paediatrician_referral_date,
+    consultant_paediatrician_input_date,
+    paediatric_neurologist_referral_made,
+    paediatric_neurologist_referral_date,
+    paediatric_neurologist_input_date,
+    expected_score,
 ):
-    """
-    *PASS*
-    1)  consultant_paediatrician_referral_made = True
-        consultant_paediatrician_referral_date = registration date
-        consultant_paediatrician_input_date <= 14 days after referral
-    """
-
-    REFERRAL_DATE = date(2023, 1, 1)
-    INPUT_DATE = REFERRAL_DATE + relativedelta(days=14)
-
     # creates a case with all audit values filled
     case = e12_case_factory(
-        registration__assessment__consultant_paediatrician_referral_made=True,
-        registration__assessment__consultant_paediatrician_referral_date=REFERRAL_DATE,
-        registration__assessment__consultant_paediatrician_input_date=INPUT_DATE,
+        registration__assessment__consultant_paediatrician_referral_made=consultant_paediatrician_referral_made,
+        registration__assessment__consultant_paediatrician_referral_date=consultant_paediatrician_referral_date,
+        registration__assessment__consultant_paediatrician_input_date=consultant_paediatrician_input_date,
+        registration__assessment__paediatric_neurologist_referral_made=paediatric_neurologist_referral_made,
+        registration__assessment__paediatric_neurologist_referral_date=paediatric_neurologist_referral_date,
+        registration__assessment__paediatric_neurologist_input_date=paediatric_neurologist_input_date,
     )
 
     # get registration for the saved case model
@@ -63,30 +167,134 @@ def test_measure_1_should_pass_seen_paediatrician(
     ).paediatrician_with_expertise_in_epilepsies
 
     assert (
-        kpi_score == KPI_SCORE["PASS"]
-    ), f"Patient saw a Paediatrician IN {INPUT_DATE - REFERRAL_DATE} after referral, but did not pass measure"
+        kpi_score == expected_score
+    ), f"Patient saw a Paediatrician IN {PASS_INPUT_DATE - REFERRAL_DATE} after referral, but did not pass measure. measures - (paediatrician - referral_made: {consultant_paediatrician_referral_made}, referral date: {consultant_paediatrician_referral_date} input_date: {consultant_paediatrician_input_date}, neurologist - referral_made: {paediatric_neurologist_referral_made}, referral_date: {paediatric_neurologist_referral_date} input_date: {paediatric_neurologist_input_date}"
 
 
+@pytest.mark.parametrize(
+    "consultant_paediatrician_referral_made,consultant_paediatrician_referral_date,consultant_paediatrician_input_date,paediatric_neurologist_referral_made,paediatric_neurologist_referral_date,paediatric_neurologist_input_date,expected_score",
+    [
+        (
+            None,
+            None,
+            None,
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),  # Neurologist seen within 14 days, paediatrician not involved
+        (
+            True,
+            None,
+            None,
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),  # Neurologist seen within 14 days, paediatrician involved but not referred
+        (
+            True,
+            REFERRAL_DATE,
+            None,
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),  # Neurologist seen within 14 days, paediatrician involved but not referred
+        (
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),  # Neurologist seen within 14 days, paediatrician seen within 14 days - both seen within 14 days so pass
+        (
+            True,
+            REFERRAL_DATE,
+            FAIL_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),  # Neurologist seen within 14 days, paediatrician seen after 14 days - only one has to be seen within 14 days
+        (
+            False,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),  # Neurologist seen within 14 days, paediatrician not declared referred but seen and referred within 14 days: both seen within 14 days so pass
+        (
+            False,
+            REFERRAL_DATE,
+            FAIL_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),  # Neurologist seen within 14 days, paediatrician not declared referred but seen after 14 days of referral: only one has to be seen within 14 days
+        (
+            False,
+            None,
+            FAIL_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),  # Neurologist seen within 14 days, paediatrician not declared referred, no referral date but seen after 14 days of referral
+        (
+            False,
+            REFERRAL_DATE,
+            None,
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),  # Neurologist seen within 14 days, paediatrician not declared referred but referral date made but not seen
+        (
+            None,
+            REFERRAL_DATE,
+            None,
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),  # Neurologist seen within 14 days, paediatrician referral none with referral date but not seen
+        (
+            None,
+            None,
+            PASS_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            PASS_INPUT_DATE,
+            KPI_SCORE["PASS"],
+        ),  # Neurologist seen within 14 days, paediatrician referral none with no input date but seen
+    ],
+)
 @pytest.mark.django_db
 def test_measure_1_should_pass_seen_neurologist(
     e12_case_factory,
+    consultant_paediatrician_referral_made,
+    consultant_paediatrician_referral_date,
+    consultant_paediatrician_input_date,
+    paediatric_neurologist_referral_made,
+    paediatric_neurologist_referral_date,
+    paediatric_neurologist_input_date,
+    expected_score,
 ):
-    """
-    *PASS*
-    2)  paediatric_neurologist_referral_made = True
-        paediatric_neurologist_referral_date = registration date
-        paediatric_neurologist_input_date <= 14 days after referral
-
-    """
-
-    REFERRAL_DATE = date(2023, 1, 1)
-    INPUT_DATE = REFERRAL_DATE + relativedelta(days=14)
 
     # creates a case with all audit values filled
     case = e12_case_factory(
-        registration__assessment__paediatric_neurologist_referral_made=True,
-        registration__assessment__paediatric_neurologist_referral_date=REFERRAL_DATE,
-        registration__assessment__paediatric_neurologist_input_date=INPUT_DATE,
+        registration__assessment__consultant_paediatrician_referral_made=consultant_paediatrician_referral_made,
+        registration__assessment__consultant_paediatrician_referral_date=consultant_paediatrician_referral_date,
+        registration__assessment__consultant_paediatrician_input_date=consultant_paediatrician_input_date,
+        registration__assessment__paediatric_neurologist_referral_made=paediatric_neurologist_referral_made,
+        registration__assessment__paediatric_neurologist_referral_date=paediatric_neurologist_referral_date,
+        registration__assessment__paediatric_neurologist_input_date=paediatric_neurologist_input_date,
     )
 
     # get registration for the saved case model
@@ -100,36 +308,116 @@ def test_measure_1_should_pass_seen_neurologist(
     ).paediatrician_with_expertise_in_epilepsies
 
     assert (
-        kpi_score == KPI_SCORE["PASS"]
-    ), f"Patient saw a Neurologist IN {INPUT_DATE - REFERRAL_DATE} after referral, but did not pass measure"
+        kpi_score == expected_score
+    ), f"Patient saw a Neurologist in {PASS_INPUT_DATE - REFERRAL_DATE} after referral, but did not pass measure: measures - (paediatrician - referral_made: {consultant_paediatrician_referral_made}, referral date: {consultant_paediatrician_referral_date} input_date: {consultant_paediatrician_input_date}, neurologist - referral_made: {paediatric_neurologist_referral_made}, referral_date: {paediatric_neurologist_referral_date} input_date: {paediatric_neurologist_input_date}"
 
 
+@pytest.mark.parametrize(
+    "consultant_paediatrician_referral_made,consultant_paediatrician_referral_date,consultant_paediatrician_input_date,paediatric_neurologist_referral_made,paediatric_neurologist_referral_date,paediatric_neurologist_input_date,expected_score",
+    [
+        (
+            True,
+            REFERRAL_DATE,
+            FAIL_INPUT_DATE,
+            None,
+            None,
+            None,
+            KPI_SCORE["FAIL"],
+        ),  # Paediatrician seen within 14 days, neurologist not involved
+        (
+            True,
+            REFERRAL_DATE,
+            FAIL_INPUT_DATE,
+            True,
+            None,
+            None,
+            KPI_SCORE["FAIL"],
+        ),  # Paediatrician seen within 14 days, neurologist involved but not referred
+        (
+            True,
+            REFERRAL_DATE,
+            FAIL_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["FAIL"],
+        ),  # Paediatrician seen within 14 days, neurologist involved but not referred
+        (
+            True,
+            REFERRAL_DATE,
+            FAIL_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["FAIL"],
+        ),  # Paediatrician not seen within 14 days, neurologist not seen within 14 days# Paediatrician not seen within 14 days, neurologist seen within 14 days
+        (
+            True,
+            REFERRAL_DATE,
+            FAIL_INPUT_DATE,
+            False,
+            REFERRAL_DATE,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["FAIL"],
+        ),  # Paediatrician seen within 14 days, neurologist not declared referred but seen and referred within 14 days
+        (
+            True,
+            REFERRAL_DATE,
+            FAIL_INPUT_DATE,
+            False,
+            None,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["FAIL"],
+        ),  # Paediatrician seen within 14 days, neurologist not declared referred, no referral date but seen after 14 days of referral
+        (
+            True,
+            REFERRAL_DATE,
+            FAIL_INPUT_DATE,
+            False,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["FAIL"],
+        ),  # Paediatrician seen within 14 days, neurologist not declared referred but referral date made but not seen
+        (
+            True,
+            REFERRAL_DATE,
+            FAIL_INPUT_DATE,
+            None,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["FAIL"],
+        ),  # Paediatrician seen within 14 days, neurologist referral none with referral date but not seen
+        (
+            True,
+            REFERRAL_DATE,
+            FAIL_INPUT_DATE,
+            None,
+            None,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["FAIL"],
+        ),  # Paediatrician seen within 14 days, neurologist referral none with no input date but seen
+    ],
+)
 @pytest.mark.django_db
-def test_measure_1_should_fail_not_seen_14_days_after_referral(
+def test_measure_1_should_fail_not_seen_paediatrician_or_neurologist_14_days_after_referral(
     e12_case_factory,
+    consultant_paediatrician_referral_made,
+    consultant_paediatrician_referral_date,
+    consultant_paediatrician_input_date,
+    paediatric_neurologist_referral_made,
+    paediatric_neurologist_referral_date,
+    paediatric_neurologist_input_date,
+    expected_score,
 ):
-    """
-    *FAIL*
-    1)  consultant_paediatrician_referral_made = True
-        consultant_paediatrician_referral_date = registration date
-        consultant_paediatrician_input_date > 14 days after referral
-        paediatric_neurologist_referral_made = True
-        paediatric_neurologist_referral_date = registration date
-        paediatric_neurologist_input_date > 14 days after referral
-
-    """
-
-    REFERRAL_DATE = date(2023, 1, 1)
-    INPUT_DATE = REFERRAL_DATE + relativedelta(days=15)
 
     # creates a case with all audit values filled
     case = e12_case_factory(
-        registration__assessment__consultant_paediatrician_referral_made=True,
-        registration__assessment__consultant_paediatrician_referral_date=REFERRAL_DATE,
-        registration__assessment__consultant_paediatrician_input_date=INPUT_DATE,
-        registration__assessment__paediatric_neurologist_referral_made=True,
-        registration__assessment__paediatric_neurologist_referral_date=REFERRAL_DATE,
-        registration__assessment__paediatric_neurologist_input_date=INPUT_DATE,
+        registration__assessment__consultant_paediatrician_referral_made=consultant_paediatrician_referral_made,
+        registration__assessment__consultant_paediatrician_referral_date=consultant_paediatrician_referral_date,
+        registration__assessment__consultant_paediatrician_input_date=consultant_paediatrician_input_date,
+        registration__assessment__paediatric_neurologist_referral_made=paediatric_neurologist_referral_made,
+        registration__assessment__paediatric_neurologist_referral_date=paediatric_neurologist_referral_date,
+        registration__assessment__paediatric_neurologist_input_date=paediatric_neurologist_input_date,
     )
 
     # get registration for the saved case model
@@ -143,8 +431,8 @@ def test_measure_1_should_fail_not_seen_14_days_after_referral(
     ).paediatrician_with_expertise_in_epilepsies
 
     assert (
-        kpi_score == KPI_SCORE["FAIL"]
-    ), f"Patient did not see a Paediatrician/Neurologist within 14 days of referral (seen after {INPUT_DATE - REFERRAL_DATE}), but did not fail measure"
+        kpi_score == expected_score
+    ), f"Patient did not see a Paediatrician/Neurologist within 14 days of referral (seen after {FAIL_INPUT_DATE - REFERRAL_DATE}), but did not fail measure: measures - (paediatrician - referral_made: {consultant_paediatrician_referral_made}, referral date: {consultant_paediatrician_referral_date} input_date: {consultant_paediatrician_input_date}, neurologist - referral_made: {paediatric_neurologist_referral_made}, referral_date: {paediatric_neurologist_referral_date} input_date: {paediatric_neurologist_input_date}"
 
 
 @pytest.mark.django_db
@@ -176,3 +464,302 @@ def test_measure_1_should_fail_no_doctor_involved(
     assert (
         kpi_score == KPI_SCORE["FAIL"]
     ), f"Patient did not see a Paediatrician/Neurologist, but did not fail measure"
+
+
+@pytest.mark.parametrize(
+    "consultant_paediatrician_referral_made,consultant_paediatrician_referral_date,consultant_paediatrician_input_date,paediatric_neurologist_referral_made,paediatric_neurologist_referral_date,paediatric_neurologist_input_date,expected_score",
+    [
+        (
+            True,
+            REFERRAL_DATE,
+            None,
+            None,
+            None,
+            None,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Paediatrician seen within 14 days, neurologist not involved
+        (
+            True,
+            REFERRAL_DATE,
+            None,
+            True,
+            None,
+            None,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Paediatrician seen within 14 days, neurologist involved but not referred
+        (
+            True,
+            REFERRAL_DATE,
+            None,
+            True,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Paediatrician seen within 14 days, neurologist involved but not referred
+        (
+            True,
+            REFERRAL_DATE,
+            None,
+            False,
+            None,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Paediatrician seen within 14 days, neurologist not declared referred, no referral date but seen after 14 days of referral
+        (
+            True,
+            REFERRAL_DATE,
+            None,
+            False,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Paediatrician seen within 14 days, neurologist not declared referred but referral date made but not seen
+        (
+            True,
+            REFERRAL_DATE,
+            None,
+            None,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Paediatrician seen within 14 days, neurologist referral none with referral date but not seen
+        (
+            True,
+            REFERRAL_DATE,
+            None,
+            None,
+            None,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Paediatrician seen within 14 days, neurologist referral none with no input date but seen
+        (
+            True,
+            None,
+            PASS_INPUT_DATE,
+            None,
+            None,
+            None,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Paediatrician seen within 14 days, neurologist not involved
+        (
+            True,
+            None,
+            PASS_INPUT_DATE,
+            True,
+            None,
+            None,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Paediatrician seen within 14 days, neurologist involved but not referred
+        (
+            True,
+            None,
+            PASS_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Paediatrician seen within 14 days, neurologist involved but not referred
+        (
+            True,
+            None,
+            PASS_INPUT_DATE,
+            False,
+            None,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Paediatrician seen within 14 days, neurologist not declared referred, no referral date but seen after 14 days of referral
+        (
+            True,
+            None,
+            PASS_INPUT_DATE,
+            False,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Paediatrician seen within 14 days, neurologist not declared referred but referral date made but not seen
+        (
+            True,
+            None,
+            PASS_INPUT_DATE,
+            None,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Paediatrician seen within 14 days, neurologist referral none with referral date but not seen
+        (
+            True,
+            None,
+            PASS_INPUT_DATE,
+            None,
+            None,
+            FAIL_INPUT_DATE,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Paediatrician seen within 14 days, neurologist referral none with no input date but seen
+        (
+            None,
+            None,
+            None,
+            True,
+            None,
+            PASS_INPUT_DATE,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Neurologist seen within 14 days, paediatrician not involved
+        (
+            True,
+            None,
+            None,
+            True,
+            None,
+            PASS_INPUT_DATE,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Neurologist seen within 14 days, paediatrician involved but not referred
+        (
+            True,
+            REFERRAL_DATE,
+            None,
+            True,
+            None,
+            PASS_INPUT_DATE,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Neurologist seen within 14 days, paediatrician involved but not referred
+        (
+            False,
+            None,
+            FAIL_INPUT_DATE,
+            True,
+            None,
+            PASS_INPUT_DATE,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Neurologist seen within 14 days, paediatrician not declared referred, no referral date but seen after 14 days of referral
+        (
+            False,
+            REFERRAL_DATE,
+            None,
+            True,
+            None,
+            PASS_INPUT_DATE,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Neurologist seen within 14 days, paediatrician not declared referred but referral date made but not seen
+        (
+            None,
+            REFERRAL_DATE,
+            None,
+            True,
+            None,
+            PASS_INPUT_DATE,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Neurologist seen within 14 days, paediatrician referral none with referral date but not seen
+        (
+            None,
+            None,
+            PASS_INPUT_DATE,
+            True,
+            None,
+            PASS_INPUT_DATE,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Neurologist seen within 14 days, paediatrician referral none with no input date but seen
+        (
+            None,
+            None,
+            None,
+            True,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Neurologist seen within 14 days, paediatrician not involved
+        (
+            True,
+            None,
+            None,
+            True,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Neurologist seen within 14 days, paediatrician involved but not referred
+        (
+            True,
+            REFERRAL_DATE,
+            None,
+            True,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Neurologist seen within 14 days, paediatrician involved but not referred
+        (
+            False,
+            None,
+            FAIL_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Neurologist seen within 14 days, paediatrician not declared referred, no referral date but seen after 14 days of referral
+        (
+            False,
+            REFERRAL_DATE,
+            None,
+            True,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Neurologist seen within 14 days, paediatrician not declared referred but referral date made but not seen
+        (
+            None,
+            REFERRAL_DATE,
+            None,
+            True,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Neurologist seen within 14 days, paediatrician referral none with referral date but not seen
+        (
+            None,
+            None,
+            PASS_INPUT_DATE,
+            True,
+            REFERRAL_DATE,
+            None,
+            KPI_SCORE["NOT_SCORED"],
+        ),  # Neurologist seen within 14 days, paediatrician referral none with no input date but seen
+    ],
+)
+@pytest.mark.django_db
+def test_measure_1_not_eligible(
+    e12_case_factory,
+    consultant_paediatrician_referral_made,
+    consultant_paediatrician_referral_date,
+    consultant_paediatrician_input_date,
+    paediatric_neurologist_referral_made,
+    paediatric_neurologist_referral_date,
+    paediatric_neurologist_input_date,
+    expected_score,
+):
+    """
+    *NOT_SCORED*
+    1)  consultant_paediatrician_referral_made = False
+        paediatric_neurologist_referral_made = False
+    """
+
+    # creates a case with all audit values filled
+    case = e12_case_factory(
+        registration__assessment__consultant_paediatrician_referral_made=consultant_paediatrician_referral_made,
+        registration__assessment__consultant_paediatrician_referral_date=consultant_paediatrician_referral_date,
+        registration__assessment__consultant_paediatrician_input_date=consultant_paediatrician_input_date,
+        registration__assessment__paediatric_neurologist_referral_made=paediatric_neurologist_referral_made,
+        registration__assessment__paediatric_neurologist_referral_date=paediatric_neurologist_referral_date,
+        registration__assessment__paediatric_neurologist_input_date=paediatric_neurologist_input_date,
+    )
+
+    # get registration for the saved case model
+    registration = Registration.objects.get(case=case)
+
+    calculate_kpis(registration_instance=registration)
+
+    # ensure we get the updated database object, not the Python object
+    kpi_score = KPI.objects.get(
+        pk=registration.kpi.pk
+    ).paediatrician_with_expertise_in_epilepsies
+
+    assert (
+        kpi_score == expected_score
+    ), f"Patient (paediatrician - referral_made: {consultant_paediatrician_referral_made}, referral date: {consultant_paediatrician_referral_date} input_date: {consultant_paediatrician_input_date}, neurologist - referral_made: {paediatric_neurologist_referral_made}, referral_date: {paediatric_neurologist_referral_date} input_date: {paediatric_neurologist_input_date} did not have enough criteria to pass or fail measure , but did not return NOT_SCORED"

--- a/epilepsy12/views/case_views.py
+++ b/epilepsy12/views/case_views.py
@@ -665,6 +665,9 @@ def update_case(request, organisation_id, case_id):
             case.registration.kpi.delete()
             case.registration.audit_progress.delete()
             # deletes related registration, KPI and Registration if they exist
+        case.updated_at = timezone.now()
+        case.updated_by = request.user
+        case.save()  # save the updated case before deleting it to ensure the updated_at and updated_by fields are updated
         case.delete()
         url = reverse("cases", kwargs={"organisation_id": organisation_id})
         return HttpResponseClientRedirect(redirect_to=url, status=200)


### PR DESCRIPTION
### Overview

Recalculate KPI 1
The addition of `paediatric_neurologist_input_achieved` or `paediatric_neurologist_input_achieved` fields introduced options where edge cases were not being correctly scored. 
This introduces a reworking of the measure and 39 additional tests to cover the edge cases

closes #1154