### PR TITLE
Set default number of gunicorn workers

### DIFF
--- a/s/start-prod
+++ b/s/start-prod
@@ -7,4 +7,5 @@ python manage.py seed --mode=seed_groups_and_permissions
 gunicorn \
     --bind=0.0.0.0:8000 \
     --timeout 600 \
+    --workers 5 \
     rcpch-audit-engine.wsgi


### PR DESCRIPTION
Port of https://github.com/rcpch/national-paediatric-diabetes-audit/pull/1256. Part of #1266 

Following their guidance: https://docs.gunicorn.org/en/latest/design.html#how-many-workers

2 CPU cores => (2 * 2) + 1 = 5

(Currently we have 4 CPU cores but I will reduce it down to 2 after this change)

The default was 1! No wonder we had reports of the platform slowing down - some slower operations could have been starving out other requests to the worker.