### PR TITLE
Fix submission on last day of grace period and close cohort 6

### DIFF
--- a/epilepsy12/general_functions/cohort_number.py
+++ b/epilepsy12/general_functions/cohort_number.py
@@ -11,8 +11,9 @@ from .date_functions import nth_tuesday_of_year
 
 def days_remaining_before_submission(audit_submission_date: date, current_date: date) -> int:
     if audit_submission_date:
-        remaining_dateime = audit_submission_date - current_date
-        return remaining_dateime.days if remaining_dateime.days > 0 else 0
+        remaining = audit_submission_date - current_date
+        # submission is possible on the last day
+        return max(0, remaining.days + 1)
 
 
 def cohort_number_from_first_paediatric_assessment_date(

--- a/epilepsy12/general_functions/cohort_number.py
+++ b/epilepsy12/general_functions/cohort_number.py
@@ -116,7 +116,7 @@ def cohorts_and_dates(first_paediatric_assessment_date: date):
         submitting_cohort_number = None
         submitting_cohort = {}
 
-    if date.today().month >= 12 or date.today() < nth_tuesday_of_year(
+    if date.today().month >= 12 or date.today() <= nth_tuesday_of_year(
         date.today().year, n=2
     ):
         # if today is in or after December and before the second Tuesday of the year - during this period

--- a/epilepsy12/general_functions/cohort_number.py
+++ b/epilepsy12/general_functions/cohort_number.py
@@ -9,9 +9,9 @@ from datetime import date
 from .date_functions import nth_tuesday_of_year
 
 
-def days_remaining_before_submission(audit_submission_date: date) -> int:
+def days_remaining_before_submission(audit_submission_date: date, current_date: date) -> int:
     if audit_submission_date:
-        remaining_dateime = audit_submission_date - date.today()
+        remaining_dateime = audit_submission_date - current_date
         return remaining_dateime.days if remaining_dateime.days > 0 else 0
 
 
@@ -74,7 +74,8 @@ def dates_for_cohort(cohort: int):
     cohort_end_date = date(year=2016 + cohort + 1, month=11, day=30)
     submission_date = nth_tuesday_of_year(cohort_end_date.year + 2, n=2)
     days_remaining_til_submission = days_remaining_before_submission(
-        audit_submission_date=submission_date
+        audit_submission_date=submission_date,
+        current_date=date.today(),
     )
 
     cohort_data = {

--- a/epilepsy12/models_folder/case.py
+++ b/epilepsy12/models_folder/case.py
@@ -163,6 +163,9 @@ class Case(TimeStampAbstractBaseClass, UserStampAbstractBaseClass, HelpTextMixin
         Today's date is optional and defaults to date.today()
         """
         return stringify_time_elapsed(self.date_of_birth, today_date)
+    
+    def editable(self):
+        return not self.locked and (self.registration and self.registration.days_remaining_before_submission > 0)
 
     def save(self, *args, **kwargs) -> None:
         # calculate the index of multiple deprivation quintile if the postcode is present

--- a/epilepsy12/models_folder/registration.py
+++ b/epilepsy12/models_folder/registration.py
@@ -20,6 +20,7 @@ from .time_and_user_abstract_base_classes import *
 from ..general_functions import (
     dates_for_cohort,
     cohort_number_from_first_paediatric_assessment_date,
+    days_remaining_before_submission
 )
 from ..validators import not_in_the_future_validator
 
@@ -79,13 +80,7 @@ class Registration(
 
     @property
     def days_remaining_before_submission(self) -> int:
-        """Returns remaining days between current datetime and submission datetime, minimum value 0."""
-        if self.audit_submission_date:
-            remaining_datetime = self.audit_submission_date - self.get_current_date()
-            if remaining_datetime.days is None or remaining_datetime.days < 0:
-                return 0
-            else:
-                return remaining_datetime.days
+        return days_remaining_before_submission(self.audit_submission_date, self.get_current_date())
 
     # relationships
     case = models.OneToOneField("epilepsy12.Case", on_delete=models.PROTECT, null=True)

--- a/epilepsy12/tests/model_tests/test_registration.py
+++ b/epilepsy12/tests/model_tests/test_registration.py
@@ -138,7 +138,7 @@ def test_registration_days_remaining_before_submission(
             2022, 1, 10
         )  # cohort 5, submission date 9/1/24
     ).registration
-    assert registration.days_remaining_before_submission == 405
+    assert registration.days_remaining_before_submission == 406
 
     # submission date = 2023-01-10, 41 days after today
     registration = e12_case_factory(
@@ -146,7 +146,7 @@ def test_registration_days_remaining_before_submission(
             2021, 1, 1
         )  # cohort 4, submission 10/1/2023
     ).registration
-    assert registration.days_remaining_before_submission == 41
+    assert registration.days_remaining_before_submission == 42
 
 
 @patch.object(Registration, "get_current_date", return_value=date(2025, 1, 30))

--- a/epilepsy12/views/registration_views.py
+++ b/epilepsy12/views/registration_views.py
@@ -600,19 +600,16 @@ def first_paediatric_assessment_date(request, case_id):
     case = Case.objects.get(pk=case_id)
     registration = Registration.objects.filter(case=case).get()
 
-    # TODO MRB: put back after hotfix
-    # if request.user.is_superuser or request.user.is_rcpch_audit_team_member:
-    earliest_allowable_date = case.date_of_birth
-    # else:
-    #     # registering a new child in the audit by a clinical team
-    #     # sets the minimum allowable date to the currently submitting cohort start date or the start of the previous cohort if it is still within its grace period
-    #     cohort_dates = cohorts_and_dates(first_paediatric_assessment_date=date.today())
-    #     if cohort_dates["within_grace_period"]:
-    #         earliest_allowable_date = cohort_dates["grace_cohort"]["cohort_start_date"]
-    #     else:
-    #         earliest_allowable_date = cohort_dates["submitting_cohort"][
-    #             "cohort_start_date"
-    #         ]
+    if request.user.is_superuser or request.user.is_rcpch_audit_team_member:
+        earliest_allowable_date = case.date_of_birth
+    else:
+        # registering a new child in the audit by a clinical team
+        # sets the minimum allowable date to the currently submitting cohort start date or the start of the previous cohort if it is still within its grace period
+        cohort_dates = cohorts_and_dates(first_paediatric_assessment_date=date.today())
+        if cohort_dates["within_grace_period"]:
+            earliest_allowable_date = cohort_dates["grace_cohort"]["cohort_start_date"]
+        else:
+            earliest_allowable_date = cohort_dates["submitting_cohort_start_date"]
 
     try:
         error_message = None

--- a/s/ci
+++ b/s/ci
@@ -23,7 +23,7 @@ docker compose run mkdocs /bin/bash -c 'mkdocs build --config-file documentation
 # HOTFIX: Build again to embed the docs
 docker compose build
 
-# HOTFIX: push the image before the tests so we can deploy asap for https://github.com/rcpch/rcpch-audit-engine/issues/1162
+# Push the image to Azure. This allows us to deploy in an emergency before the tests complete
 azure_tag="${AZURE_REGISTRY_NAME}.azurecr.io/e12-django:${GITHUB_SHA}"
 docker tag e12-django:built ${azure_tag}
 docker push ${azure_tag}

--- a/templates/epilepsy12/partials/case_table.html
+++ b/templates/epilepsy12/partials/case_table.html
@@ -134,54 +134,21 @@
             <div class='ui buttons'>
               <button 
                 data-tooltip='Edit or delete child.'
-                {% if case.locked %}
-                  class="ui rcpch_purple icon disabled button"
-                {% else %}
-                  class="ui rcpch_purple icon button"
-                {% endif %}
-                tabindexed="0" {% if case.locked or not perms.epilepsy12.change_case and not request.user.is_rcpch_audit_team_member %}disabled{% endif %}>
+                class="ui rcpch_purple icon button"
+                tabindexed="0"
+                {% if not perms.epilepsy12.change_case or not case.editable and not request.user.is_rcpch_audit_team_member %}disabled{% endif %}>
                 <a href="{% url 'update_case' organisation_id=organisation_id case_id=case.id%}" class="rcpch_purple half_button">
                   <i class="edit outline icon icon_white"></i>
                   Edit
                 </a>
               </button>
-              
-              {% if case.registration.first_paediatric_assessment_date %}
-                {% if case.locked %}
-                <button 
+              <button 
                   data-tooltip='Complete audit details.'
-                  class="ui rcpch_dark_purple disabled button" 
+                  class="ui rcpch_dark_purple button" 
                   tabindexed="2" 
                   onclick="location.href='{% url 'register'  case.id %}'"
+                  {% if not case.editable and not request.user.is_rcpch_audit_team_member %} disabled {% endif %}
                 >Audit</button>
-                {% else %}
-                <button 
-                  data-tooltip='Complete audit details.'
-                  class="ui rcpch_dark_purple button"
-                  tabindexed="2"
-                  onclick="location.href='{% url 'register'  case.id %}'"
-                  >Audit</button>
-                
-                {% endif %}
-              {% else %}
-                {% if case.locked and not request.user.is_rcpch_audit_team_member %}
-
-                <button 
-                  class="ui rcpch_dark_purple disabled button" 
-                  tabindexed="2"
-                  onclick="location.href='{% url 'register' case_id=case.id %}'"
-                >Audit</button>
-
-                {% else %}
-
-                <button 
-                  class="ui rcpch_dark_purple button" 
-                  tabindexed="2"
-                  onclick="location.href='{% url 'register' case_id=case.id %}'"
-                >Audit</button>
-
-                {% endif %}
-              {% endif %}
             </div>
 
             {% if not case.registration.audit_progress.audit_complete and not case.locked and case.registration.first_paediatric_assessment_date %}

--- a/templates/epilepsy12/partials/case_table.html
+++ b/templates/epilepsy12/partials/case_table.html
@@ -173,7 +173,7 @@
                 hx-post="{{hx_post}}"
                 hx_trigger='click' 
                 hx-target="#case_table"
-                {% if case.locked and not perms.epilepsy12.can_unlock_child_case_data_from_editing or not case.locked and not perms.epilepsy12.can_lock_child_case_data_from_editing  %}
+                {% if case.registration.days_remaining_before_submission == 0 or case.locked and not perms.epilepsy12.can_unlock_child_case_data_from_editing or not case.locked and not perms.epilepsy12.can_lock_child_case_data_from_editing  %}
                   disabled
                 {% else %}
                     {% if case.locked %}
@@ -253,14 +253,16 @@
                   </button>
                 </div>
               {% else %}
-                {% if case.registration.days_remaining_before_submission > 7 and case.registration.audit_progress.audit_complete %}
-                  {% if case.locked %}
-                    <span data-tooltip="Data complete and uploaded. {{case}}'s record can still be unlocked and edited up until {{case.registration.audit_submission_date|date:'D j M Y'}}"><i class="rcpch_pink check circle outline icon"></i></span>
+                {% if case.registration.audit_progress.audit_complete %}
+                  {% if case.registration.days_remaining_before_submission > 0 %}
+                    {% if case.locked %}
+                      <span data-tooltip="Data complete and uploaded. {{case}}'s record can still be unlocked and edited up until {{case.registration.audit_submission_date|date:'D j M Y'}}"><i class="rcpch_pink check circle outline icon"></i></span>
+                    {% else %}
+                      <span data-tooltip="Data complete. Ready for upload by {{case.registration.audit_submission_date|date:'D j M Y'}}"><i class="rcpch_pink check circle outline icon"></i></span>
+                    {% endif %}
                   {% else %}
-                    <span data-tooltip="Data complete. Ready for upload by {{case.registration.audit_submission_date|date:'D j M Y'}}"><i class="rcpch_pink check circle outline icon"></i></span>
+                    <span data-tooltip="Data complete and submission date has passed. No further editing is possible."><i class="rcpch_orange check circle outline icon"></i></span>
                   {% endif %}
-                {% elif case.registration.audit_progress.audit_complete %}
-                  <span data-tooltip="Data complete"><i class="rcpch_orange check circle outline icon"></i></span>
                 {% else %}
                   <span data-tooltip="Data incomplete."><i class="rcpch_light_blue dot circle outline icon"></i></span>
                 {% endif %}

--- a/templates/epilepsy12/partials/organisation/cohort_card.html
+++ b/templates/epilepsy12/partials/organisation/cohort_card.html
@@ -21,12 +21,14 @@
           </h4>
         </div>
 
-        <div class="rcpch_summary_stats_row">
-          <h1 style="color: var(--rcpch_pink)">{{cohort_data.grace_cohort.days_remaining}}</h1>
-          <h2>Days remaining</h2>
-          <h3>until latest submission date</h3>
-          <h4>({{cohort_data.grace_cohort.submission_date}})</h4>
-        </div>
+        {% if cohort_data.grace_cohort.submission_date > cohort_data.today %} 
+          <div class="rcpch_summary_stats_row">
+            <h1 style="color: var(--rcpch_pink)">{{cohort_data.grace_cohort.days_remaining}}</h1>
+            <h2>Days remaining</h2>
+            <h3>until latest submission date</h3>
+            <h4>({{cohort_data.grace_cohort.submission_date}})</h4>
+          </div>
+        {% endif %}
       </div>
     </div>
 


### PR DESCRIPTION
Fixes #1172

Undo the hot fixes we did to quickly unblock submission on the last day of the grace period (#1163, #1164, #1165) and the underlying bugs:

- `days_remaining_before_submission` should be inclusive of the last day of the grace period
- `submitting_cohort` was a number so we couldn't get `cohort_start_date` from it, we needed `submitting_cohort_start_date`

This will have the effect of closing out cohort 6 so will only merge after our extended deadline (Sunday 19th Jan).

Also removes the "0 days remaining" for cohort 6 on the homepage.

Finally as a side effect also fixes #1176 

