### PR TITLE
Fix edit button on unregistered cases for non audit team members

### DIFF
--- a/epilepsy12/models_folder/case.py
+++ b/epilepsy12/models_folder/case.py
@@ -165,7 +165,13 @@ class Case(TimeStampAbstractBaseClass, UserStampAbstractBaseClass, HelpTextMixin
         return stringify_time_elapsed(self.date_of_birth, today_date)
     
     def editable(self):
-        return not self.locked and (self.registration and self.registration.days_remaining_before_submission > 0)
+        if self.locked:
+            return False
+        
+        if not hasattr(self, "registration"):
+            return True
+        
+        return self.registration.days_remaining_before_submission > 0
 
     def save(self, *args, **kwargs) -> None:
         # calculate the index of multiple deprivation quintile if the postcode is present


### PR DESCRIPTION
Fixes #1183 

I introduced `Case.editable` in #1178 but it didn't work properly. `self.registration` was throwing `RelatedObjectDoesNotExist` for unregistered cases. The template rendering ate this somehow so the page still renders. Either way I didn't notice because I'm an `rcpch_audit_team_member` so can always edit.

This PR changes the logic to use `hasattr` and states out each expected branch separately.