### PR TITLE
Delete historical record on deletion

### DIFF
--- a/epilepsy12/models_folder/antiepilepsy_medicine.py
+++ b/epilepsy12/models_folder/antiepilepsy_medicine.py
@@ -78,7 +78,7 @@ class AntiEpilepsyMedicine(
         blank=True,
     )
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_user(self):

--- a/epilepsy12/models_folder/assessment.py
+++ b/epilepsy12/models_folder/assessment.py
@@ -165,7 +165,7 @@ class Assessment(TimeStampAbstractBaseClass, UserStampAbstractBaseClass, HelpTex
         null=True,
     )
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_user(self):

--- a/epilepsy12/models_folder/case.py
+++ b/epilepsy12/models_folder/case.py
@@ -140,7 +140,7 @@ class Case(TimeStampAbstractBaseClass, UserStampAbstractBaseClass, HelpTextMixin
         null=True,
     )
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     # relationships
     organisations = models.ManyToManyField(

--- a/epilepsy12/models_folder/comorbidity.py
+++ b/epilepsy12/models_folder/comorbidity.py
@@ -30,7 +30,7 @@ class Comorbidity(
         null=True,
     )
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_user(self):

--- a/epilepsy12/models_folder/entities/comorbidity_list.py
+++ b/epilepsy12/models_folder/entities/comorbidity_list.py
@@ -18,7 +18,7 @@ class ComorbidityList(TimeStampAbstractBaseClass, UserStampAbstractBaseClass):
     term = models.CharField(default=None, null=True, blank=True)
     preferredTerm = models.CharField(default=None, null=True, blank=True)
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_user(self):

--- a/epilepsy12/models_folder/entities/epilepsy_cause.py
+++ b/epilepsy12/models_folder/entities/epilepsy_cause.py
@@ -19,7 +19,7 @@ class EpilepsyCause(TimeStampAbstractBaseClass, UserStampAbstractBaseClass):
     term = models.CharField(default=None, null=True, blank=True)
     preferredTerm = models.CharField(default=None, null=True, blank=True)
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_user(self):

--- a/epilepsy12/models_folder/entities/medicine.py
+++ b/epilepsy12/models_folder/entities/medicine.py
@@ -28,7 +28,7 @@ class Medicine(TimeStampAbstractBaseClass, UserStampAbstractBaseClass, HelpTextM
     preferredTerm = models.CharField(default=None, null=True, blank=True)
     is_rescue = models.BooleanField(default=None, null=True, blank=True)
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_user(self):

--- a/epilepsy12/models_folder/entities/organisation.py
+++ b/epilepsy12/models_folder/entities/organisation.py
@@ -105,7 +105,7 @@ class Organisation(TimeStampAbstractBaseClass):
         to="epilepsy12.Country", on_delete=models.PROTECT, null=True, blank=True
     )
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_user(self):

--- a/epilepsy12/models_folder/entities/syndrome_list.py
+++ b/epilepsy12/models_folder/entities/syndrome_list.py
@@ -27,7 +27,7 @@ class SyndromeList(
         default=None,
     )
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_user(self):

--- a/epilepsy12/models_folder/epilepsy12_site.py
+++ b/epilepsy12/models_folder/epilepsy12_site.py
@@ -51,7 +51,7 @@ class Site(TimeStampAbstractBaseClass, UserStampAbstractBaseClass):
     )
     transfer_request_date = models.DateField(blank=True, null=True, default=None)
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     # relationships
     # Site is a link table between Case and Organisation in a many to many relationship

--- a/epilepsy12/models_folder/epilepsy12user.py
+++ b/epilepsy12/models_folder/epilepsy12user.py
@@ -214,7 +214,7 @@ class Epilepsy12User(AbstractUser, PermissionsMixin):
         related_name="updated_users",
     )
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     REQUIRED_FIELDS = ["role", "first_name", "surname", "is_rcpch_audit_team_member"]
     USERNAME_FIELD = "email"

--- a/epilepsy12/models_folder/epilepsy_context.py
+++ b/epilepsy12/models_folder/epilepsy_context.py
@@ -97,7 +97,7 @@ class EpilepsyContext(
         choices=OPT_OUT_UNCERTAIN,
     )
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_user(self):

--- a/epilepsy12/models_folder/episode.py
+++ b/epilepsy12/models_folder/episode.py
@@ -277,7 +277,7 @@ class Episode(TimeStampAbstractBaseClass, UserStampAbstractBaseClass, HelpTextMi
         max_length=250, default=None, null=True, blank=True
     )
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_user(self):

--- a/epilepsy12/models_folder/first_paediatric_assessment.py
+++ b/epilepsy12/models_folder/first_paediatric_assessment.py
@@ -74,7 +74,7 @@ class FirstPaediatricAssessment(
         default=None,
     )
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_user(self):

--- a/epilepsy12/models_folder/investigations.py
+++ b/epilepsy12/models_folder/investigations.py
@@ -96,7 +96,7 @@ class Investigations(
         blank=True,
     )
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_user(self):

--- a/epilepsy12/models_folder/management.py
+++ b/epilepsy12/models_folder/management.py
@@ -158,7 +158,7 @@ class Management(TimeStampAbstractBaseClass, UserStampAbstractBaseClass, HelpTex
         blank=True,
     )
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_user(self):

--- a/epilepsy12/models_folder/multiaxial_diagnosis.py
+++ b/epilepsy12/models_folder/multiaxial_diagnosis.py
@@ -126,7 +126,7 @@ class MultiaxialDiagnosis(
         null=True,
     )
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_user(self):

--- a/epilepsy12/models_folder/organisation_employer.py
+++ b/epilepsy12/models_folder/organisation_employer.py
@@ -44,7 +44,7 @@ class OrganisationEmployer(models.Model):
         related_name="updated_organisation_employers",
     )
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     class Meta:
         constraints = [

--- a/epilepsy12/models_folder/organisational_audit.py
+++ b/epilepsy12/models_folder/organisational_audit.py
@@ -61,7 +61,7 @@ class OrganisationalAuditSubmission(TimeStampAbstractBaseClass, UserStampAbstrac
     # or
     local_health_board = models.ForeignKey(LocalHealthBoard, null=True, on_delete=models.SET_NULL)
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     submitted = models.BooleanField(default=False)
 

--- a/epilepsy12/models_folder/registration.py
+++ b/epilepsy12/models_folder/registration.py
@@ -65,7 +65,7 @@ class Registration(
 
     cohort = models.PositiveSmallIntegerField(default=None, null=True)
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_user(self):

--- a/epilepsy12/models_folder/semiology_keyword.py
+++ b/epilepsy12/models_folder/semiology_keyword.py
@@ -17,7 +17,7 @@ class Keyword(models.Model):
         max_length=100
     )
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_user(self):

--- a/epilepsy12/models_folder/syndrome.py
+++ b/epilepsy12/models_folder/syndrome.py
@@ -41,7 +41,7 @@ class Syndrome(TimeStampAbstractBaseClass, UserStampAbstractBaseClass, HelpTextM
         default=None,
     )
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_user(self):


### PR DESCRIPTION
Without this we retain demographic information for patients in the database after deletion even though it is no longer accessible via the platform