### PR TITLE
Fix homepage crash for users in organisations called CHILD DEVELOPMENT CENTRE

### DIFF
--- a/epilepsy12/common_view_functions/__init__.py
+++ b/epilepsy12/common_view_functions/__init__.py
@@ -32,8 +32,6 @@ from .report_queries import (
     get_all_open_uk_regions,
 )
 from .sanction_user_access import (
-    return_selected_organisation,
-    sanction_user,
     logged_in_user_may_access_this_organisation,
 )
 from .group_for_group import group_for_role

--- a/epilepsy12/common_view_functions/sanction_user_access.py
+++ b/epilepsy12/common_view_functions/sanction_user_access.py
@@ -2,44 +2,6 @@ from django.core.exceptions import PermissionDenied
 from django.apps import apps
 
 
-def return_selected_organisation(user):
-    """
-    Function called from organisation views
-    Returns the selected hospital based on user affiliation. If an RCPCH member and no hospital affilation
-    the first in the list is returned. Otherwise, an error is raised
-    Accepts a user object.
-    """
-
-    Organisation = apps.get_model("epilepsy12", "Organisation")
-
-    if user.organisation_employer is not None:
-        # current user is affiliated with an existing organisation - set viewable trust to this
-        return Organisation.objects.get(name=user.organisation_employer)
-    else:
-        # current user is NOT affiliated with an existing organisation
-        if user.is_rcpch_staff or user.is_superuser or user.is_superuser:
-            # current user is a member of the RCPCH audit team and also not affiliated with a organisation
-            # therefore set selected organisation to first of organisation on the list
-            return Organisation.objects.order_by("name").first()
-        else:
-            # Imposter! You shall not pass!
-            raise PermissionDenied()
-
-
-def sanction_user(user):
-    if user.organisation_employer is not None:
-        # current user is affiliated with an existing organisation - set viewable trust to this
-        return True
-    else:
-        # current user is NOT affiliated with an existing organisation
-        if user.is_rcpch_staff or user.is_superuser or user.is_superuser:
-            # current user is a member of the RCPCH audit team and also not affiliated with a organisation
-            # therefore set selected organisation to first of organisation on the list
-            return True
-        else:
-            # Imposter! You shall not pass!
-            raise PermissionDenied()
-
 def logged_in_user_may_access_this_organisation(user, organisation_requested):
     """
     Called from selected_trust_kpis

--- a/epilepsy12/views/route_views.py
+++ b/epilepsy12/views/route_views.py
@@ -1,17 +1,9 @@
 from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
 
-from epilepsy12.models import Organisation
-
 
 @login_required
 def index(request):
-    """
-    This is the landing page for all site visitors. Any navigation on from here requires the user to login,
-    except the children and families page which requires an organisation id to filter against. An organisation is chosen
-    here at random, but in future might be chosen based on the location of the visitor's ISP.
-    """
-    organisation = Organisation.objects.get(name=request.user.organisation_employer)
     template_name = "epilepsy12/epilepsy12index.html"
-    context = {"organisation": organisation}
+    context = {"organisation": request.user.organisation_employer}
     return render(request=request, template_name=template_name, context=context)


### PR DESCRIPTION
I've been getting occasional emails about a crash on the homepage

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/contrib/auth/decorators.py", line 60, in _view_wrapper
    return view_func(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/epilepsy12/views/route_views.py", line 14, in index
    organisation = Organisation.objects.get(name=request.user.organisation_employer)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/query.py", line 652, in get
    raise self.model.MultipleObjectsReturned(
    ^

Exception Type: MultipleObjectsReturned at /
Exception Value: get() returned more than one Organisation -- it returned 10!
Raised during: epilepsy12.views.route_views.index
```

It happens because we look up the organisation by name and some names like CHILD DEVELOPMENT CENTRE are used for multiple orgs.

The fix is to simply reference the `organisation_employer` from the user directly.

I was searching for other usages of this pattern and found some old code in `sanction_user_access.py` that wasn't used any more, so I've deleted it.