### PR TITLE
Speed up templates using the organisation selector

### DIFF
--- a/epilepsy12/models_folder/entities/organisation.py
+++ b/epilepsy12/models_folder/entities/organisation.py
@@ -15,11 +15,24 @@ from simple_history.models import HistoricalRecords
 from ..time_and_user_abstract_base_classes import TimeStampAbstractBaseClass
 
 
+class OrganisationManager(models.Manager):
+    def get_organisation_list(self, exclude_pk=None):
+        queryset = self.filter(active=True)
+
+        if exclude_pk is not None:
+            queryset = queryset.exclude(pk=exclude_pk)
+
+        # Avoid N+1 query problem when the template renders the list
+        return queryset.select_related("trust", "local_health_board").order_by("name")
+
+
 class Organisation(TimeStampAbstractBaseClass):
     """
     This class details information about organisations.
     It represents a list of organisations that can be looked up
     """
+
+    objects = OrganisationManager()
 
     ods_code = CharField(
         max_length=100, null=True, blank=True, default=None, unique=True

--- a/epilepsy12/views/assessment_views.py
+++ b/epilepsy12/views/assessment_views.py
@@ -212,10 +212,7 @@ def consultant_paediatrician_referral_made(request, assessment_id):
             else:
                 site.delete()
 
-    # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
-
-    context = {"assessment": assessment, "organisation_list": organisation_list}
+    context = {"assessment": assessment, "organisation_list": Organisation.objects.get_organisation_list() }
 
     # add previous and current sites to context
     sites_context = add_sites_and_site_history_to_context(assessment.registration.case)
@@ -264,13 +261,10 @@ def consultant_paediatrician_referral_date(request, assessment_id):
     # refresh all objects and return
     assessment = Assessment.objects.get(pk=assessment_id)
 
-    # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
-
     context = {
         "assessment": assessment,
         "general_paediatric_edit_active": False,
-        "organisation_list": organisation_list,
+        "organisation_list": Organisation.objects.get_organisation_list(),
     }
 
     # add previous and current sites to context
@@ -314,7 +308,7 @@ def consultant_paediatrician_input_achieved(request, assessment_id):
         error_message = error
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     assessment = Assessment.objects.get(pk=assessment_id)
 
@@ -382,7 +376,7 @@ def consultant_paediatrician_input_date(request, assessment_id):
     assessment = Assessment.objects.get(pk=assessment_id)
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "assessment": Assessment.objects.get(pk=assessment_id),
@@ -435,10 +429,8 @@ def general_paediatric_centre(request, assessment_id):
     )
 
     # filter list to include only NHS organisations
