### PR TITLE
fix-mri-unscored

### DIFF
--- a/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_5.py
+++ b/epilepsy12/common_view_functions/calculate_kpi_functions/score_kpi_5.py
@@ -54,7 +54,7 @@ def score_kpi_5(registration_instance, age_at_first_paediatric_assessment) -> in
 
         if investigations.mri_indicated is not None:
             if any(mri_dates_are_none) and investigations.mri_indicated is True:
-                return KPI_SCORE["NOT_SCORED"]
+                return KPI_SCORE["FAIL"]
             elif investigations.mri_indicated is False:
                 return KPI_SCORE["FAIL"]
 

--- a/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_5.py
+++ b/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_5.py
@@ -14,7 +14,7 @@ AND
 
 - [ x] Measure 5 passed (registration.kpi.mri == 1) if MRI done in 6 weeks and are NOT JME or JAE or CAE or CECTS/Rolandic or Epilepsy with generalized tonic–clonic seizures alone (lines 270-324)
 - [ x] Measure 5 failed (registration.kpi.mri == 0) if MRI not done in 6 weeks and are NOT JME or JAE or CAE or CECTS/Rolandic or Epilepsy with generalized tonic–clonic seizures alone (lines 270-324)
-- [ x] Measure 5 ineligible (registration.kpi.mri == 0) if JME or JAE or CAE or CECTS/Rolandic or Epilepsy with generalized tonic–clonic seizures alone
+- [ x] Measure 5 ineligible (registration.kpi.mri ==2) if JME or JAE or CAE or CECTS/Rolandic or Epilepsy with generalized tonic–clonic seizures alone
 """
 
 # Standard imports
@@ -182,6 +182,16 @@ def test_measure_5_mri_syndromes_pass_fail(
         assert (
             kpi_score == EXPECTED_SCORE
         ), f"None of JME or JAE or CAE or CECTS/Rolandi present, MRI booked > 6 weeks but not failing measure"
+
+    registration.investigations.mri_brain_requested_date = None
+    registration.investigations.mri_brain_reported_date = None
+    registration.investigations.mri_indicated = True
+    registration.investigations.save()
+
+    calculate_kpis(registration_instance=registration)
+
+    kpi_score = KPI.objects.get(pk=registration.kpi.pk).mri
+    assert kpi_score == KPI_SCORE["FAIL"], "MRI indicated but no dates should fail."
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Overview

In the KPI 5 calculation, if `mri_indicated` were scored true, and a date is missing, the measure should faily but currently returns `NOT_SCORED`

This has been fixed. The comment also has been corrected to return the correct value.

A new test has been added for this.

closes #1158