### PR TITLE
Create test users automatically (take 2)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     image: e12-django:built # build image and save for use by other containers
     depends_on:
       - postgis
-    command: s/start-dev
+    command: ${DJANGO_START_COMMAND:-s/start-dev}
     restart: always
 
   # PostgreSQL with PostGIS extension

--- a/envs/env-template
+++ b/envs/env-template
@@ -77,3 +77,7 @@ POSTGRES_USER=epilepsy12user
 TZ="Europe/London"
 
 ENABLE_REQUEST_LOGGING="False"
+
+# FOR LOCAL DEVELOPMENT
+LOCAL_DEV_ADMIN_EMAIL="incubator@rcpch.ac.uk"
+LOCAL_DEV_ADMIN_PASSWORD="devp@ssword12345")

--- a/epilepsy12/decorator.py
+++ b/epilepsy12/decorator.py
@@ -398,7 +398,7 @@ def login_and_otp_required():
             # Bypass 2fa if local dev, with warning message
             if settings.DEBUG and user.is_authenticated:
                 logger.warning(
-                    "User %s has bypassed 2FA for %s as settings.DEBUG is %s and user is superuser",
+                    "User %s has bypassed 2FA for %s as settings.DEBUG is %s",
                     user,
                     view,
                     settings.DEBUG,

--- a/epilepsy12/decorator.py
+++ b/epilepsy12/decorator.py
@@ -396,7 +396,7 @@ def login_and_otp_required():
             user = request.user
 
             # Bypass 2fa if local dev, with warning message
-            if settings.DEBUG and user.is_superuser:
+            if settings.DEBUG and user.is_authenticated:
                 logger.warning(
                     "User %s has bypassed 2FA for %s as settings.DEBUG is %s and user is superuser",
                     user,

--- a/epilepsy12/forms_folder/epilepsy12_user_form.py
+++ b/epilepsy12/forms_folder/epilepsy12_user_form.py
@@ -406,6 +406,20 @@ class CaptchaAuthenticationForm(AuthenticationForm):
     def __init__(self, request, *args, **kwargs) -> None:
         super().__init__(request, *args, **kwargs)
 
+        # If in DEBUG -> don't require captch, pre fill fields
+        if settings.DEBUG:
+            logger.warning(
+                f"IN LOCAL DEVELOPMENT, BYPASSING LOGIN BY PREFILLING FIELDS"
+            )
+            self.fields["username"].widget.attrs["value"] = (
+                settings.LOCAL_DEV_ADMIN_EMAIL
+                or "SET LOCAL_DEV_ADMIN_EMAIL IN ENVIRONMENT VARIABLES"
+            )
+            self.fields["password"].widget.attrs["value"] = (
+                settings.LOCAL_DEV_ADMIN_PASSWORD
+                or "SET LOCAL_DEV_ADMIN_PASSWORD IN ENVIRONMENT VARIABLES"
+            )
+
     def clean_username(self) -> dict[str, Any]:
         email = super().clean()["username"]
         if email:

--- a/epilepsy12/management/commands/create_dev_users.py
+++ b/epilepsy12/management/commands/create_dev_users.py
@@ -75,28 +75,28 @@ class Command(BaseCommand):
         else:
             self.stdout.write(self.style.WARNING(f"{local_dev_admin_email} already exists."))
 
-        self.create_user_if_not_exists(
-            email=lead_clinician_dev_email,
-            first_name="LeadClinician",
-            surname="DevUser",
-            password=password,
-            role=AUDIT_CENTRE_LEAD_CLINICIAN,
-        )
+        # self.create_user_if_not_exists(
+        #     email=lead_clinician_dev_email,
+        #     first_name="LeadClinician",
+        #     surname="DevUser",
+        #     password=password,
+        #     role=AUDIT_CENTRE_LEAD_CLINICIAN,
+        # )
 
-        self.create_user_if_not_exists(
-            email=clinician_dev_email,
-            first_name="Clinician",
-            surname="DevUser",
-            password=password,
-            role=AUDIT_CENTRE_CLINICIAN,
-        )
+        # self.create_user_if_not_exists(
+        #     email=clinician_dev_email,
+        #     first_name="Clinician",
+        #     surname="DevUser",
+        #     password=password,
+        #     role=AUDIT_CENTRE_CLINICIAN,
+        # )
 
-        self.create_user_if_not_exists(
-            email=administrator_dev_email,
-            first_name="Administrator",
-            surname="DevUser",
-            password=password,
-            role=AUDIT_CENTRE_ADMINISTRATOR,
-        )
+        # self.create_user_if_not_exists(
+        #     email=administrator_dev_email,
+        #     first_name="Administrator",
+        #     surname="DevUser",
+        #     password=password,
+        #     role=AUDIT_CENTRE_ADMINISTRATOR,
+        # )
         
 

--- a/epilepsy12/management/commands/create_dev_users.py
+++ b/epilepsy12/management/commands/create_dev_users.py
@@ -75,28 +75,28 @@ class Command(BaseCommand):
         else:
             self.stdout.write(self.style.WARNING(f"{local_dev_admin_email} already exists."))
 
-        # self.create_user_if_not_exists(
-        #     email=lead_clinician_dev_email,
-        #     first_name="LeadClinician",
-        #     surname="DevUser",
-        #     password=password,
-        #     role=AUDIT_CENTRE_LEAD_CLINICIAN,
-        # )
+        self.create_user_if_not_exists(
+            email=lead_clinician_dev_email,
+            first_name="LeadClinician",
+            surname="DevUser",
+            password=password,
+            role=AUDIT_CENTRE_LEAD_CLINICIAN,
+        )
 
-        # self.create_user_if_not_exists(
-        #     email=clinician_dev_email,
-        #     first_name="Clinician",
-        #     surname="DevUser",
-        #     password=password,
-        #     role=AUDIT_CENTRE_CLINICIAN,
-        # )
+        self.create_user_if_not_exists(
+            email=clinician_dev_email,
+            first_name="Clinician",
+            surname="DevUser",
+            password=password,
+            role=AUDIT_CENTRE_CLINICIAN,
+        )
 
-        # self.create_user_if_not_exists(
-        #     email=administrator_dev_email,
-        #     first_name="Administrator",
-        #     surname="DevUser",
-        #     password=password,
-        #     role=AUDIT_CENTRE_ADMINISTRATOR,
-        # )
+        self.create_user_if_not_exists(
+            email=administrator_dev_email,
+            first_name="Administrator",
+            surname="DevUser",
+            password=password,
+            role=AUDIT_CENTRE_ADMINISTRATOR,
+        )
         
 

--- a/epilepsy12/management/commands/create_dev_users.py
+++ b/epilepsy12/management/commands/create_dev_users.py
@@ -1,0 +1,102 @@
+import os
+
+from django.apps import apps
+from django.core.management.base import BaseCommand
+from django.contrib.auth import get_user_model
+
+from ...constants.user_types import (
+    AUDIT_CENTRE_LEAD_CLINICIAN,
+    AUDIT_CENTRE_CLINICIAN,
+    AUDIT_CENTRE_ADMINISTRATOR,
+    RCPCH_AUDIT_TEAM
+)
+
+class Command(BaseCommand):
+    help = "Create test users using the base set in environment variables: LOCAL_DEV_ADMIN_EMAIL and LOCAL_DEV_ADMIN_PASSWORD."
+
+    def create_user_if_not_exists(self, email, first_name, surname, password, role):
+        user_model = get_user_model()
+
+        if not user_model.objects.filter(email=email).exists():
+            Organisation = apps.get_model("epilepsy12", "Organisation")
+
+            dev_organisation_employer = Organisation.objects.get(
+                ods_code="RJZ01"  # Kings College Hospital
+            )
+
+            user_model.objects.create_user(
+                first_name=first_name,
+                surname=surname,
+                email=email,
+                password=password,
+                role=role,
+                is_active=True,
+                organisation_employer=dev_organisation_employer,
+                email_confirmed=True
+            )
+            
+            self.stdout.write(self.style.SUCCESS(f"Successfully created {email}."))
+        else:
+            self.stdout.write(self.style.WARNING(f"{email} already exists."))
+
+    def handle(self, *args, **kwargs):
+        user_model = get_user_model()
+
+        # Grab environment variables
+        local_dev_admin_email = os.environ.get("LOCAL_DEV_ADMIN_EMAIL", None)
+        password = os.environ.get("LOCAL_DEV_ADMIN_PASSWORD", None)
+
+        if not local_dev_admin_email or not password:
+            self.stdout.write(self.style.WARNING("LOCAL_DEV_ADMIN_EMAIL or LOCAL_DEV_ADMIN_PASSWORD not set. Not creating any test users."))
+
+        (local_part, domain) = local_dev_admin_email.split("@")
+
+        lead_clinician_dev_email = f"{local_part}+lead_clinician@{domain}"
+        clinician_dev_email = f"{local_part}+clinician@{domain}"
+        administrator_dev_email = f"{local_part}+administrator@{domain}"
+
+        if not user_model.objects.filter(email=local_dev_admin_email).exists():
+            Organisation = apps.get_model("epilepsy12", "Organisation")
+
+            dev_organisation_employer = Organisation.objects.get(
+                ods_code="RJZ01"  # Kings College Hospital
+            )
+
+            user_model.objects.create_superuser(
+                first_name="Superuser",
+                surname="DevUser",
+                email=local_dev_admin_email,
+                password=password,
+                role=RCPCH_AUDIT_TEAM,
+                organisation_employer=dev_organisation_employer
+            )
+            
+            self.stdout.write(self.style.SUCCESS(f"Successfully created {local_dev_admin_email}."))
+        else:
+            self.stdout.write(self.style.WARNING(f"{local_dev_admin_email} already exists."))
+
+        self.create_user_if_not_exists(
+            email=lead_clinician_dev_email,
+            first_name="LeadClinician",
+            surname="DevUser",
+            password=password,
+            role=AUDIT_CENTRE_LEAD_CLINICIAN,
+        )
+
+        self.create_user_if_not_exists(
+            email=clinician_dev_email,
+            first_name="Clinician",
+            surname="DevUser",
+            password=password,
+            role=AUDIT_CENTRE_CLINICIAN,
+        )
+
+        self.create_user_if_not_exists(
+            email=administrator_dev_email,
+            first_name="Administrator",
+            surname="DevUser",
+            password=password,
+            role=AUDIT_CENTRE_ADMINISTRATOR,
+        )
+        
+

--- a/epilepsy12/models_folder/epilepsy12user.py
+++ b/epilepsy12/models_folder/epilepsy12user.py
@@ -21,6 +21,7 @@ from epilepsy12.constants.user_types import (
     TITLES,
     # preferences in the view
     VIEW_PREFERENCES,
+    RCPCH_AUDIT_TEAM
 )
 
 logger = logging.getLogger(__name__)
@@ -121,19 +122,12 @@ class Epilepsy12UserManager(BaseUserManager):
             raise ValueError(_("Superuser must have is_staff=True."))
         if extra_fields.get("is_superuser") is not True:
             raise ValueError(_("Superuser must have is_superuser=True."))
+        if not extra_fields.get("role") == RCPCH_AUDIT_TEAM:
+            raise ValueError(_("Superuser must have role=RCPCH_AUDIT_TEAM."))
 
-        if extra_fields.get("role") not in [1, 2, 3, 4]:
-            raise ValueError("--role must be an integer between 1 and 4")
-        else:
-            if extra_fields.get("role") == 4:
-                extra_fields.setdefault("is_rcpch_staff", True)
-                extra_fields.setdefault("view_preference", 2)  # national scope
-                extra_fields.setdefault("organisation_employer", None)
-            else:
-                organisation_employer = Organisation.objects.get(
-                    ods_code="RJZ01"
-                )  # clinicians added to KCH by default
-                extra_fields.setdefault("organisation_employer", organisation_employer)
+        extra_fields.setdefault("is_rcpch_staff", True)
+        extra_fields.setdefault("view_preference", 2)  # national scope
+        extra_fields.setdefault("organisation_employer", None)
 
         logged_in_user = self.create_user(email.lower(), password, **extra_fields)
 

--- a/epilepsy12/tests/filterset_tests/test_filtersets.py
+++ b/epilepsy12/tests/filterset_tests/test_filtersets.py
@@ -523,6 +523,8 @@ def test_filter_by_has_support_for_mental_health_support(e12_case_factory):
     assert case_false not in filtered
 
 
+# Run last in CI to try and speed up runs
+@pytest.mark.slow
 @pytest.mark.django_db
 def test_filter_by_kpi_failed(e12_case_factory):
     _clean_cases_from_test_db()

--- a/rcpch-audit-engine/settings.py
+++ b/rcpch-audit-engine/settings.py
@@ -44,6 +44,9 @@ DEBUG = os.getenv("DEBUG", "False") == "True"
 if DEBUG is True:
     CAPTCHA_TEST_MODE = True  # if in debug mode, can just type 'PASSED' and captcha validates. Default value is False
 
+    LOCAL_DEV_ADMIN_EMAIL = os.getenv("LOCAL_DEV_ADMIN_EMAIL")
+    LOCAL_DEV_ADMIN_PASSWORD = os.getenv("LOCAL_DEV_ADMIN_PASSWORD")
+
 # GENERAL CAPTCHA SETTINGS
 CAPTCHA_IMAGE_SIZE = (200, 50)
 CAPTCHA_FONT_SIZE = 40

--- a/s/ci
+++ b/s/ci
@@ -29,7 +29,9 @@ docker tag e12-django:built ${azure_tag}
 docker push ${azure_tag}
 
 # Tests (against local Postgres)
-docker compose up -d --wait
+# Avoid the start-dev script seeding and pytest seeding fighting
+# each other and causing OOM errors
+DJANGO_START_COMMAND='s/start-test' docker compose up -d --wait
 s/test -m 'not slow'
 s/test -m 'slow'
 docker compose down

--- a/s/pr-check
+++ b/s/pr-check
@@ -3,6 +3,6 @@
 # Avoid the start-dev script seeding and pytest seeding fighting
 # each other and causing OOM errors
 DJANGO_START_COMMAND='sleep 100000' docker compose up -d --wait
-s/test -s -m 'not slow'
-s/test -s -m 'slow'
+s/test -m 'not slow'
+s/test -m 'slow'
 docker compose down

--- a/s/pr-check
+++ b/s/pr-check
@@ -1,6 +1,8 @@
 #!/bin/bash -e
 
-docker compose up -d --wait
-s/test -m 'not slow'
-s/test -m 'slow'
+# Avoid the start-dev script seeding and pytest seeding fighting
+# each other and causing OOM errors
+DJANGO_START_COMMAND='sleep 100000' docker compose up -d --wait
+s/test -s -m 'not slow'
+s/test -s -m 'slow'
 docker compose down

--- a/s/pr-check
+++ b/s/pr-check
@@ -2,7 +2,7 @@
 
 # Avoid the start-dev script seeding and pytest seeding fighting
 # each other and causing OOM errors
-DJANGO_START_COMMAND='sleep 100000' docker compose up -d --wait
+DJANGO_START_COMMAND='s/start-test' docker compose up -d --wait
 s/test -m 'not slow'
 s/test -m 'slow'
 docker compose down

--- a/s/start-dev
+++ b/s/start-dev
@@ -3,5 +3,5 @@
 python manage.py collectstatic --noinput
 python manage.py migrate
 python manage.py seed --mode=seed_groups_and_permissions
-# python manage.py create_dev_users
+python manage.py create_dev_users
 python manage.py runserver 0.0.0.0:8000

--- a/s/start-dev
+++ b/s/start-dev
@@ -3,4 +3,5 @@
 python manage.py collectstatic --noinput
 python manage.py migrate
 python manage.py seed --mode=seed_groups_and_permissions
+python manage.py create_dev_users
 python manage.py runserver 0.0.0.0:8000

--- a/s/start-dev
+++ b/s/start-dev
@@ -3,5 +3,5 @@
 python manage.py collectstatic --noinput
 python manage.py migrate
 python manage.py seed --mode=seed_groups_and_permissions
-python manage.py create_dev_users
+# python manage.py create_dev_users
 python manage.py runserver 0.0.0.0:8000

--- a/s/start-test
+++ b/s/start-test
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+python manage.py collectstatic --noinput
+
+# Keep the container alive to run the tests
+sleep 100000


### PR DESCRIPTION
Port of https://github.com/rcpch/national-paediatric-diabetes-audit/pull/864 to E12

Automatically creates test users for each role and pre-fills the login form with the superuser when running in dev

Raising a new PR as the original (https://github.com/rcpch/rcpch-audit-engine/pull/1252) was cursed with death by process exited with error 137. Unfortunately this PR was also affected.

I don't really know why the error happened with this change but when I removed the code to seed users from startup it stopped. So it was definitely isolated to this PR. Goodness knows why. I have changed the `s/pr-check` and `s/ci` files to not use the main `s/start-dev` script and that seems to have stabilised it. I suspect the main database was being seeded at the same time as the test database and somehow that caused GitHub actions to get upset and terminate the job.

Finally I've also marked `test_filtersets.py::test_get_kpi_failed_counts` as `@slow` since in this new setup it seemed to take ages using 100% of CPU on Postgres (probably #1119 happening again). 