-    organisation_list = (
-        Organisation.objects.filter(active=True)
-        .order_by("name")
-        .exclude(pk=general_paediatric_centre.pk)
+    organisation_list = Organisation.objects.get_organisation_list(
+        exclude_pk=general_paediatric_centre.pk
     )
 
     context = {
@@ -488,10 +480,8 @@ def edit_general_paediatric_centre(request, assessment_id, site_id):
     )
 
     # filter list to include only NHS organisations
-    organisation_list = (
-        Organisation.objects.filter(active=True)
-        .order_by("name")
-        .exclude(pk=general_paediatric_centre.pk)
+    organisation_list = Organisation.objects.get_organisation_list(
+        exclude_pk=general_paediatric_centre.pk
     )
 
     context = {
@@ -538,10 +528,8 @@ def update_general_paediatric_centre_pressed(request, assessment_id, site_id, ac
     selected_site = Site.objects.get(pk=site_id)
 
     # filter list to include only NHS organisations
-    organisation_list = (
-        Organisation.objects.filter(active=True)
-        .order_by("name")
-        .exclude(pk=selected_site.organisation.pk)
+    organisation_list = Organisation.objects.get_organisation_list(
+        exclude_pk=selected_site.organisation.pk
     )
 
     context = {
@@ -604,7 +592,7 @@ def delete_general_paediatric_centre(request, assessment_id, site_id):
     assessment = Assessment.objects.get(pk=assessment_id)
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "assessment": assessment,
@@ -696,7 +684,7 @@ def paediatric_neurologist_referral_made(request, assessment_id):
                     site.delete()
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {"assessment": assessment, "organisation_list": organisation_list}
 
@@ -751,7 +739,7 @@ def paediatric_neurologist_referral_date(request, assessment_id):
     assessment = Assessment.objects.get(pk=assessment_id)
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "assessment": assessment,
@@ -814,7 +802,7 @@ def paediatric_neurologist_input_date(request, assessment_id):
     assessment.save(update_fields=["paediatric_neurologist_input_achieved"])
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "assessment": assessment,
@@ -864,7 +852,7 @@ def paediatric_neurologist_input_achieved(request, assessment_id):
         error_message = error
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     assessment = Assessment.objects.get(pk=assessment_id)
 
@@ -928,7 +916,7 @@ def paediatric_neurology_centre(request, assessment_id):
     )
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "assessment": assessment,
@@ -976,7 +964,7 @@ def edit_paediatric_neurology_centre(request, assessment_id, site_id):
     )
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "assessment": assessment,
@@ -1019,7 +1007,7 @@ def update_paediatric_neurology_centre_pressed(request, assessment_id, site_id, 
         neurology_edit_active = False
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "assessment": assessment,
@@ -1081,7 +1069,7 @@ def delete_paediatric_neurology_centre(request, assessment_id, site_id):
     assessment = Assessment.objects.get(pk=assessment_id)
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "assessment": assessment,
@@ -1136,7 +1124,7 @@ def childrens_epilepsy_surgical_service_referral_criteria_met(request, assessmen
 
     assessment = Assessment.objects.get(pk=assessment_id)
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "assessment": assessment,
@@ -1224,7 +1212,7 @@ def childrens_epilepsy_surgical_service_referral_made(request, assessment_id):
                     site.delete()
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "assessment": assessment,
@@ -1282,7 +1270,7 @@ def childrens_epilepsy_surgical_service_referral_date(request, assessment_id):
     assessment = Assessment.objects.get(pk=assessment_id)
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "assessment": assessment,
@@ -1331,7 +1319,7 @@ def childrens_epilepsy_surgical_service_review_date_status(
         error_message = e
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     if status == "unknown":
         # remove any previously stored surgical review date
@@ -1393,7 +1381,7 @@ def childrens_epilepsy_surgical_service_input_date(request, assessment_id):
     assessment = Assessment.objects.get(pk=assessment_id)
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "assessment": assessment,
@@ -1445,7 +1433,7 @@ def epilepsy_surgery_centre(request, assessment_id):
     )
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "assessment": assessment,
@@ -1498,7 +1486,7 @@ def edit_epilepsy_surgery_centre(request, assessment_id, site_id):
     )
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "assessment": assessment,
@@ -1542,7 +1530,7 @@ def update_epilepsy_surgery_centre_pressed(request, assessment_id, site_id, acti
         surgery_edit_active = False
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "assessment": Assessment.objects.get(pk=assessment_id),
@@ -1607,7 +1595,7 @@ def delete_epilepsy_surgery_centre(request, assessment_id, site_id):
     assessment = Assessment.objects.get(pk=assessment_id)
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "assessment": Assessment.objects.get(pk=assessment_id),
@@ -1844,8 +1832,8 @@ def assessment(request, case_id):
     assessment = Assessment.objects.filter(registration=registration).get()
 
     # filter list to include only NHS organisations
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
-
+    organisation_list = Organisation.objects.get_organisation_list()
+    
     site = Site.objects.filter(
         site_is_actively_involved_in_epilepsy_care=True,
         site_is_primary_centre_of_epilepsy_care=True,

--- a/epilepsy12/views/organisation_views.py
+++ b/epilepsy12/views/organisation_views.py
@@ -215,7 +215,7 @@ def selected_organisation_summary(request, organisation_id):
         or request.user.is_rcpch_staff
     ):
         # select any organisations except currently selected organisation
-        organisation_list = Organisation.objects.filter(active=True).order_by("name")
+        organisation_list = Organisation.objects.get_organisation_list()
     else:
         if selected_organisation.country.boundary_identifier == "W92000004":  # Wales
             organisation_list = Organisation.objects.filter(

--- a/epilepsy12/views/registration_views.py
+++ b/epilepsy12/views/registration_views.py
@@ -108,7 +108,7 @@ def register(request, case_id):
     else:
         registration = Registration.objects.filter(case=case).get()
 
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     previously_registered = 0
 
@@ -233,7 +233,7 @@ def allocate_lead_site(request, registration_id):
 
     # get the new
 
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "organisation_list": organisation_list,
@@ -271,12 +271,7 @@ def transfer_lead_site(request, registration_id, site_id):
 
     # remove the currently selected organisation from the list - should not be able to
     # transfer to the current organisation
-    organisation_list = (
-        Organisation.objects.filter(active=True)
-        .exclude(pk=site.organisation.pk)
-        .order_by("name")
-        .all()
-    )
+    organisation_list = Organisation.objects.get_organisation_list(exclude_pk=site.organisation.pk)
 
     context = {
         "organisation_list": organisation_list,
@@ -307,7 +302,7 @@ def transfer_lead_site(request, registration_id, site_id):
 def cancel_lead_site(request, registration_id, site_id):
     registration = Registration.objects.get(pk=registration_id)
     site = Site.objects.get(pk=site_id)
-    organisation_list = Organisation.objects.filter(active=True).order_by("name")
+    organisation_list = Organisation.objects.get_organisation_list()
 
     context = {
         "registration": registration,


### PR DESCRIPTION
On my travels with Django Silk (#1267) trying to reproduce #1266 I noticed the organisation_list.html template referenced .trust/.local_health_board which meant an extra database query per organisation. The classic N + 1 ORM query problem.

Using `select_related` to fetch them in the same query reduces endpoints with this pattern from ~1s locally to ~100ms.