### PR TITLE
Upgrade Django to fix dependabot warning

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,7 @@ requests==2.32.4
 # third party imports
 ## django and misc
 dj_database_url==2.3.0
-django==5.2.3
+django==5.2.6
 django-auto-logout==0.5.1
 django-filter==25.1
 django-htmx==1.23.0


### PR DESCRIPTION
https://github.com/rcpch/rcpch-audit-engine/security/dependabot/24
