### PR TITLE
View dashboard for closed cohort (cohort 6)

### DIFF
--- a/epilepsy12/views/organisation_views.py
+++ b/epilepsy12/views/organisation_views.py
@@ -76,14 +76,21 @@ def selected_organisation_summary(request, organisation_id):
 
     template_name = "epilepsy12/organisation.html"
 
-    # get submitting_cohort number - in future will be selectable
+    # Dates for the closed, data collection ongoing and actively recruiting cohorts
     cohort_data = cohorts_and_dates(first_paediatric_assessment_date=date.today())
 
-    cohort_number = (
-        cohort_data["grace_cohort"]["cohort"]
-        if cohort_data["within_grace_period"]
-        else cohort_data["submitting_cohort"]
-    )
+    # Where dashboard data is filtered by cohort, which cohort?
+    # Users still want to see dashboard data even when data collection is complete.
+    requested_cohort_number = request.GET.get("cohort")
+    
+    if requested_cohort_number:
+        cohort_number = int(requested_cohort_number)
+    else:
+        cohort_number = (
+            cohort_data["grace_cohort"]["cohort"]
+            if cohort_data["within_grace_period"]
+            else cohort_data["submitting_cohort"]
+        )
 
     # thes are all registered cases for the current cohort at the selected organisation to be plotted in the map
     cases_to_plot = filter_all_registered_cases_by_active_lead_site_and_cohort_and_level_of_abstraction(
@@ -324,12 +331,18 @@ def selected_trust_kpis(request, organisation_id, access):
     """
 
     # Get all relevant data for submission cohort
-    cohort_data = cohorts_and_dates(first_paediatric_assessment_date=date.today())
-    cohort_number = (
-        cohort_data["grace_cohort"]["cohort"]
-        if cohort_data["within_grace_period"]
-        else cohort_data["submitting_cohort"]
-    )
+    requested_cohort_number = request.GET.get("cohort")
+
+    if requested_cohort_number:
+        cohort_number = int(requested_cohort_number)
+    else:
+        cohort_data = cohorts_and_dates(first_paediatric_assessment_date=date.today())
+        cohort_number = (
+            cohort_data["grace_cohort"]["cohort"]
+            if cohort_data["within_grace_period"]
+            else cohort_data["submitting_cohort"]
+        )
+    
     organisation = Organisation.objects.get(pk=organisation_id)
 
     if logged_in_user_may_access_this_organisation(request.user, organisation):
@@ -458,12 +471,18 @@ def selected_trust_select_kpi(request, organisation_id):
         # on page load there may be no kpi_name - default to paediatrician_with_experise_in_epilepsy
         kpi_name = INDIVIDUAL_KPI_MEASURES[0][0]
     kpi_name_title_case = value_from_key(key=kpi_name, choices=INDIVIDUAL_KPI_MEASURES)
-    cohort_data = cohorts_and_dates(first_paediatric_assessment_date=date.today())
-    cohort_number = (
-        cohort_data["grace_cohort"]["cohort"]
-        if cohort_data["within_grace_period"]
-        else cohort_data["submitting_cohort"]
-    )
+    
+    requested_cohort_number = request.POST.get("cohort")
+
+    if requested_cohort_number:
+        cohort_number = int(requested_cohort_number)
+    else:
+        cohort_data = cohorts_and_dates(first_paediatric_assessment_date=date.today())
+        cohort_number = (
+            cohort_data["grace_cohort"]["cohort"]
+            if cohort_data["within_grace_period"]
+            else cohort_data["submitting_cohort"]
+        )
 
     all_data = get_all_kpi_aggregation_data_for_view(
         organisation=organisation, cohort=cohort_number, open_access=False

--- a/epilepsy12/views/organisation_views.py
+++ b/epilepsy12/views/organisation_views.py
@@ -333,15 +333,17 @@ def selected_trust_kpis(request, organisation_id, access):
     # Get all relevant data for submission cohort
     requested_cohort_number = request.GET.get("cohort")
 
+    cohort_data = cohorts_and_dates(first_paediatric_assessment_date=date.today())
+    submitting_cohort_number = (
+        cohort_data["grace_cohort"]["cohort"]
+        if cohort_data["within_grace_period"]
+        else cohort_data["submitting_cohort"]
+    )
+
     if requested_cohort_number:
         cohort_number = int(requested_cohort_number)
     else:
-        cohort_data = cohorts_and_dates(first_paediatric_assessment_date=date.today())
-        cohort_number = (
-            cohort_data["grace_cohort"]["cohort"]
-            if cohort_data["within_grace_period"]
-            else cohort_data["submitting_cohort"]
-        )
+        cohort_number = submitting_cohort_number
     
     organisation = Organisation.objects.get(pk=organisation_id)
 
@@ -397,6 +399,7 @@ def selected_trust_kpis(request, organisation_id, access):
         "last_published_date": last_published_date,
         "publish_success": False,
         "cohort_number": cohort_number,
+        "submitting_cohort_number": submitting_cohort_number
     }
 
     return render(

--- a/templates/epilepsy12/partials/kpis/kpis.html
+++ b/templates/epilepsy12/partials/kpis/kpis.html
@@ -32,6 +32,7 @@ Currently the aggregation queries are run with every page load.
                             hx-get="{% url 'selected_trust_kpis' organisation_id=organisation.pk access='private' %}"
                             name="refresh"
                             hx-trigger="click"
+                            {% if cohort_number != submitting_cohort_number %}disabled{% endif %}
                             >
                             Refresh
                             <i class="htmx-indicator spinner loading icon"></i>

--- a/templates/epilepsy12/partials/organisation/cohort_card.html
+++ b/templates/epilepsy12/partials/organisation/cohort_card.html
@@ -28,6 +28,10 @@
             <h3>until latest submission date</h3>
             <h4>({{cohort_data.grace_cohort.submission_date}})</h4>
           </div>
+        {% elif cohort_number != cohort_data.grace_cohort.cohort %}
+          <div class="rcpch_summary_stats_row">
+            <a class="ui rcpch_positive button" href="?cohort={{cohort_data.grace_cohort.cohort}}">View dashboard</a>
+          </div>
         {% endif %}
       </div>
     </div>
@@ -63,6 +67,9 @@
           <h2>Days remaining</h2>
           <h3>until latest submission date</h3>
           <h4>({{cohort_data.submitting_cohort_submission_date}})</h4>
+          {% if cohort_number != cohort_data.submitting_cohort %}
+            <a class="ui rcpch_positive button" href="?cohort={{cohort_data.submitting_cohort}}">View dashboard</a>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/templates/epilepsy12/partials/organisation/individual_metrics.html
+++ b/templates/epilepsy12/partials/organisation/individual_metrics.html
@@ -36,7 +36,8 @@
             hx-target="#selected_trust_select_kpi"
             hx-swap="innerHTML"
             hx-trigger="change, load"
-            hx_indicator="#selected_trust_select_kpi"
+            hx-indicator="#selected_trust_select_kpi"
+            hx-vals='{"cohort":"{{cohort_number}}"}'
           >
 
             <div id="selected_trust_select_kpi">

--- a/templates/epilepsy12/partials/page_elements/kpi_select.html
+++ b/templates/epilepsy12/partials/page_elements/kpi_select.html
@@ -38,6 +38,7 @@ from is obvious because the endpoint posted to is specific to the choices. {% en
         hx-target="{{hx_target}}"
         hx-swap="{{hx_swap}}"
         hx-trigger="{{hx_trigger}}"
+        hx-vals='{"cohort":"{{cohort_number}}"}'
         value="{{test_positive}}"
       />
       <div class="default text">{{hx_default_text}}</div>

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -469,7 +469,7 @@
             <div class="sixteen wide column">
                 <div
                     class="sixteen wide rcpch segment"
-                    hx-get="{% url 'selected_trust_kpis' organisation_id=selected_organisation.pk access='private' %}"
+                    hx-get="{% url 'selected_trust_kpis' organisation_id=selected_organisation.pk access='private' %}?cohort={{cohort_number}}"
                     hx-trigger="load" hx-swap='innerHTML'
                     hx-indicator='#kpis'
                     hx-target="#kpis">

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -469,7 +469,8 @@
             <div class="sixteen wide column">
                 <div
                     class="sixteen wide rcpch segment"
-                    hx-get="{% url 'selected_trust_kpis' organisation_id=selected_organisation.pk access='private' %}?cohort={{cohort_number}}"
+                    hx-get="{% url 'selected_trust_kpis' organisation_id=selected_organisation.pk access='private' %}"
+                    hx-vals='{"cohort":"{{cohort_number}}"}'
                     hx-trigger="load" hx-swap='innerHTML'
                     hx-indicator='#kpis'
                     hx-target="#kpis">


### PR DESCRIPTION
Closes #1182 

I've done the minimum possible amount of work to allow users to view the dashboard for cohort 6 now it has closed.

When you're viewing cohort 7:

![Capture](https://github.com/user-attachments/assets/3d16d06d-5e59-4df5-b164-8dcc6c1b5968)

and when you're viewing cohort 6:

![Capture](https://github.com/user-attachments/assets/5d146c04-e64f-45c3-818a-f0b915dbbc78)

The refresh KPI buttons is disabled when viewing closed cohorts.