### PR TITLE
HOTFIX: Temporarily unplug earliest_allowable_date validation

### DIFF
--- a/epilepsy12/views/registration_views.py
+++ b/epilepsy12/views/registration_views.py
@@ -600,18 +600,19 @@ def first_paediatric_assessment_date(request, case_id):
     case = Case.objects.get(pk=case_id)
     registration = Registration.objects.filter(case=case).get()
 
-    if request.user.is_superuser or request.user.is_rcpch_audit_team_member:
-        earliest_allowable_date = case.date_of_birth
-    else:
-        # registering a new child in the audit by a clinical team
-        # sets the minimum allowable date to the currently submitting cohort start date or the start of the previous cohort if it is still within its grace period
-        cohort_dates = cohorts_and_dates(first_paediatric_assessment_date=date.today())
-        if cohort_dates["within_grace_period"]:
-            earliest_allowable_date = cohort_dates["grace_cohort"]["cohort_start_date"]
-        else:
-            earliest_allowable_date = cohort_dates["submitting_cohort"][
-                "cohort_start_date"
-            ]
+    # TODO MRB: put back after hotfix
+    # if request.user.is_superuser or request.user.is_rcpch_audit_team_member:
+    earliest_allowable_date = case.date_of_birth
+    # else:
+    #     # registering a new child in the audit by a clinical team
+    #     # sets the minimum allowable date to the currently submitting cohort start date or the start of the previous cohort if it is still within its grace period
+    #     cohort_dates = cohorts_and_dates(first_paediatric_assessment_date=date.today())
+    #     if cohort_dates["within_grace_period"]:
+    #         earliest_allowable_date = cohort_dates["grace_cohort"]["cohort_start_date"]
+    #     else:
+    #         earliest_allowable_date = cohort_dates["submitting_cohort"][
+    #             "cohort_start_date"
+    #         ]
 
     try:
         error_message = None

--- a/s/ci
+++ b/s/ci
@@ -23,15 +23,15 @@ docker compose run mkdocs /bin/bash -c 'mkdocs build --config-file documentation
 # HOTFIX: Build again to embed the docs
 docker compose build
 
+# HOTFIX: push the image before the tests so we can deploy asap for https://github.com/rcpch/rcpch-audit-engine/issues/1162
+azure_tag="${AZURE_REGISTRY_NAME}.azurecr.io/e12-django:${GITHUB_SHA}"
+docker tag e12-django:built ${azure_tag}
+docker push ${azure_tag}
+
 # Tests (against local Postgres)
 docker compose up -d
 s/test
 docker compose down
-
-# Push to Azure
-azure_tag="${AZURE_REGISTRY_NAME}.azurecr.io/e12-django:${GITHUB_SHA}"
-docker tag e12-django:built ${azure_tag}
-docker push ${azure_tag}
 
 # Deploy to staging
 az containerapp revision copy \


### PR DESCRIPTION
Whilst I work to properly fix and unit test handling the end day of the grace period (#1162)