### PR TITLE
Fix site_contact_email in the docs

### DIFF
--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -124,7 +124,7 @@ extra:
       link: https://twitter.com/rcpchtweets
     - icon: fontawesome/brands/github
       link: https://github.com/rcpch
-  site_contact_email: !ENV SITE_CONTACT_EMAIL
+  site_contact_email: epilepsy12@rcpch.ac.uk
 
 nav:
   - Home:


### PR DESCRIPTION
Fixes #1270. I broke this when I moved the docs to be served out of the main container (https://github.com/rcpch/rcpch-audit-engine/pull/1042) which I broke in the move to Azure Container Apps (#1029).