### PR TITLE
fixes the extra `cumulative_score` addition in the `total_fields_expected` function, fixes the tests, adds more, improves the management view checks when medications are selected

### DIFF
--- a/epilepsy12/common_view_functions/recalculate_form_generate_response.py
+++ b/epilepsy12/common_view_functions/recalculate_form_generate_response.py
@@ -80,7 +80,6 @@ def update_audit_progress(model_instance):
         f"{verbose_name_underscored}_complete": all_completed_fields
         == all_expected_fields,
     }
-
     # all models are related to registration, except registration itself
     if verbose_name_underscored == "registration":
         registration = model_instance
@@ -162,7 +161,6 @@ def total_fields_expected(model_instance):
     """
     Returns as expected fields for a given model instance, based on user selections.
     """
-
     model_class_name = model_instance.__class__.__name__
     # get the minimum number of fields for this model
     cumulative_score = scoreable_fields_for_model_class_name(
@@ -287,6 +285,7 @@ def total_fields_expected(model_instance):
                     - Both questions appear for females aged 12 year and over and on topiramate
                     - the Annual Risk Acknowledgment Form question appear for males on topiramate (the pregnancy prevention programme doesn't apply to males)
                     """
+                    # by this stage cumulative score must already be +3 for medicine name, start date,  risk discussed
                     if model_instance.registration.cohort > 6:
                         if medicine.medicine_entity is not None:
                             if (
@@ -298,16 +297,23 @@ def total_fields_expected(model_instance):
                                 cumulative_score += 1
 
                                 if model_instance.registration.case.sex == 2:
-                                    # if patient is a girl and either she is on valproate or she is 12 years or older and on topiramate
-                                    # essential fields are:
-                                    # 'is_a_pregnancy_prevention_programme_in_place
-                                    cumulative_score += 1
                                     if (
-                                        medicine.is_a_pregnancy_prevention_programme_needed
-                                    ):
-                                        # essential fields are:
-                                        # 'is_a_pregnancy_prevention_programme_in_place
-                                        cumulative_score += 1
+                                        medicine.medicine_entity.conceptId
+                                        == "387481005"
+                                        or (
+                                            medicine.medicine_entity.conceptId
+                                            == "777808008"  # topiramate
+                                            and calculated_age.years >= 12
+                                        )
+                                    ):  # valproate or topiramate
+                                        # if patient is a girl and either she is on valproate or she is 12 years or older and on topiramate
+                                        if (
+                                            medicine.is_a_pregnancy_prevention_programme_needed
+                                        ):
+                                            # essential fields are:
+                                            # 'is_a_pregnancy_prevention_programme_in_place
+                                            cumulative_score += 1
+
                     else:
                         # cohort is 6 or below
                         # essential fields are:
@@ -318,10 +324,7 @@ def total_fields_expected(model_instance):
                             and calculated_age.years >= 12
                         ):
                             if medicine.medicine_entity is not None:
-                                if (
-                                    medicine.medicine_entity.medicine_name
-                                    == "Sodium valproate"
-                                ):
+                                if medicine.medicine_entity.conceptId == "387481005":
                                     # essential fields are:
                                     # 'is_a_pregnancy_prevention_programme_needed' - this is not scored
                                     if (
@@ -428,6 +431,7 @@ def avoid_fields(model_instance):
         ]
 
     elif model_class_name == "AntiEpilepsyMedicine":
+        print("Avoiding fields for AntiEpilepsyMedicine")
         return META_VARIABLES + [
             "management",
             "is_rescue_medicine",
@@ -687,8 +691,8 @@ def number_of_completed_fields_in_related_models(model_instance):
                 for medicine in medicines:
                     # essential fields are:
                     # medicineentity_medicine_name', 'antiepilepsy_medicine_start_date',
-                    # 'antiepilepsy_medicine_risk_discussed', and if valproate prescribed
-                    # in a girl > 12y, 'is_a_pregnancy_prevention_programme_in_place'
+                    # 'antiepilepsy_medicine_risk_discussed', and if valproate/topiramate depending on cohort prescribed
+                    # 'is_a_pregnancy_prevention_programme_in_place'
                     # 'has_a_valproate_annual_risk_acknowledgement_form_been_completed'
                     cumulative_score += completed_fields(medicine)
 

--- a/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_8_topiramate.py
+++ b/epilepsy12/tests/common_view_functions_tests/calculate_kpi_tests/test_measure_8_topiramate.py
@@ -7,6 +7,9 @@ import pytest
 
 # RCPCH imports
 from epilepsy12.common_view_functions import calculate_kpis
+from epilepsy12.common_view_functions.recalculate_form_generate_response import (
+    total_fields_expected,
+)
 from epilepsy12.constants import SEX_TYPE, KPI_SCORE
 from epilepsy12.models import (
     AntiEpilepsyMedicine,

--- a/epilepsy12/tests/view_tests/form_calculations/test_total_fields_expected.py
+++ b/epilepsy12/tests/view_tests/form_calculations/test_total_fields_expected.py
@@ -1,6 +1,6 @@
-""" Tests for `total_fields_expected` fn and `scoreable_fields_for_model_class_name` helper fn.
+"""Tests for `total_fields_expected` fn and `scoreable_fields_for_model_class_name` helper fn.
 
-All models EXCEPT the following 5 simply return the output of `scoreable_fields_for_model_class_name`. 
+All models EXCEPT the following 5 simply return the output of `scoreable_fields_for_model_class_name`.
 
 Additionally, these 5 use `scoreable_fields_for_model_class_name` += some extra fields in related models.
 
@@ -26,6 +26,7 @@ from epilepsy12.models import (
     Medicine,
 )
 from epilepsy12.common_view_functions.recalculate_form_generate_response import (
+    completed_fields,
     scoreable_fields_for_model_class_name,
     total_fields_expected,
     count_episode_fields,
@@ -47,6 +48,7 @@ from epilepsy12.constants import (
     NON_EPILEPSY_SEIZURE_ONSET,
     NON_EPILEPSY_SEIZURE_TYPE,
 )
+from epilepsy12.models_folder.management import Management
 from epilepsy12.tests.view_tests.form_calculations.test_number_of_completed_fields_in_related_models import (
     get_random_answers_update_counter,
 )
@@ -513,3 +515,102 @@ def test_total_fields_expected_management(
     assert (
         return_value == expected_value
     ), f"total_fields_expected(management) expected {expected_value} but got {return_value}. 13yo girl registered with Valproate AED and Keppra as rescue"
+
+
+# Test the form total_fields_expected for topiramate or valproate based on the sex and age of the case
+# After cohort 6, both topiramate and valproate require pregnancy prevention programme fields to be filled in girls though in the case of topiramate only if she is over 12y.
+# For boys no pregnancy prevention programme fields are required for either medicine but valproate still requires the annual risk acknowledgement form to be completed.
+# In cohort 6 and below neither medicine requires pregnancy prevention programme fields to be filled only for girls over 12y on valproate. For cohort 6 and below
+# the annual risk acknowledgement is not required
+
+
+# Note the baseline minimum expected fields for management is 5 when an AED has been given.
+@pytest.mark.parametrize(
+    "age_over_12, medicine, sex, expected_value",
+    [
+        (True, "777808008", 2, 5 + 5),  # over 12, female, topiramate
+        (True, "387481005", 2, 5 + 5),  # over 12, female, valproate
+        (False, "777808008", 2, 5 + 4),  # under 12, female, topiramate
+        (False, "387481005", 2, 5 + 5),  # under 12, female, valproate
+        (True, "777808008", 1, 5 + 4),  # over 12, male, topiramate
+        (True, "387481005", 1, 5 + 4),  # over 12, male, valproate
+    ],
+)
+@pytest.mark.django_db
+def test_total_fields_expected_topiramate_or_valproate_for_sex_and_age(
+    e12_case_factory,
+    e12_anti_epilepsy_medicine_factory,
+    GOSH,
+    age_over_12,
+    medicine,
+    sex,
+    expected_value,
+):
+    """
+    Tests total_fields_expected(management) returns correct expected output, with all fields all True.
+    """
+    if age_over_12:
+        dob = date(2024, 5, 1) - relativedelta(years=13)
+    else:
+        dob = date(2024, 5, 1) - relativedelta(years=10)
+
+    CASE = e12_case_factory(
+        first_name=f"temp_child_{GOSH.name}",
+        date_of_birth=dob,
+        organisations__organisation=GOSH,
+        sex=SEX_TYPE[sex][0],
+    )
+
+    CASE.registration.first_paediatric_assessment_date = date(2024, 5, 1)
+    CASE.registration.cohort = 7
+    CASE.registration.management.has_an_aed_been_given = True
+    CASE.registration.save()
+
+    # score +3 for medicine present, +2 as topiramate in childbearing female
+    if (
+        (age_over_12 and medicine == "777808008") or (medicine == "387481005")
+    ) and sex == 2:
+        aed_answers = {
+            "medicine_entity": Medicine.objects.get(conceptId=medicine),
+            "antiepilepsy_medicine_start_date": date(2024, 6, 1),
+            "antiepilepsy_medicine_risk_discussed": True,
+            "is_a_pregnancy_prevention_programme_needed": True,
+            "is_a_pregnancy_prevention_programme_in_place": True,
+            "has_a_valproate_annual_risk_acknowledgement_form_been_completed": True,
+        }
+    else:
+        aed_answers = {
+            "medicine_entity": Medicine.objects.get(conceptId=medicine),
+            "antiepilepsy_medicine_start_date": date(2024, 6, 1),
+            "antiepilepsy_medicine_risk_discussed": True,
+            "is_a_pregnancy_prevention_programme_needed": None,
+            "is_a_pregnancy_prevention_programme_in_place": None,
+            "has_a_valproate_annual_risk_acknowledgement_form_been_completed": True,
+        }
+
+    e12_anti_epilepsy_medicine_factory(
+        management=CASE.registration.management,
+        is_rescue_medicine=False,
+        **aed_answers,
+    )
+
+    return_value = total_fields_expected(CASE.registration.management)
+
+    assert (
+        CASE.registration.cohort == 7
+    ), "Cohort should be 7 for first paediatric assessment date of 2024-05-01"
+    if age_over_12:
+        assert CASE.age_days() > (
+            12 * 365.25
+        ), f"Case should be over 12 years old, but is {CASE.age_days()/365.25} years old"
+    else:
+        assert CASE.age_days() < (
+            12 * 365.25
+        ), f"Case should be under 12 years old, but is {CASE.age_days()/365.25} years old"
+    assert (
+        CASE.sex == sex
+    ), f"Case should be {SEX_TYPE[sex][1]}, but is {SEX_TYPE[CASE.sex][1]}"
+
+    assert (
+        return_value == expected_value
+    ), f"total_fields_expected(management) expected {expected_value} but got {return_value}. >12yo girl registered with Topiramate AED"

--- a/epilepsy12/tests/view_tests/form_calculations/test_total_fields_expected.py
+++ b/epilepsy12/tests/view_tests/form_calculations/test_total_fields_expected.py
@@ -537,7 +537,7 @@ def test_total_fields_expected_management(
     ],
 )
 @pytest.mark.django_db
-def test_total_fields_expected_topiramate_or_valproate_for_sex_and_age(
+def test_total_fields_expected_topiramate_or_valproate_for_sex_and_age_cohort_7(
     e12_case_factory,
     e12_anti_epilepsy_medicine_factory,
     GOSH,
@@ -599,6 +599,100 @@ def test_total_fields_expected_topiramate_or_valproate_for_sex_and_age(
     assert (
         CASE.registration.cohort == 7
     ), "Cohort should be 7 for first paediatric assessment date of 2024-05-01"
+    if age_over_12:
+        assert CASE.age_days() > (
+            12 * 365.25
+        ), f"Case should be over 12 years old, but is {CASE.age_days()/365.25} years old"
+    else:
+        assert CASE.age_days() < (
+            12 * 365.25
+        ), f"Case should be under 12 years old, but is {CASE.age_days()/365.25} years old"
+    assert (
+        CASE.sex == sex
+    ), f"Case should be {SEX_TYPE[sex][1]}, but is {SEX_TYPE[CASE.sex][1]}"
+
+    assert (
+        return_value == expected_value
+    ), f"total_fields_expected(management) expected {expected_value} but got {return_value}. >12yo girl registered with Topiramate AED"
+
+
+@pytest.mark.parametrize(
+    "age_over_12, medicine, sex, expected_value",
+    [
+        (True, "777808008", 2, 5 + 3),  # over 12, female, topiramate
+        (
+            True,
+            "387481005",
+            2,
+            5 + 5,
+        ),  # over 12, female, valproate (needs annual risk acknowledgement and pregnancy prevention programme)
+        (False, "777808008", 2, 5 + 3),  # under 12, female, topiramate
+        (False, "387481005", 2, 5 + 3),  # under 12, female, valproate
+        (True, "777808008", 1, 5 + 3),  # over 12, male, topiramate
+        (True, "387481005", 1, 5 + 3),  # over 12, male, valproate
+    ],
+)
+@pytest.mark.django_db
+def test_total_fields_expected_topiramate_or_valproate_for_sex_and_age_cohort_6(
+    e12_case_factory,
+    e12_anti_epilepsy_medicine_factory,
+    GOSH,
+    age_over_12,
+    medicine,
+    sex,
+    expected_value,
+):
+    """
+    Tests total_fields_expected(management) returns correct expected output, with all fields all True.
+    """
+    if age_over_12:
+        dob = date(2023, 2, 1) - relativedelta(years=13)
+    else:
+        dob = date(2023, 2, 1) - relativedelta(years=9)
+
+    CASE = e12_case_factory(
+        first_name=f"temp_child_{GOSH.name}",
+        date_of_birth=dob,
+        organisations__organisation=GOSH,
+        sex=SEX_TYPE[sex][0],
+    )
+
+    CASE.registration.first_paediatric_assessment_date = date(2023, 5, 1)
+    CASE.registration.cohort = 6
+    CASE.registration.management.has_an_aed_been_given = True
+    CASE.registration.save()
+
+    # score +3 for medicine present, +2 as topiramate in childbearing female
+    if age_over_12 and medicine == "387481005" and sex == 2:
+        aed_answers = {
+            "medicine_entity": Medicine.objects.get(conceptId=medicine),
+            "antiepilepsy_medicine_start_date": date(2023, 6, 1),
+            "antiepilepsy_medicine_risk_discussed": True,
+            "is_a_pregnancy_prevention_programme_needed": True,
+            "is_a_pregnancy_prevention_programme_in_place": True,
+            "has_a_valproate_annual_risk_acknowledgement_form_been_completed": None,
+        }
+    else:
+        aed_answers = {
+            "medicine_entity": Medicine.objects.get(conceptId=medicine),
+            "antiepilepsy_medicine_start_date": date(2023, 6, 1),
+            "antiepilepsy_medicine_risk_discussed": True,
+            "is_a_pregnancy_prevention_programme_needed": None,
+            "is_a_pregnancy_prevention_programme_in_place": None,
+            "has_a_valproate_annual_risk_acknowledgement_form_been_completed": None,
+        }
+
+    e12_anti_epilepsy_medicine_factory(
+        management=CASE.registration.management,
+        is_rescue_medicine=False,
+        **aed_answers,
+    )
+
+    return_value = total_fields_expected(CASE.registration.management)
+
+    assert (
+        CASE.registration.cohort == 6
+    ), f"Cohort should be 6 for first paediatric assessment date of 2023-05-01, but got {CASE.registration.cohort}"
     if age_over_12:
         assert CASE.age_days() > (
             12 * 365.25

--- a/epilepsy12/views/management_views.py
+++ b/epilepsy12/views/management_views.py
@@ -360,39 +360,56 @@ def medicine_id(request, antiepilepsy_medicine_id, medicine_status):
 
     antiepilepsy_medicine.medicine_entity = medicine_entity
 
+    # determine if pregnancy prevention programme questions are needed
+    # Note that as of issue #1215, topiramate is only included for cohorts >6 as requiring pregnancy prevention programme
+    # in girls over 12 years of age. Girls on sodium valproate should have a pregnancy prevention programme in place when they are
+    # over 12 years in cohort 6, and any age in later cohorts.
+
+    def requires_pregnancy_prevention_programme(cohort, medicine_concept_id, age, sex):
+        """
+        Determine if a pregnancy prevention programme is required based on cohort, medicine, age, and sex
+        As of issue #1215, topiramate is only included for cohorts >6 as requiring pregnancy prevention programme from 12y and up
+        as well as all girls on sodium valproate in cohorts >6 irrespective of age
+        387481005 = sodium valproate
+        777808008 = topiramate
+
+        """
+        if cohort > 6:
+            if medicine_concept_id == "387481005" and sex == 2:  # sodium valproate
+                return True  # all girls on valproate irrespective of age need a pregnancy prevention programme
+            elif (
+                medicine_concept_id == "777808008" and sex == 2 and age >= 12
+            ):  # topiramate
+                return True  # girls over 12 on topiramate need a pregnancy prevention programme
+            return False
+        else:
+            if (
+                medicine_concept_id == "387481005" and sex == 2 and age >= 12
+            ):  # sodium valproate
+                return True  # girls on valproate over 12 need a pregnancy prevention programme
+            return False  # other medicines/cohorts do not require pregnancy prevention programme (including topiramate in cohort 6 and below)
+
     if hasattr(antiepilepsy_medicine, "medicine_entity"):
         if antiepilepsy_medicine.medicine_entity is not None:
-            if (
-                antiepilepsy_medicine.medicine_entity.medicine_name
-                == "Sodium valproate"
-                and int(antiepilepsy_medicine.management.registration.case.sex) == 2
+            today = date.today()
+            calculated_age = relativedelta.relativedelta(
+                today,
+                antiepilepsy_medicine.management.registration.case.date_of_birth,
+            )
+            sex = int(antiepilepsy_medicine.management.registration.case.sex)
+            if requires_pregnancy_prevention_programme(
+                cohort=antiepilepsy_medicine.management.registration.cohort,
+                medicine_concept_id=antiepilepsy_medicine.medicine_entity.conceptId,
+                age=calculated_age.years,
+                sex=sex,
             ):
-                today = date.today()
-                calculated_age = relativedelta.relativedelta(
-                    today,
-                    antiepilepsy_medicine.management.registration.case.date_of_birth,
+                antiepilepsy_medicine.is_a_pregnancy_prevention_programme_needed = True
+                antiepilepsy_medicine.is_a_pregnancy_prevention_programme_in_place = (
+                    None
                 )
-                if calculated_age.years >= 12:
-                    # sodium valproate selected and patient is female
-                    antiepilepsy_medicine.is_a_pregnancy_prevention_programme_needed = (
-                        True
-                    )
-                    antiepilepsy_medicine.is_a_pregnancy_prevention_programme_in_place = (
-                        None
-                    )
-                    antiepilepsy_medicine.has_a_valproate_annual_risk_acknowledgement_form_been_completed = (
-                        None
-                    )
-                else:
-                    antiepilepsy_medicine.is_a_pregnancy_prevention_programme_needed = (
-                        False
-                    )
-                    antiepilepsy_medicine.is_a_pregnancy_prevention_programme_in_place = (
-                        None
-                    )
-                    antiepilepsy_medicine.has_a_valproate_annual_risk_acknowledgement_form_been_completed = (
-                        None
-                    )
+                antiepilepsy_medicine.has_a_valproate_annual_risk_acknowledgement_form_been_completed = (
+                    None
+                )
             else:
                 antiepilepsy_medicine.is_a_pregnancy_prevention_programme_needed = False
                 antiepilepsy_medicine.is_a_pregnancy_prevention_programme_in_place = (


### PR DESCRIPTION
### Overview

fixes #1293
The scoring for the form when children were on topiramate and valproate was overscoring the expected number of fields. This has been fixed.

Along the way it was noted that the way a medicine was saved in the view did not take account of the cohort so this has been fixed.

Tests have been added to test the expected scores for both medications in girls and boys both over and under 12y, against cohort 6 and cohort 7