### PR TITLE
Add focus-scroll to organisational audit

### DIFF
--- a/templates/epilepsy12/organisational_audit.html
+++ b/templates/epilepsy12/organisational_audit.html
@@ -3,7 +3,7 @@
 <div class="ui rcpch container main_content">
     {% if submission_period.is_open %}
         <h2 class="org-audit-header">Organisational Audit {{submission_period.year}} - {{group_name}}</h2>
-        <form class="ui rcpch form" method="POST" hx-post="{{ request.path }}" hx-trigger="input delay:0.5s,submit">
+        <form class="ui rcpch form" method="POST" hx-post="{{ request.path }}" hx-trigger="input delay:0.5s,submit"  hx-swap="innerHTML focus-scroll:true">
             {% include 'epilepsy12/partials/organisational_audit_form.html' %}
         </form>
     {% else %}


### PR DESCRIPTION
Avoids org audit jumping to the bottom on an update. It didn't used to last year so I suspect an htmx upgrade in the intervening period changed this.