### PR TITLE
User in request logs

### DIFF
--- a/envs/env-template
+++ b/envs/env-template
@@ -75,3 +75,5 @@ POSTGRES_USER=epilepsy12user
 
 # TIMEZONE
 TZ="Europe/London"
+
+ENABLE_REQUEST_LOGGING="False"

--- a/epilepsy12/middleware.py
+++ b/epilepsy12/middleware.py
@@ -1,8 +1,7 @@
 from datetime import datetime
 import logging
 from threading import local
-
-from epilepsy12.models import Epilepsy12User
+from django.conf import settings
 
 request_logger = logging.getLogger("epilepsy12_request_log")
 
@@ -35,21 +34,38 @@ def get_current_request():
         return None
 
 
+class Epilepsy12CustomLoggingAttributesMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        user = getattr(request, "user", None)
+        if user and user.is_authenticated:
+            set_current_user(user)
+        else:
+            set_current_user(None)
+
+        set_current_request(request)
+
+        response = self.get_response(request)
+
+        # Clean up thread-local storage after request
+        if hasattr(_user, 'value'):
+            delattr(_user, 'value')
+        if hasattr(_user, 'request'):
+            delattr(_user, 'request')
+
+        return response
+
+
 class Epilepsy12RequestLoggingMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
-        try:
-            user = getattr(request, "user", None)
-            if user and user.is_authenticated:
-                set_current_user(user)
-            else:
-                set_current_user(None)
-            set_current_request(request)
+        response = self.get_response(request)
 
-            response = self.get_response(request)
-
+        if settings.ENABLE_REQUEST_LOGGING:
             # The dev server already does request logging
             # if settings.ENABLE_REQUEST_LOGGING:
             # This replaces the old gunicorn request logging which used this format string
@@ -58,33 +74,20 @@ class Epilepsy12RequestLoggingMiddleware:
                 datetime.now().astimezone().strftime("%d/%m/%y:%H:%M:%S %z")
             )
 
-            user = get_current_user()
-
-            username_to_log = user if user else "-"
-            if user and hasattr(user, "email"):
-                username_to_log = user.email
+            username_to_log = "-" if request.user.is_anonymous else request.user.email
 
             x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR", "")
             method_path = f"{request.method} {request.get_full_path()}"
             content_length = response.get("Content-Length", "-")
             referer = request.META.get("HTTP_REFERER", "-")
             user_agent = request.META.get("HTTP_USER_AGENT", "-")
-            audit_year = request.session.get("selected_audit_year", "-")
-            pz_code = request.session.get("pz_code", "-")
 
             log_message = (
                 f"{x_forwarded_for} - {username_to_log} [{gunicorn_formatted_datetime}] "
                 f'"{method_path}" {response.status_code} {content_length} '
-                f'"{referer}" "{user_agent}" '
-                f'audit_year="{audit_year}" pz_code="{pz_code}"'
+                f'"{referer}" "{user_agent}"'
             )
+
             request_logger.info(log_message)
 
-            return response
-
-        finally:
-            # Clean up thread-local storage after request
-            if hasattr(_user, "value"):
-                delattr(_user, "value")
-            if hasattr(_user, "request"):
-                delattr(_user, "request")
+        return response

--- a/rcpch-audit-engine/logging_settings.py
+++ b/rcpch-audit-engine/logging_settings.py
@@ -29,6 +29,16 @@ django_loggers = {
     )
 }
 
+request_loggers = {}
+
+if os.getenv("ENABLE_REQUEST_LOGGING", "False") == "True":
+    request_loggers = {
+        "epilepsy12_request_log": {
+            "handlers": ["epilepsy12_console_request_log"],
+            "level": CONSOLE_LOG_LEVEL,
+        }
+    }
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -81,6 +91,9 @@ LOGGING = {
                 "CRITICAL": "bold_red",
             },
         },
+        "epilepsy12_request_log": {
+            "format": "%(message)s",
+        }
     },
     "handlers": {
         "epilepsy12_console": {
@@ -109,6 +122,12 @@ LOGGING = {
             "filters": ["require_debug_false"],
             "class": "django.utils.log.AdminEmailHandler",
         },
+        "epilepsy12_console_request_log": {
+            "level": CONSOLE_LOG_LEVEL,
+            "class": "logging.StreamHandler",
+            "formatter": "epilepsy12_request_log",
+            "filters": [],
+        },
     },
     "loggers": {
         "django": {
@@ -123,5 +142,6 @@ LOGGING = {
         "two_factor": {
             "handlers": ["epilepsy12_console", "epilepsy12_logfile", "mail_admins"],
         },
+        **request_loggers
     },
 }

--- a/rcpch-audit-engine/settings.py
+++ b/rcpch-audit-engine/settings.py
@@ -123,6 +123,8 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    # Has to come before CommonMiddleware to access Content-Length  
+    "epilepsy12.middleware.Epilepsy12RequestLoggingMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -130,8 +132,7 @@ MIDDLEWARE = [
     "django_htmx.middleware.HtmxMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
     "django_auto_logout.middleware.auto_logout",
-    # Custom middleware for request logging
-    "epilepsy12.middleware.Epilepsy12RequestLoggingMiddleware",
+    "epilepsy12.middleware.Epilepsy12CustomLoggingAttributesMiddleware",
     # 2fa
     "django_otp.middleware.OTPMiddleware",
 ]
@@ -330,3 +331,5 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),
 }
+
+ENABLE_REQUEST_LOGGING = os.getenv("ENABLE_REQUEST_LOGGING", "False") == "True"

--- a/s/start-prod
+++ b/s/start-prod
@@ -7,6 +7,4 @@ python manage.py seed --mode=seed_groups_and_permissions
 gunicorn \
     --bind=0.0.0.0:8000 \
     --timeout 600 \
-    --access-logfile '-' \
-    --access-logformat '%({x-forwarded-for}i)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"' \
     rcpch-audit-engine.wsgi


### PR DESCRIPTION
#1254 ported across some of the code from https://github.com/rcpch/national-paediatric-diabetes-audit/pull/1090 to add emails to request logging.

It missed several parts which this PR now adds:

- Constructing the request logger so the log messages aren't blackholed
- Reading the user correctly (https://github.com/rcpch/national-paediatric-diabetes-audit/pull/1139)
- Split the middleware in two to correctly read `Content-Length`
- Add the setting to toggle request logging
- Remove the current request logging from the gunicorn startup args 