### PR TITLE
Fix adding patients if postcode validation service is down

### DIFF
--- a/epilepsy12/general_functions/postcode.py
+++ b/epilepsy12/general_functions/postcode.py
@@ -26,12 +26,21 @@ def is_valid_postcode(postcode: str) -> bool:
 
     if response.status_code == 200:
         return True
+    
+    if response.status_code in [400, 404]:
+        # Log this at error so we still email the admins about it.
+        # This is to try and spot any examples where a correct postcode is marked as invalid.
+        logger.error(
+            f"Invalid postcode {postcode} from {url}. {response.status_code=}"
+        )
+        return False
 
-    # Only other possibility should be 404, but handle any other status code
+    # For anything else, log the error but say the postcode is valid.
+    # We don't want to stop data entry if the postcode validation service is down.
     logger.error(
         f"Postcode validation failure. Could not validate postcode at {url}. {response.status_code=}"
     )
-    return False
+    return True
 
 
 def coordinates_for_postcode(postcode: str) -> bool:

--- a/epilepsy12/general_functions/postcode.py
+++ b/epilepsy12/general_functions/postcode.py
@@ -77,8 +77,8 @@ def return_random_postcode(country_boundary_identifier: str):
 
     response = requests.get(url=url)
 
-    if response.status_code == 404:
-        logger.error("Postcode generation failure. Could not get random postcode.")
+    if response.status_code != 200:
+        logger.error(f"Postcode generation failure. Could not get random postcode for {country_boundary_identifier}. {response.status_code=}")
         return None
 
     return response.json()["data"]["relationships"]["example_postcodes"]["data"][0][


### PR DESCRIPTION
Currently findthatpostcode is returning a 429. In this case we should allow the postcode since we don't know whether it's valid or not.

Also fix the code that generates random postcodes for testing to handle the same error.

The code still emits an error calling coordinates_for_postcode:

```
django-1   | ERROR [epilepsy12.models_folder.case:218] Cannot get longitude and latitude for SE129QF: cannot unpack non-iterable NoneType object
Traceback (most recent call last):
django-1   |   File "/app/epilepsy12/models_folder/case.py", line 202, in save
django-1   |     lon, lat = coordinates_for_postcode(postcode=self.postcode)
django-1   |     ^^^^^^^^
django-1   | TypeError: cannot unpack non-iterable NoneType object
```

but that's wrapped in a try catch so doesn't block saving the patient