### PR TITLE
Fix adding patients outside of Jersey

### DIFF
--- a/epilepsy12/forms_folder/case_form.py
+++ b/epilepsy12/forms_folder/case_form.py
@@ -204,3 +204,18 @@ class CaseForm(forms.ModelForm):
             return formatted_nhs_number
         else:
             raise ValidationError(f"{formatted_nhs_number} is not a valid NHS number")
+    
+    def clean_unique_reference_number(self):
+        unique_reference_number = self.cleaned_data["unique_reference_number"]
+
+        organisation = Organisation.objects.get(id=self.organisation_id)
+        if organisation.ods_code == "RGT1W":
+            if not unique_reference_number:
+                raise ValidationError("Missing unique reference number")
+        else:
+            # Ensure we save NULL not the empty string otherwise it stops you adding
+            # more patients (https://github.com/rcpch/rcpch-audit-engine/issues/1190)
+            return None
+        
+
+


### PR DESCRIPTION
Fixes #1190 

Patients outside of Jersey have `nhs_number`, not `unique_reference_number`. However they were ending up with their URN being the empty string (Django convention). This then broke the `unique_together` constraint.

This PR adds a cleaner to convert the empty strings to null, following the suggestion here: https://stackoverflow.com/questions/5772176/django-unique-together-and-blank-true.

We don't have the problem in reverse as we already null out the NHS number for Jersey patients in the respective cleaner.