### PR TITLE
Download KPIs per cohort

### DIFF
--- a/epilepsy12/urls.py
+++ b/epilepsy12/urls.py
@@ -352,12 +352,12 @@ organisation_patterns = [
     #     name="open_access",
     # ),
     path(
-        "organisation/<int:organisation_id>/kpi_download",
+        "organisation/<int:organisation_id>/kpi_download/<int:cohort>",
         view=kpi_download,
         name="kpi_download",
     ),
     path(
-        "kpi_download_file",
+        "kpi_download_file/<int:cohort>",
         view=kpi_download_file,
         name="kpi_download_file",
     ),

--- a/epilepsy12/views/organisation_views.py
+++ b/epilepsy12/views/organisation_views.py
@@ -561,12 +561,12 @@ def view_preference(request, organisation_id, template_name):
 
 @login_and_otp_required()
 @permission_required("epilepsy12.can_publish_epilepsy12_data")
-def kpi_download(request, organisation_id):
+def kpi_download(request, organisation_id, cohort):
     """
     GET: Loads the page necessary for downloading KPIs
     """
 
-    context = {"organisation_id": organisation_id}
+    context = {"organisation_id": organisation_id, "cohort": cohort}
 
     template_name = "epilepsy12/partials/kpis/kpi_download.html"
 
@@ -575,7 +575,7 @@ def kpi_download(request, organisation_id):
 
 @login_and_otp_required()
 @permission_required("epilepsy12.can_publish_epilepsy12_data")
-def kpi_download_file(request):
+def kpi_download_file(request, cohort):
 
     (
         country_df,
@@ -591,7 +591,7 @@ def kpi_download_file(request):
         nhs_england_region_totals_df,
         openuk_network_totals_df,
         country_totals_df,
-    ) = download_kpi_summary_as_csv(cohort=6)
+    ) = download_kpi_summary_as_csv(cohort)
 
     with pd.ExcelWriter("kpi_export.xlsx") as writer:
         country_df.to_excel(writer, sheet_name="Country_level", index=False)
@@ -627,5 +627,6 @@ def kpi_download_file(request):
         excel_data,
         content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     )
-    response["Content-Disposition"] = "attachment; filename=kpi_export.xlsx"
+    # cohort should be validated by Django as an integer 
+    response["Content-Disposition"] = f"attachment; filename=kpi_export_cohort_{cohort}.xlsx"
     return response

--- a/static/styles/buttons.css
+++ b/static/styles/buttons.css
@@ -235,12 +235,6 @@
   align-items: center;
 }
 
-.download.link {
-  display: flex;
-  justify-content: right;
-  align-items: center;
-}
-
 a.ui.button {
   display: flex;
   justify-content: center;

--- a/templates/epilepsy12/partials/kpis/kpi_download.html
+++ b/templates/epilepsy12/partials/kpis/kpi_download.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %} {% load static %} {% load epilepsy12_template_tags %}
 {% csrf_token %} {% block content %}
 <div class="ui rcpch container main_content">
-  <h1>KPI downloading for E12 team</h1>
+  <h1>KPI downloading for E12 team - Cohort {{cohort}}</h1>
   <p>
     KPIs are re-aggregated everytime a user enters their organisation's summary
     page. This ensures that the aggregations are as up to date as possible. The
@@ -18,7 +18,7 @@
           <button 
             class="ui rcpch_positive button jump"
           >
-          Download most recent KPI report
+          Download most recent KPI report for cohort {{cohort}}
         </button>
         </a>
     </div>

--- a/templates/epilepsy12/partials/kpis/kpi_download.html
+++ b/templates/epilepsy12/partials/kpis/kpi_download.html
@@ -14,7 +14,7 @@
   </p>
   <span class="ui buttons">
     <div id="kpi_download_button">
-        <a href="{% url 'kpi_download_file' %}">
+        <a href="{% url 'kpi_download_file' cohort=cohort %}">
           <button 
             class="ui rcpch_positive button jump"
           >

--- a/templates/epilepsy12/partials/organisation/cohort_card.html
+++ b/templates/epilepsy12/partials/organisation/cohort_card.html
@@ -35,5 +35,12 @@
     <div class="rcpch_summary_stats_row">
       <a class="ui rcpch_positive button" href="?cohort={{cohort.cohort}}">View dashboard</a>
     </div>
+  {% elif cohort_number == cohort.cohort and request.user.is_rcpch_audit_team_member %}
+    <div class="rcpch_summary_stats_row">
+      <a class="ui rcpch_positive button jump" href="{% url 'kpi_download' organisation_id=selected_organisation.pk cohort=cohort_number %}">Download KPI metrics</a>
+      <div class="rcpch_summary_stats_description">
+        Across all organisations - audit team only.
+      </div>
+    </div>
   {% endif %}
 </div>

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -10,7 +10,7 @@
             <div class="ui rcpch_view label view_title">Organisation Dashboard</div>
             {% if request.user.is_rcpch_audit_team_member %}
                 <div class="download link">
-                    <a class="ui rcpch_positive button jump" href="{% url 'kpi_download' organisation_id=selected_organisation.pk %}">Download KPI metrics</a>
+                    <a class="ui rcpch_positive button jump" href="{% url 'kpi_download' organisation_id=selected_organisation.pk cohort=cohort_number %}">Download KPI metrics</a>
                 </div>
             {% endif %}
         </div>

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -8,11 +8,6 @@
                 <button class="ui rcpch_positive button jump" _="on click go to top of #kpis">Jump to All KPI Metrics</button>
             </div>
             <div class="ui rcpch_view label view_title">Organisation Dashboard</div>
-            {% if request.user.is_rcpch_audit_team_member %}
-                <div class="download link">
-                    <a class="ui rcpch_positive button jump" href="{% url 'kpi_download' organisation_id=selected_organisation.pk cohort=cohort_number %}">Download KPI metrics</a>
-                </div>
-            {% endif %}
         </div>
 
         


### PR DESCRIPTION
Fixes #1122 

The Download KPI metrics button downloads the KPI report for the current cohort you are looking at in the summary dashboard. I've also moved the button to make it clearer which cohort you are downloading for.

![Screenshot 2025-04-15 215931](https://github.com/user-attachments/assets/b188ab44-49ad-4300-b5b5-2e6253cb75b5)
![Screenshot 2025-04-15 220052](https://github.com/user-attachments/assets/d0dba2d7-6601-4d41-a770-16eb01a8e7af)
