### PR TITLE
Speed up CI (follow up to #1223)

### DIFF
--- a/s/ci
+++ b/s/ci
@@ -29,8 +29,8 @@ docker tag e12-django:built ${azure_tag}
 docker push ${azure_tag}
 
 # Tests (against local Postgres)
-docker compose up -d
-s/test
+docker compose up -d --wait
+s/test -m 'not slow'
 s/test -m 'slow'
 docker compose down
 


### PR DESCRIPTION
I was a noodle and didn't update the CI script properly in #1223 so deploys actually got slower.

This fixes it to run only the slow test after all the other tests, matching the pr-check script.