### PR TITLE
Merge Trust and Local Health Board dropdowns with improved UX

### DIFF
--- a/epilepsy12/common_view_functions/sanction_user_access.py
+++ b/epilepsy12/common_view_functions/sanction_user_access.py
@@ -54,3 +54,75 @@ def organisation_white_list_for_user(epilepsy12_user):
         .distinct()
         .order_by("name")
     )
+
+
+def merged_parent_list_for_user(epilepsy12_user, organisation_list=None):
+    """
+    Returns a merged list of Trusts and Local Health Boards that the user can access.
+    Each item in the list is a dict with:
+    - pk: primary key
+    - name: parent name  
+    - parent_type: 'trust' or 'local_health_board'
+    - ods_code: ODS code
+    
+    Avoids N+1 queries by fetching all parents in two queries, then merging in Python.
+    
+    Args:
+        epilepsy12_user: The user to get parents for
+        organisation_list: Optional pre-filtered organisation queryset. If None, 
+                          will call organisation_white_list_for_user()
+    
+    Returns:
+        List of dicts sorted by name
+    """
+    Trust = apps.get_model("epilepsy12", "Trust")
+    LocalHealthBoard = apps.get_model("epilepsy12", "LocalHealthBoard")
+    
+    # Get organisation list if not provided
+    if organisation_list is None:
+        organisation_list = organisation_white_list_for_user(epilepsy12_user)
+    
+    # Get all trusts and LHBs that have organisations in the whitelist
+    # Using values_list to avoid loading full objects we don't need
+    trust_ids = organisation_list.filter(
+        trust__isnull=False, 
+        active=True
+    ).values_list('trust', flat=True).distinct()
+    
+    lhb_ids = organisation_list.filter(
+        local_health_board__isnull=False, 
+    ).values_list('local_health_board', flat=True).distinct()
+    
+    # Fetch all trusts and LHBs in two queries (not N+1)
+    trusts = Trust.objects.filter(
+        id__in=trust_ids,
+        active=True
+    ).values('pk', 'name', 'ods_code').order_by('name')
+    
+    lhbs = LocalHealthBoard.objects.filter(
+        id__in=lhb_ids
+    ).values('pk', 'name', 'ods_code').order_by('name')
+    
+    # Merge and annotate with parent_type
+    merged_list = []
+    
+    for trust in trusts:
+        merged_list.append({
+            'pk': trust['pk'],
+            'name': trust['name'],
+            'parent_type': 'trust',
+            'ods_code': trust['ods_code'],
+        })
+    
+    for lhb in lhbs:
+        merged_list.append({
+            'pk': lhb['pk'],
+            'name': lhb['name'],
+            'parent_type': 'local_health_board',
+            'ods_code': lhb['ods_code'],
+        })
+    
+    # Sort by name
+    merged_list.sort(key=lambda x: x['name'])
+    
+    return merged_list

--- a/epilepsy12/common_view_functions/sanction_user_access.py
+++ b/epilepsy12/common_view_functions/sanction_user_access.py
@@ -84,16 +84,17 @@ def merged_parent_list_for_user(epilepsy12_user, organisation_list=None):
     
     # Get all trusts and LHBs that have organisations in the whitelist
     # Using values_list to avoid loading full objects we don't need
+    # organisation_list is already filtered by active=True organisations
     trust_ids = organisation_list.filter(
-        trust__isnull=False, 
-        active=True
+        trust__isnull=False
     ).values_list('trust', flat=True).distinct()
     
     lhb_ids = organisation_list.filter(
-        local_health_board__isnull=False, 
+        local_health_board__isnull=False
     ).values_list('local_health_board', flat=True).distinct()
     
     # Fetch all trusts and LHBs in two queries (not N+1)
+    # Only trusts have an active field - LHBs don't
     trusts = Trust.objects.filter(
         id__in=trust_ids,
         active=True

--- a/epilepsy12/common_view_functions/sanction_user_access.py
+++ b/epilepsy12/common_view_functions/sanction_user_access.py
@@ -64,8 +64,15 @@ def merged_parent_list_for_user(epilepsy12_user, organisation_list=None):
     - name: parent name  
     - parent_type: 'trust' or 'local_health_board'
     - ods_code: ODS code
+    - country: country code (for trusts only)
     
     Avoids N+1 queries by fetching all parents in two queries, then merging in Python.
+    
+    Special handling for Jersey:
+    - Jersey is a special case (country="Jersey") with its own trust
+    - Jersey users can only see Jersey trust
+    - Non-Jersey users cannot see Jersey trust unless employed there
+    - Admin users can see all trusts including Jersey
     
     Args:
         epilepsy12_user: The user to get parents for
@@ -77,10 +84,32 @@ def merged_parent_list_for_user(epilepsy12_user, organisation_list=None):
     """
     Trust = apps.get_model("epilepsy12", "Trust")
     LocalHealthBoard = apps.get_model("epilepsy12", "LocalHealthBoard")
+    Organisation = apps.get_model("epilepsy12", "Organisation")
     
     # Get organisation list if not provided
     if organisation_list is None:
         organisation_list = organisation_white_list_for_user(epilepsy12_user)
+    
+    # Check if user is admin (can see all trusts including Jersey)
+    is_admin = (
+        epilepsy12_user.is_rcpch_staff or 
+        epilepsy12_user.is_superuser or 
+        epilepsy12_user.is_rcpch_audit_team_member
+    )
+    
+    # Check if user is employed at Jersey (only do this check for non-admin users)
+    # Jersey country can be "Jersey" or "JERSEY" (case-insensitive check)
+    if not is_admin:
+        user_organisations = Organisation.objects.filter(
+            epilepsy12_users__epilepsy12_user=epilepsy12_user,
+            epilepsy12_users__is_active=True,
+        )
+        user_is_jersey_employed = user_organisations.filter(
+            trust__country__iexact="JERSEY"
+        ).exists()
+    else:
+        # Admin users can see everything, so we don't need to check Jersey employment
+        user_is_jersey_employed = True  # Set to True so Jersey is not filtered out
     
     # Get all trusts and LHBs that have organisations in the whitelist
     # Using values_list to avoid loading full objects we don't need
@@ -95,24 +124,32 @@ def merged_parent_list_for_user(epilepsy12_user, organisation_list=None):
     
     # Fetch all trusts and LHBs in two queries (not N+1)
     # Only trusts have an active field - LHBs don't
+    # Include country field for Jersey filtering
     trusts = Trust.objects.filter(
         id__in=trust_ids,
         active=True
-    ).values('pk', 'name', 'ods_code').order_by('name')
+    ).values('pk', 'name', 'ods_code', 'country').order_by('name')
     
     lhbs = LocalHealthBoard.objects.filter(
         id__in=lhb_ids
     ).values('pk', 'name', 'ods_code').order_by('name')
     
     # Merge and annotate with parent_type
+    # Filter out Jersey for non-Jersey users (unless they're employed there)
     merged_list = []
     
     for trust in trusts:
+        # Skip Jersey trust if user is not employed there
+        # Jersey country can be "Jersey" or "JERSEY" - case insensitive check
+        if trust['country'] and trust['country'].upper() == 'JERSEY' and not user_is_jersey_employed:
+            continue
+            
         merged_list.append({
             'pk': trust['pk'],
             'name': trust['name'],
             'parent_type': 'trust',
             'ods_code': trust['ods_code'],
+            'country': trust['country'],
         })
     
     for lhb in lhbs:
@@ -121,6 +158,7 @@ def merged_parent_list_for_user(epilepsy12_user, organisation_list=None):
             'name': lhb['name'],
             'parent_type': 'local_health_board',
             'ods_code': lhb['ods_code'],
+            'country': None,  # LHBs don't have country field
         })
     
     # Sort by name

--- a/epilepsy12/models_folder/entities/local_health_board.py
+++ b/epilepsy12/models_folder/entities/local_health_board.py
@@ -32,7 +32,17 @@ class LocalHealthBoardBoundaries(TimeStampAbstractBaseClass):
         abstract = True
 
 
+class LocalHealthBoardManager(models.Manager):
+    def get_local_health_board_list(self, exclude_pk=None):
+        queryset = self.filter(active=True)
+
+        if exclude_pk is not None:
+            queryset = queryset.exclude(pk=exclude_pk)
+
+        return queryset.order_by("name")
+
 class LocalHealthBoard(LocalHealthBoardBoundaries):
+    objects = LocalHealthBoardManager()
     ods_code = models.CharField(max_length=3)
     publication_date = models.DateField(blank=True, null=True)
 

--- a/epilepsy12/models_folder/entities/trust.py
+++ b/epilepsy12/models_folder/entities/trust.py
@@ -1,8 +1,18 @@
 from django.contrib.gis.db import models
 from ..time_and_user_abstract_base_classes import TimeStampAbstractBaseClass
 
+class TrustManager(models.Manager):
+    def get_trust_list(self, exclude_pk=None):
+        queryset = self.filter(active=True)
+
+        if exclude_pk is not None:
+            queryset = queryset.exclude(pk=exclude_pk)
+
+        return queryset.order_by("name")
 
 class Trust(TimeStampAbstractBaseClass):
+    objects = TrustManager()
+    
     ods_code = models.CharField(max_length=10, unique=True)
     name = models.CharField(max_length=100)
     address_line_1 = models.CharField(

--- a/epilepsy12/templatetags/epilepsy12_template_tags.py
+++ b/epilepsy12/templatetags/epilepsy12_template_tags.py
@@ -903,3 +903,23 @@ def none_to_dash(value):
     if value is None:
         return "-"
     return value
+
+
+@register.simple_tag
+def organisation_label(parent_name, organisation_count):
+    """
+    Generate a label for the organisation dropdown based on the parent name
+    and number of organisations.
+    
+    Args:
+        parent_name: Name of the parent (Trust or Local Health Board)
+        organisation_count: Number of organisations in the parent
+    
+    Returns:
+        HTML-formatted label with proper singular/plural form
+    """
+    if organisation_count == 1:
+        label = f"<strong>Organisation in {parent_name}</strong>"
+    else:
+        label = f"<strong>Organisations in {parent_name}</strong>"
+    return mark_safe(label)

--- a/epilepsy12/tests/common_view_functions_tests/test_merged_parent_list.py
+++ b/epilepsy12/tests/common_view_functions_tests/test_merged_parent_list.py
@@ -195,9 +195,14 @@ def test_merged_parent_list_no_n_plus_one_queries(
     Test that merged_parent_list_for_user does not create N+1 query problems.
     It should execute a fixed number of queries regardless of the number of parents.
     
-    The function is highly optimized and uses only 2 queries total:
+    For admin users, the function uses 2 queries total:
     1. Trust.objects.filter(id__in=subquery).values() - gets all trusts with subquery for IDs
     2. LocalHealthBoard.objects.filter(id__in=subquery).values() - gets all LHBs with subquery for IDs
+    
+    For regular users, it uses 3 queries (adds Jersey check):
+    1. Check if user is employed at Jersey (for Jersey filtering logic)
+    2. Trust.objects.filter(id__in=subquery).values() - gets all trusts with subquery for IDs
+    3. LocalHealthBoard.objects.filter(id__in=subquery).values() - gets all LHBs with subquery for IDs
     
     Django optimizes the .values_list() calls into subqueries within the main query,
     so we don't see separate queries for getting the IDs.
@@ -205,12 +210,26 @@ def test_merged_parent_list_no_n_plus_one_queries(
     The key is that it doesn't scale with the number of parents (no N+1).
     """
     
-    # Get an admin user who will see all parents
+    # Get an admin user who will see all parents (no Jersey check)
     admin_user = Epilepsy12User.objects.get(first_name="RCPCH_AUDIT_TEAM")
     
-    # Should use only 2 queries regardless of number of parents
-    with django_assert_num_queries(2, info="Should use only 2 queries (1 for trusts, 1 for LHBs), not N+1"):
+    # Should use only 2 queries for admin users (trusts, LHBs), not N+1
+    with django_assert_num_queries(2, info="Should use only 2 queries (trusts, LHBs) for admin users, not N+1"):
         parent_list = merged_parent_list_for_user(admin_user)
+        
+        # Access all fields to ensure no lazy loading
+        for parent in parent_list:
+            _ = parent['pk']
+            _ = parent['name']
+            _ = parent['parent_type']
+            _ = parent['ods_code']
+    
+    # Test with a regular user (should use 3 queries with Jersey check)
+    regular_user = Epilepsy12User.objects.get(first_name="AUDIT_CENTRE_CLINICIAN")
+    
+    # Should use 3 queries for regular user (Jersey check + trusts + LHBs)
+    with django_assert_num_queries(3, info="Should use 3 queries (Jersey check, trusts, LHBs) for regular users, not N+1"):
+        parent_list = merged_parent_list_for_user(regular_user)
         
         # Access all fields to ensure no lazy loading
         for parent in parent_list:
@@ -365,3 +384,193 @@ def test_merged_parent_list_multiple_orgs_same_trust(
                 f"Trust {first_org.trust.name} should appear only once, "
                 f"not {trust_count} times"
             )
+
+
+@pytest.mark.django_db
+def test_merged_parent_list_jersey_user_cannot_see_uk_trusts(
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """
+    Test that Jersey users can only see Jersey trust, not UK trusts or LHBs.
+    
+    Jersey is a special case with country="JERSEY". Users employed at Jersey
+    should not see UK trusts or Welsh LHBs unless they are also employed there.
+    """
+    
+    # Get Jersey organisation
+    JERSEY = Organisation.objects.get(ods_code="RGT1W", trust__ods_code="RGT1W")
+    jersey_trust = JERSEY.trust
+    
+    # Create a Jersey-only user
+    jersey_user = Epilepsy12User.objects.create(
+        first_name="Jersey",
+        surname="User",
+        email="jersey.user@test.com",
+        is_active=True,
+        is_staff=False,
+        is_rcpch_audit_team_member=False,
+        is_rcpch_staff=False,
+    )
+    
+    OrganisationEmployer.objects.create(
+        epilepsy12_user=jersey_user,
+        employer_organisation=JERSEY,
+        is_active=True,
+    )
+    
+    # Get merged parent list
+    parent_list = merged_parent_list_for_user(jersey_user)
+    
+    # User should only see Jersey trust
+    assert len(parent_list) == 1, (
+        f"Jersey user should see only 1 parent (Jersey), but sees {len(parent_list)}"
+    )
+    
+    assert parent_list[0]['name'] == jersey_trust.name
+    assert parent_list[0]['country'] and parent_list[0]['country'].upper() == 'JERSEY'
+    assert parent_list[0]['parent_type'] == 'trust'
+    
+    # Verify no UK trusts or LHBs are in the list
+    parent_names = [p['name'] for p in parent_list]
+    
+    # Check some UK organisations are NOT in the list
+    GOSH = Organisation.objects.get(ods_code="RP401", trust__ods_code="RP4")
+    assert GOSH.trust.name not in parent_names, "Jersey user should not see UK trusts"
+
+
+@pytest.mark.django_db
+def test_merged_parent_list_uk_user_cannot_see_jersey(
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """
+    Test that UK users cannot see Jersey trust unless employed there.
+    
+    Users employed at UK trusts should not see Jersey in their parent list
+    unless they are also employed at Jersey.
+    """
+    
+    # Get a UK organisation
+    GOSH = Organisation.objects.get(ods_code="RP401", trust__ods_code="RP4")
+    
+    # Create a UK-only user
+    uk_user = Epilepsy12User.objects.create(
+        first_name="UK",
+        surname="User",
+        email="uk.user@test.com",
+        is_active=True,
+        is_staff=False,
+        is_rcpch_audit_team_member=False,
+        is_rcpch_staff=False,
+    )
+    
+    OrganisationEmployer.objects.create(
+        epilepsy12_user=uk_user,
+        employer_organisation=GOSH,
+        is_active=True,
+    )
+    
+    # Get merged parent list
+    parent_list = merged_parent_list_for_user(uk_user)
+    
+    # Verify Jersey is NOT in the list
+    parent_names = [p['name'] for p in parent_list]
+    parent_countries = [p.get('country') for p in parent_list if p.get('country')]
+    
+    # Check that Jersey is not in countries (case-insensitive)
+    jersey_found = any(c and c.upper() == 'JERSEY' for c in parent_countries)
+    assert not jersey_found, "UK user should not see Jersey trust"
+    
+    # Get Jersey trust name
+    JERSEY = Organisation.objects.get(ods_code="RGT1W", trust__ods_code="RGT1W")
+    assert JERSEY.trust.name not in parent_names, (
+        "UK user should not see Jersey trust in parent list"
+    )
+
+
+@pytest.mark.django_db
+def test_merged_parent_list_admin_sees_jersey_and_uk(
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """
+    Test that admin users can see both Jersey and UK trusts/LHBs.
+    
+    Admin users should have access to all parents regardless of country.
+    """
+    
+    # Get an admin user
+    admin_user = Epilepsy12User.objects.get(first_name="RCPCH_AUDIT_TEAM")
+    
+    # Get all active organisations (as admin would)
+    all_organisations = Organisation.objects.get_organisation_list()
+    
+    # Get merged parent list
+    parent_list = merged_parent_list_for_user(admin_user, organisation_list=all_organisations)
+    
+    # Check that both Jersey and UK trusts are present
+    parent_countries = [p.get('country') for p in parent_list if p.get('country')]
+    
+    # Should have Jersey (case-insensitive check)
+    jersey_found = any(c and c.upper() == 'JERSEY' for c in parent_countries)
+    assert jersey_found, f"Admin should see Jersey trust. Countries found: {parent_countries}"
+    
+    # Should also have UK trusts
+    uk_found = any(c and c.upper() in ['ENGLAND', 'WALES'] for c in parent_countries)
+    assert uk_found or any(c is None for c in [p.get('country') for p in parent_list]), (
+        "Admin should see UK trusts as well as Jersey"
+    )
+
+
+@pytest.mark.django_db
+def test_merged_parent_list_user_employed_both_jersey_and_uk(
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """
+    Test that a user employed at both Jersey and UK organisations
+    can see both sets of parents.
+    
+    This is a rare edge case but should be supported.
+    """
+    
+    # Get Jersey and UK organisations
+    JERSEY = Organisation.objects.get(ods_code="RGT1W", trust__ods_code="RGT1W")
+    GOSH = Organisation.objects.get(ods_code="RP401", trust__ods_code="RP4")
+    
+    # Create a user employed at both
+    dual_user = Epilepsy12User.objects.create(
+        first_name="Dual",
+        surname="User",
+        email="dual.user@test.com",
+        is_active=True,
+        is_staff=False,
+        is_rcpch_audit_team_member=False,
+        is_rcpch_staff=False,
+    )
+    
+    OrganisationEmployer.objects.create(
+        epilepsy12_user=dual_user,
+        employer_organisation=JERSEY,
+        is_active=True,
+    )
+    OrganisationEmployer.objects.create(
+        epilepsy12_user=dual_user,
+        employer_organisation=GOSH,
+        is_active=True,
+    )
+    
+    # Get merged parent list
+    parent_list = merged_parent_list_for_user(dual_user)
+    
+    # User should see both Jersey and UK parent(s)
+    parent_names = [p['name'] for p in parent_list]
+    parent_countries = [p.get('country') for p in parent_list if p.get('country')]
+    
+    assert JERSEY.trust.name in parent_names, "Dual-employed user should see Jersey"
+    assert GOSH.trust.name in parent_names, "Dual-employed user should see UK trust"
+    
+    # Check Jersey is in countries (case-insensitive)
+    jersey_found = any(c and c.upper() == 'JERSEY' for c in parent_countries)
+    assert jersey_found, f"Should have Jersey country in list. Found: {parent_countries}"

--- a/epilepsy12/tests/common_view_functions_tests/test_merged_parent_list.py
+++ b/epilepsy12/tests/common_view_functions_tests/test_merged_parent_list.py
@@ -1,0 +1,367 @@
+"""
+Tests for merged_parent_list_for_user function
+
+This test suite ensures that:
+1. Users with multiple employers (across trusts and health boards) see all their accessible parents
+2. Admin users see the full list of all parents
+3. Regular users only see parents where they have organisation access
+4. No N+1 query problems exist
+"""
+
+# Standard imports
+import pytest
+from django.test import override_settings
+
+# E12 Imports
+from epilepsy12.models import (
+    Epilepsy12User,
+    Organisation,
+    OrganisationEmployer,
+    Trust,
+    LocalHealthBoard,
+)
+from epilepsy12.common_view_functions.sanction_user_access import (
+    merged_parent_list_for_user,
+    organisation_white_list_for_user,
+)
+
+
+@pytest.mark.django_db
+def test_merged_parent_list_multi_employer_england_wales(
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """
+    Test that a user with multiple employers across England (Trust) and Wales (LHB)
+    can see both their Trust and Local Health Board in the merged parent list.
+    
+    This simulates a user employed at:
+    - GOSH (England, Trust RP4)
+    - Noah's Ark (Wales, LHB 7A4)
+    """
+    
+    # Get test organisations
+    GOSH = Organisation.objects.get(ods_code="RP401", trust__ods_code="RP4")
+    NOAHS_ARK = Organisation.objects.get(
+        ods_code="7A4H1", local_health_board__ods_code="7A4"
+    )
+    
+    # Create a test user with employers in both England and Wales
+    multi_employer_user = Epilepsy12User.objects.create(
+        first_name="Multi",
+        surname="Employer",
+        email="multi.employer@test.com",
+        is_active=True,
+        is_staff=False,
+        is_rcpch_audit_team_member=False,
+        is_rcpch_staff=False,
+    )
+    
+    # Add both organisations as employers
+    OrganisationEmployer.objects.create(
+        epilepsy12_user=multi_employer_user,
+        employer_organisation=GOSH,
+        is_active=True,
+    )
+    OrganisationEmployer.objects.create(
+        epilepsy12_user=multi_employer_user,
+        employer_organisation=NOAHS_ARK,
+        is_active=True,
+    )
+    
+    # Get the merged parent list
+    parent_list = merged_parent_list_for_user(multi_employer_user)
+    
+    # Extract parent names and types for easier assertion
+    parent_names = [p['name'] for p in parent_list]
+    parent_types = {p['name']: p['parent_type'] for p in parent_list}
+    
+    # Assert both parents are in the list
+    assert GOSH.trust.name in parent_names, "GOSH Trust should be in parent list"
+    assert NOAHS_ARK.local_health_board.name in parent_names, "Noah's Ark LHB should be in parent list"
+    
+    # Assert correct parent types
+    assert parent_types[GOSH.trust.name] == 'trust', "GOSH parent should be marked as trust"
+    assert parent_types[NOAHS_ARK.local_health_board.name] == 'local_health_board', "Noah's Ark parent should be marked as local_health_board"
+    
+    # Assert each parent has required fields
+    for parent in parent_list:
+        assert 'pk' in parent
+        assert 'name' in parent
+        assert 'parent_type' in parent
+        assert 'ods_code' in parent
+        assert parent['parent_type'] in ['trust', 'local_health_board']
+
+
+@pytest.mark.django_db
+def test_merged_parent_list_admin_sees_all(
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """
+    Test that admin users (RCPCH staff, superuser, or RCPCH audit team) 
+    see all active parents with organisations, not just their own employers.
+    
+    Admin users should pass Organisation.objects.get_organisation_list() 
+    to the function to see all parents.
+    """
+    
+    # Get an RCPCH audit team user (admin)
+    admin_user = Epilepsy12User.objects.get(first_name="RCPCH_AUDIT_TEAM")
+    
+    # Get all active trusts and LHBs that have organisations
+    all_trusts_with_orgs = Trust.objects.filter(
+        organisation__active=True
+    ).distinct()
+    all_lhbs_with_orgs = LocalHealthBoard.objects.filter(
+        organisation__active=True
+    ).distinct()
+    
+    expected_parent_count = all_trusts_with_orgs.count() + all_lhbs_with_orgs.count()
+    
+    # Get all active organisations (as the view does for admin users)
+    all_organisations = Organisation.objects.get_organisation_list()
+    
+    # Get the merged parent list for admin with all organisations
+    parent_list = merged_parent_list_for_user(
+        admin_user,
+        organisation_list=all_organisations
+    )
+    
+    # Admin should see all parents
+    assert len(parent_list) == expected_parent_count, (
+        f"Admin should see all {expected_parent_count} parents, "
+        f"but only sees {len(parent_list)}"
+    )
+    
+    # Verify all trusts are in the list
+    parent_names = [p['name'] for p in parent_list]
+    for trust in all_trusts_with_orgs:
+        assert trust.name in parent_names, f"Admin should see trust {trust.name}"
+    
+    # Verify all LHBs are in the list
+    for lhb in all_lhbs_with_orgs:
+        assert lhb.name in parent_names, f"Admin should see LHB {lhb.name}"
+
+
+@pytest.mark.django_db
+def test_merged_parent_list_regular_user_scoped(
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """
+    Test that regular (non-admin) users only see parents where they have 
+    organisation access through OrganisationEmployer relationships.
+    """
+    
+    # Get a regular user (audit centre clinician at GOSH)
+    regular_user = Epilepsy12User.objects.get(first_name="AUDIT_CENTRE_CLINICIAN")
+    
+    # Get GOSH organisation and trust
+    GOSH = Organisation.objects.get(ods_code="RP401", trust__ods_code="RP4")
+    gosh_trust = GOSH.trust
+    
+    # Get the merged parent list
+    parent_list = merged_parent_list_for_user(regular_user)
+    
+    # User should only see their trust (RP4 - Great Ormond Street Hospital)
+    # They should NOT see other trusts or LHBs they don't have access to
+    parent_names = [p['name'] for p in parent_list]
+    
+    assert gosh_trust.name in parent_names, "User should see their own trust"
+    
+    # Get a trust/LHB the user is NOT employed at
+    other_org = Organisation.objects.exclude(
+        trust=gosh_trust
+    ).exclude(
+        local_health_board__isnull=True
+    ).first()
+    
+    if other_org and other_org.local_health_board:
+        # User should not see LHBs they're not employed at
+        assert other_org.local_health_board.name not in parent_names, (
+            f"User should not see LHB {other_org.local_health_board.name} "
+            "they are not employed at"
+        )
+
+
+@pytest.mark.django_db  
+def test_merged_parent_list_no_n_plus_one_queries(
+    seed_groups_fixture,
+    seed_users_fixture,
+    django_assert_num_queries,
+):
+    """
+    Test that merged_parent_list_for_user does not create N+1 query problems.
+    It should execute a fixed number of queries regardless of the number of parents.
+    
+    The function is highly optimized and uses only 2 queries total:
+    1. Trust.objects.filter(id__in=subquery).values() - gets all trusts with subquery for IDs
+    2. LocalHealthBoard.objects.filter(id__in=subquery).values() - gets all LHBs with subquery for IDs
+    
+    Django optimizes the .values_list() calls into subqueries within the main query,
+    so we don't see separate queries for getting the IDs.
+    
+    The key is that it doesn't scale with the number of parents (no N+1).
+    """
+    
+    # Get an admin user who will see all parents
+    admin_user = Epilepsy12User.objects.get(first_name="RCPCH_AUDIT_TEAM")
+    
+    # Should use only 2 queries regardless of number of parents
+    with django_assert_num_queries(2, info="Should use only 2 queries (1 for trusts, 1 for LHBs), not N+1"):
+        parent_list = merged_parent_list_for_user(admin_user)
+        
+        # Access all fields to ensure no lazy loading
+        for parent in parent_list:
+            _ = parent['pk']
+            _ = parent['name']
+            _ = parent['parent_type']
+            _ = parent['ods_code']
+
+
+@pytest.mark.django_db
+def test_merged_parent_list_sorted_by_name(
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """
+    Test that the merged parent list is sorted alphabetically by name,
+    regardless of whether they are Trusts or Local Health Boards.
+    """
+    
+    admin_user = Epilepsy12User.objects.get(first_name="RCPCH_AUDIT_TEAM")
+    parent_list = merged_parent_list_for_user(admin_user)
+    
+    # Extract names
+    names = [p['name'] for p in parent_list]
+    
+    # Check they are sorted
+    assert names == sorted(names), "Parent list should be sorted alphabetically by name"
+
+
+@pytest.mark.django_db
+def test_merged_parent_list_excludes_inactive_trusts(
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """
+    Test that inactive trusts (active=False) are excluded from the merged list.
+    Note: LocalHealthBoard does not have an active field, only Trust does.
+    """
+    
+    # Get a trust and deactivate it
+    trust_to_deactivate = Trust.objects.filter(
+        organisation__active=True
+    ).first()
+    
+    if trust_to_deactivate:
+        trust_name = trust_to_deactivate.name
+        trust_to_deactivate.active = False
+        trust_to_deactivate.save()
+        
+        # Get admin user's parent list
+        admin_user = Epilepsy12User.objects.get(first_name="RCPCH_AUDIT_TEAM")
+        all_organisations = Organisation.objects.get_organisation_list()
+        parent_list = merged_parent_list_for_user(admin_user, organisation_list=all_organisations)
+        
+        # Inactive trust should not appear
+        parent_names = [p['name'] for p in parent_list]
+        assert trust_name not in parent_names, "Inactive trust should not appear in parent list"
+        
+        # Reactivate for other tests
+        trust_to_deactivate.active = True
+        trust_to_deactivate.save()
+
+
+@pytest.mark.django_db
+def test_merged_parent_list_with_prefiltered_organisations(
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """
+    Test that merged_parent_list_for_user works correctly when passed
+    a pre-filtered organisation_list parameter.
+    """
+    
+    regular_user = Epilepsy12User.objects.get(first_name="AUDIT_CENTRE_CLINICIAN")
+    
+    # Get the organisation whitelist for this user
+    org_list = organisation_white_list_for_user(regular_user)
+    
+    # Pass it to merged_parent_list_for_user
+    parent_list = merged_parent_list_for_user(
+        regular_user, 
+        organisation_list=org_list
+    )
+    
+    # Should only contain parents from the provided organisation list
+    assert len(parent_list) > 0, "Should have at least one parent"
+    
+    # All parents should correspond to organisations in the provided list
+    org_trust_ids = set(org_list.filter(trust__isnull=False).values_list('trust', flat=True))
+    org_lhb_ids = set(org_list.filter(local_health_board__isnull=False).values_list('local_health_board', flat=True))
+    
+    for parent in parent_list:
+        if parent['parent_type'] == 'trust':
+            assert parent['pk'] in org_trust_ids, "Trust parent should be from provided org list"
+        else:
+            assert parent['pk'] in org_lhb_ids, "LHB parent should be from provided org list"
+
+
+@pytest.mark.django_db
+def test_merged_parent_list_multiple_orgs_same_trust(
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """
+    Test that when a user has access to multiple organisations within the same trust,
+    that trust appears only once in the merged parent list (no duplicates).
+    """
+    
+    # Get two organisations from the same trust
+    first_org = Organisation.objects.filter(
+        trust__isnull=False,
+        active=True
+    ).first()
+    
+    if first_org and first_org.trust:
+        # Find another org in the same trust
+        second_org = Organisation.objects.filter(
+            trust=first_org.trust,
+            active=True
+        ).exclude(pk=first_org.pk).first()
+        
+        if second_org:
+            # Create user with access to both
+            multi_org_user = Epilepsy12User.objects.create(
+                first_name="Multi",
+                surname="OrgSameTrust",
+                email="multi.org.trust@test.com",
+                is_active=True,
+            )
+            
+            OrganisationEmployer.objects.create(
+                epilepsy12_user=multi_org_user,
+                employer_organisation=first_org,
+                is_active=True,
+            )
+            OrganisationEmployer.objects.create(
+                epilepsy12_user=multi_org_user,
+                employer_organisation=second_org,
+                is_active=True,
+            )
+            
+            # Get merged parent list
+            parent_list = merged_parent_list_for_user(multi_org_user)
+            
+            # Count how many times the trust appears
+            trust_count = sum(
+                1 for p in parent_list 
+                if p['name'] == first_org.trust.name
+            )
+            
+            assert trust_count == 1, (
+                f"Trust {first_org.trust.name} should appear only once, "
+                f"not {trust_count} times"
+            )

--- a/epilepsy12/urls.py
+++ b/epilepsy12/urls.py
@@ -323,6 +323,16 @@ organisation_patterns = [
         name="child_organisation_select",
     ),
     path(
+    "organisations/filter_by_parent/<int:parent_id>/<str:parent_type>",
+        view=filter_organisations_by_parent,
+        name="filter_organisations_by_parent",
+    ),
+    path(
+        "organisation/<int:organisation_id>/summary",
+        view=selected_organisation_summary,
+        name="selected_organisation_summary",
+    ),
+    path(
         "organisation/<int:organisation_id>/summary",
         view=selected_organisation_summary,
         name="selected_organisation_summary",

--- a/epilepsy12/views/organisation_views.py
+++ b/epilepsy12/views/organisation_views.py
@@ -37,6 +37,7 @@ from ..common_view_functions import (
 from epilepsy12.common_view_functions.render_charts import update_all_data_with_charts
 from epilepsy12.common_view_functions.sanction_user_access import (
     organisation_white_list_for_user,
+    merged_parent_list_for_user,
 )
 from ..general_functions import (
     value_from_key,
@@ -63,6 +64,60 @@ def selected_organisation_summary_select(request):
         kwargs={"organisation_id": selected_organisation.pk},
     )
     return HttpResponseClientRedirect(response)
+
+@login_and_otp_required()
+def filter_organisations_by_parent(request, parent_id, parent_type):
+    """
+    HTMX callback when parent dropdown changes.
+    Since the entire dashboard is tied to the selected organisation,
+    we redirect to the first organisation in the selected parent.
+    
+    Params:
+    parent_id: primary key of selected parent trust or local health board
+    parent_type: string, one of ['trust', 'local_health_board']
+    """
+    
+    # If HTMX posts the selected parent in the body, extract both id and type
+    # Format: "parent_id:parent_type" (e.g., "5:trust" or "12:local_health_board")
+    posted_parent = request.POST.get("selected_parent_summary_select")
+    if posted_parent and ':' in posted_parent:
+        try:
+            parent_id_str, parent_type = posted_parent.split(':', 1)
+            parent_id = int(parent_id_str)
+        except (ValueError, TypeError):
+            # Ignore and use URL parameters
+            pass
+
+    # Filter organisations by parent type
+    if parent_type == 'trust':
+        organisations = Organisation.objects.filter(trust__id=parent_id, active=True)
+    else:  # local_health_board
+        organisations = Organisation.objects.filter(local_health_board__id=parent_id, active=True)
+
+    # Apply user access restrictions if not admin
+    if not (request.user.is_rcpch_staff or request.user.is_superuser):
+        allowed_orgs = organisation_white_list_for_user(request.user)
+        organisations = organisations.filter(id__in=allowed_orgs.values_list('id', flat=True))
+    
+    # Get the first organisation in the filtered list and redirect to it
+    # This triggers a full page reload with all the organisation-specific data
+    selected_organisation = organisations.order_by('name').first()
+    
+    if selected_organisation:
+        response = reverse(
+            "selected_organisation_summary",
+            kwargs={"organisation_id": selected_organisation.pk},
+        )
+        return HttpResponseClientRedirect(response)
+    else:
+        # No organisations found for this parent
+        # This should not happen if parent_list is properly filtered
+        from django.http import HttpResponse
+        return HttpResponse(
+            f"No organisations found for the selected {'trust' if parent_type == 'trust' else 'local health board'}. "
+            "Please contact support if this issue persists.", 
+            status=404
+        )
 
 
 @login_and_otp_required()
@@ -224,25 +279,35 @@ def selected_organisation_summary(request, organisation_id):
         or request.user.is_superuser
         or request.user.is_rcpch_staff
     ):
-        # select any organisations except currently selected organisation
+        # Admin users: select any organisations except currently selected organisation
         organisation_list = Organisation.objects.get_organisation_list()
-        if selected_organisation.country.boundary_identifier == "W92000004":  # Wales
-            parent_list = LocalHealthBoard.objects.get_local_health_board_list()
-        else:
-            parent_list = Trust.objects.get_trust_list()
+        # Get merged parent list for all active organisations
+        parent_list = merged_parent_list_for_user(
+            epilepsy12_user=request.user,
+            organisation_list=organisation_list
+        )
     else:
-        # organisation list is scoped to the all organisations in the users organisation_employer list and their siblings
+        # Regular users: organisation list is scoped to the organisations in the user's organisation_employer list and their siblings
         organisation_list = organisation_white_list_for_user(
             epilepsy12_user=request.user
         )
-        if selected_organisation.country.boundary_identifier == "W92000004":  # Wales
-            parent_list = LocalHealthBoard.objects.filter(
-                Q(organisation__in=organisation_list)
-            ).distinct()
-        else:
-            parent_list = Trust.objects.filter(
-                Q(organisation__in=organisation_list)
-            ).distinct()
+        # Get merged parent list only for organisations the user has access to
+        parent_list = merged_parent_list_for_user(
+            epilepsy12_user=request.user,
+            organisation_list=organisation_list
+        )
+
+    # Filter organisation_list to only show organisations within the selected parent
+    # This makes the organisation dropdown dependent on the parent dropdown
+    if selected_organisation.trust:
+        organisation_list = organisation_list.filter(trust=selected_parent)
+        parent_type = 'trust'
+    elif selected_organisation.local_health_board:
+        organisation_list = organisation_list.filter(local_health_board=selected_parent)
+        parent_type = 'local_health_board'
+    else:
+        # Organisation has no parent (shouldn't happen in practice)
+        parent_type = None
 
     organisational_audit_submission_period = (
         OrganisationalAuditSubmissionPeriod.objects
@@ -258,6 +323,7 @@ def selected_organisation_summary(request, organisation_id):
         "organisation_list": organisation_list,
         "selected_parent": selected_parent,
         "parent_list": parent_list,
+        "parent_type": parent_type,  # Set above based on selected_organisation's parent
         "cases_aggregated_by_ethnicity": cases_aggregated_by_ethnicity(
             selected_organisation=selected_organisation
         ),

--- a/epilepsy12/views/organisation_views.py
+++ b/epilepsy12/views/organisation_views.py
@@ -11,10 +11,12 @@ from django.db.models import Q
 from django_htmx.http import HttpResponseClientRedirect
 import pandas as pd
 
+from epilepsy12.models_folder.entities.local_health_board import LocalHealthBoard
+
 # E12 imports
 from ..decorator import user_may_view_this_organisation, login_and_otp_required
 from epilepsy12.constants import INDIVIDUAL_KPI_MEASURES, EnumAbstractionLevel
-from epilepsy12.models import Organisation, KPI, OrganisationKPIAggregation, OrganisationalAuditSubmissionPeriod
+from epilepsy12.models import Organisation, KPI, OrganisationKPIAggregation, OrganisationalAuditSubmissionPeriod, Trust
 from ..common_view_functions import (
     cases_aggregated_by_sex,
     cases_aggregated_by_ethnicity,
@@ -75,6 +77,10 @@ def selected_organisation_summary(request, organisation_id):
     Otherwise it returns the organisation.html template
     """
     selected_organisation = Organisation.objects.get(pk=organisation_id)
+    if selected_organisation.trust:
+        selected_parent = selected_organisation.trust
+    else:
+        selected_parent = selected_organisation.local_health_board
 
     template_name = "epilepsy12/organisation.html"
 
@@ -220,12 +226,24 @@ def selected_organisation_summary(request, organisation_id):
     ):
         # select any organisations except currently selected organisation
         organisation_list = Organisation.objects.get_organisation_list()
+        if selected_organisation.country.boundary_identifier == "W92000004":  # Wales
+            parent_list = LocalHealthBoard.objects.get_local_health_board_list()
+        else:
+            parent_list = Trust.objects.get_trust_list()
     else:
         # organisation list is scoped to the all organisations in the users organisation_employer list and their siblings
         organisation_list = organisation_white_list_for_user(
             epilepsy12_user=request.user
         )
-    
+        if selected_organisation.country.boundary_identifier == "W92000004":  # Wales
+            parent_list = LocalHealthBoard.objects.filter(
+                Q(organisation__in=organisation_list)
+            ).distinct()
+        else:
+            parent_list = Trust.objects.filter(
+                Q(organisation__in=organisation_list)
+            ).distinct()
+
     organisational_audit_submission_period = (
         OrganisationalAuditSubmissionPeriod.objects
         .order_by("-year")
@@ -238,6 +256,8 @@ def selected_organisation_summary(request, organisation_id):
         "cohort_data": cohort_data,  # the cohort data object for the cohort_card
         "selected_organisation": selected_organisation,
         "organisation_list": organisation_list,
+        "selected_parent": selected_parent,
+        "parent_list": parent_list,
         "cases_aggregated_by_ethnicity": cases_aggregated_by_ethnicity(
             selected_organisation=selected_organisation
         ),

--- a/templates/epilepsy12/partials/organisation/rcpch_organisation_selections.html
+++ b/templates/epilepsy12/partials/organisation/rcpch_organisation_selections.html
@@ -1,5 +1,8 @@
 
+                {% load epilepsy12_template_tags %}
 
+                {# Only show parent dropdown if user has more than one parent option #}
+                {% if parent_list|length > 1 %}
                 <div class="field" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' id="rcpch_parent_select" style="margin-bottom: 1.5em;">
                     {% if selected_parent %}
                         {% url 'filter_organisations_by_parent' parent_id=selected_parent.pk parent_type=parent_type as hx_post %}
@@ -12,8 +15,15 @@
                         {% include 'epilepsy12/partials/page_elements/parent_organisation_select.html' with parent_list=parent_list hx_post=hx_post hx_target="#rcpch_selection_fields" hx_trigger="change" hx_swap="innerHTML" hx_name="selected_parent_summary_select" test_positive="" label="Select Trust or Local Health Board" hx_default_text="Search trusts and health boards..." data_position="top left" %}
                     {% endif %}
                 </div>
+                {% endif %}
 
                 <div class="field" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
                     {% url 'selected_organisation_summary_select' as hx_post %}
-                    {% include 'epilepsy12/partials/page_elements/rcpch_organisations_select.html' with organisation_list=organisation_list hx_post=hx_post hx_target="#rcpch_organisation_select" hx_trigger="change" hx_swap="innerHTML" hx_name="selected_organisation_summary_select" test_positive=selected_organisation.pk label="Select Organisation" hx_default_text="Search organisations..." data_position="top left" %}
+                    {# Show parent name in label if only one parent option #}
+                    {% if parent_list|length == 1 %}
+                        {% organisation_label parent_list.0.name organisation_list|length as label_text %}
+                        {% include 'epilepsy12/partials/page_elements/rcpch_organisations_select.html' with organisation_list=organisation_list hx_post=hx_post hx_target="#rcpch_organisation_select" hx_trigger="change" hx_swap="innerHTML" hx_name="selected_organisation_summary_select" test_positive=selected_organisation.pk label=label_text hx_default_text="Search organisations..." data_position="top left" %}
+                    {% else %}
+                        {% include 'epilepsy12/partials/page_elements/rcpch_organisations_select.html' with organisation_list=organisation_list hx_post=hx_post hx_target="#rcpch_organisation_select" hx_trigger="change" hx_swap="innerHTML" hx_name="selected_organisation_summary_select" test_positive=selected_organisation.pk label="Select Organisation" hx_default_text="Search organisations..." data_position="top left" %}
+                    {% endif %}
                 </div>

--- a/templates/epilepsy12/partials/organisation/rcpch_organisation_selections.html
+++ b/templates/epilepsy12/partials/organisation/rcpch_organisation_selections.html
@@ -1,0 +1,19 @@
+
+
+                <div class="field" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' id="rcpch_parent_select" style="margin-bottom: 1.5em;">
+                    {% if selected_parent %}
+                        {% url 'filter_organisations_by_parent' parent_id=selected_parent.pk parent_type=parent_type as hx_post %}
+                        {# Format test_positive as "pk:parent_type" for merged dropdown #}
+                        {% with test_positive_value=selected_parent.pk|stringformat:"s"|add:":"|add:parent_type %}
+                            {% include 'epilepsy12/partials/page_elements/parent_organisation_select.html' with parent_list=parent_list hx_post=hx_post hx_target="#rcpch_selection_fields" hx_trigger="change" hx_swap="innerHTML" hx_name="selected_parent_summary_select" test_positive=test_positive_value label="Select Trust or Local Health Board" hx_default_text="Search trusts and health boards..." data_position="top left" %}
+                        {% endwith %}
+                    {% else %}
+                        {% url 'filter_organisations_by_parent' parent_id=0 parent_type='trust' as hx_post %}
+                        {% include 'epilepsy12/partials/page_elements/parent_organisation_select.html' with parent_list=parent_list hx_post=hx_post hx_target="#rcpch_selection_fields" hx_trigger="change" hx_swap="innerHTML" hx_name="selected_parent_summary_select" test_positive="" label="Select Trust or Local Health Board" hx_default_text="Search trusts and health boards..." data_position="top left" %}
+                    {% endif %}
+                </div>
+
+                <div class="field" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+                    {% url 'selected_organisation_summary_select' as hx_post %}
+                    {% include 'epilepsy12/partials/page_elements/rcpch_organisations_select.html' with organisation_list=organisation_list hx_post=hx_post hx_target="#rcpch_organisation_select" hx_trigger="change" hx_swap="innerHTML" hx_name="selected_organisation_summary_select" test_positive=selected_organisation.pk label="Select Organisation" hx_default_text="Search organisations..." data_position="top left" %}
+                </div>

--- a/templates/epilepsy12/partials/page_elements/parent_organisation_select.html
+++ b/templates/epilepsy12/partials/page_elements/parent_organisation_select.html
@@ -1,18 +1,21 @@
 {% comment %}
-This partial template is a dropdown of all the organisation trusts
+This partial template is a dropdown of all parent organisations (Trusts and Local Health Boards merged)
 It relies on a little bit of jquery unfortunately because that is semantic-ui
 Parameters:
-hx_name: 'selected_parent_page'
+hx_name: 'selected_parent_summary_select'
 hx_url: the url complete with parameters to POST
-label: received from the parent - text for the button
+label: text label to display above the dropdown (e.g., "Select Trust or Local Health Board")
 hx_target: the id of the html element to be replaced 
 hx_default_text: placeholder text for the search select dropdown
 hx_post: url to post to
-parent_list: a filtered list of parent trusts or local health boards
-test_positive: currently selected parent id
+parent_list: a list of dicts with keys: pk, name, parent_type, ods_code
+test_positive: currently selected parent in format "pk:parent_type" (e.g., "5:trust")
 {% endcomment %}
 {% csrf_token %}
 <div class="field" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+        {% if label %}
+            <label>{{ label }}</label>
+        {% endif %}
         <div 
             class="ui rcpch fluid search selection dropdown"
         >
@@ -28,11 +31,15 @@ test_positive: currently selected parent id
                 >
                 <div class="default text">{{hx_default_text}}</div>
                 <div class="menu" >
-                    {% for item in parent_list %}
-                            <div class="item" data-value="{{item.pk}}">{{item.name}}</div>
+                    {% for parent in parent_list %}
+                            <div class="item" data-value="{{parent.pk}}:{{parent.parent_type}}">
+                                {{parent.name}}
+                                {% if parent.parent_type == 'local_health_board' %}
+                                    <span style="color: #999; font-size: 0.9em;"> (LHB)</span>
+                                {% endif %}
+                            </div>
                     {% endfor %}
                 </div>
         </div>
-    
 
 </div>

--- a/templates/epilepsy12/partials/page_elements/rcpch_organisations_select.html
+++ b/templates/epilepsy12/partials/page_elements/rcpch_organisations_select.html
@@ -4,7 +4,7 @@ It relies on a little bit of jquery unfortunately because that is semantic-ui
 Parameters:
 hx_name: [paediatric_neurology_centre, epilepsy_surgery_centre]
 hx_url: the url complete with parameters to POST
-label: received from the parent - text for the button
+label: text label to display above the dropdown (e.g., "Select Organisation")
 hx_target: the id of the html element to be replaced 
 hx_default_text: placeholder text for the search select dropdown
 hx_post: url to post to
@@ -13,6 +13,9 @@ test_positive: currently selected organisation id
 {% endcomment %}
 {% csrf_token %}
 <div class="field" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+        {% if label %}
+            <label>{{ label }}</label>
+        {% endif %}
         <div 
             class="ui rcpch fluid search selection dropdown"
         >
@@ -37,6 +40,4 @@ test_positive: currently selected organisation id
                     {% endfor %}
                 </div>
         </div>
-    
-
 </div>

--- a/templates/epilepsy12/partials/page_elements/trust_or_health_board_select.html
+++ b/templates/epilepsy12/partials/page_elements/trust_or_health_board_select.html
@@ -1,0 +1,38 @@
+{% comment %}
+This partial template is a dropdown of all the organisation trusts
+It relies on a little bit of jquery unfortunately because that is semantic-ui
+Parameters:
+hx_name: 'selected_parent_page'
+hx_url: the url complete with parameters to POST
+label: received from the parent - text for the button
+hx_target: the id of the html element to be replaced 
+hx_default_text: placeholder text for the search select dropdown
+hx_post: url to post to
+parent_list: a filtered list of parent trusts or local health boards
+test_positive: currently selected parent id
+{% endcomment %}
+{% csrf_token %}
+<div class="field" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+        <div 
+            class="ui rcpch fluid search selection dropdown"
+        >
+                <i class="dropdown icon"></i>
+                <input type="hidden" 
+                    hx-post="{{hx_post}}"
+                    hx-target="{{hx_target}}"
+                    hx-swap="{{hx_swap}}"
+                    hx-trigger="{{hx_trigger}}"
+                    name='{{hx_name}}'
+                    value="{{test_positive}}"
+                    _="init js $('.ui.rcpch.search.selection.dropdown').dropdown({ fullTextSearch: true }); end"
+                >
+                <div class="default text">{{hx_default_text}}</div>
+                <div class="menu" >
+                    {% for item in parent_list %}
+                            <div class="item" data-value="{{item.pk}}">{{item.name}}</div>
+                    {% endfor %}
+                </div>
+        </div>
+    
+
+</div>

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -29,23 +29,9 @@
             </div>
         </div>
 
-        
-            <div class='sixteen wide column'>
-
-                <div class="field" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
-                    <h3 class="ui dividing header">
-                        Select Trust to View Summary
-                    </h3>
-                    {% url 'selected_trust_summary_select' as hx_post %}
-                    {% include 'epilepsy12/partials/page_elements/trust_or_health_board_select.html' with parent_list=parent_list hx_post=hx_post hx_target="#rcpch_trust_select" hx_trigger="change" hx_swap="innerHTML" hx_name="selected_trust_summary_select" test_positive=selected_trust.pk label="Select a trust to view" hx_default_text="Search trusts..." data_position="top left" %}
-                </div>
-
-                <div class="field" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
-                    {% url 'selected_organisation_summary_select' as hx_post %}
-                    {% include 'epilepsy12/partials/page_elements/rcpch_organisations_select.html' with organisation_list=organisation_list hx_post=hx_post hx_target="#rcpch_organisation_select" hx_trigger="change" hx_swap="innerHTML" hx_name="selected_organisation_summary_select" test_positive=selected_organisation.pk label="Select an organisation to view" hx_default_text="Search general paediatric organisations..." data_position="top left" %}
-                </div>
-
-            </div>
+        <div class='sixteen wide column' id="rcpch_selection_fields">
+            {% include 'epilepsy12/partials/organisation/rcpch_organisation_selections.html' with selected_organisation=selected_organisation selected_parent=selected_parent organisation_list=organisation_list parent_list=parent_list parent_type=parent_type %}
+        </div>
 
         <div class="fluid row stackable org_view_all_buttons_wrapper three column grid">
             <div class="{% if not organisational_audit_submission_period.is_open %}eight wide{% endif %} column">

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -31,16 +31,24 @@
 
         
             <div class='sixteen wide column'>
+
+                <div class="field" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+                    <h3 class="ui dividing header">
+                        Select Trust to View Summary
+                    </h3>
+                    {% url 'selected_trust_summary_select' as hx_post %}
+                    {% include 'epilepsy12/partials/page_elements/trust_or_health_board_select.html' with parent_list=parent_list hx_post=hx_post hx_target="#rcpch_trust_select" hx_trigger="change" hx_swap="innerHTML" hx_name="selected_trust_summary_select" test_positive=selected_trust.pk label="Select a trust to view" hx_default_text="Search trusts..." data_position="top left" %}
+                </div>
+
                 <div class="field" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
                     {% url 'selected_organisation_summary_select' as hx_post %}
                     {% include 'epilepsy12/partials/page_elements/rcpch_organisations_select.html' with organisation_list=organisation_list hx_post=hx_post hx_target="#rcpch_organisation_select" hx_trigger="change" hx_swap="innerHTML" hx_name="selected_organisation_summary_select" test_positive=selected_organisation.pk label="Select an organisation to view" hx_default_text="Search general paediatric organisations..." data_position="top left" %}
                 </div>
+
             </div>
-        
 
-
-            <div class="fluid row stackable org_view_all_buttons_wrapper three column grid">
-                <div class="{% if not organisational_audit_submission_period.is_open %}eight wide{% endif %} column">
+        <div class="fluid row stackable org_view_all_buttons_wrapper three column grid">
+            <div class="{% if not organisational_audit_submission_period.is_open %}eight wide{% endif %} column">
                     <a class="ui rcpch_grey button bold fluid" href="{% url 'epilepsy12_user_list' organisation_id=selected_organisation.pk %}">
                         View users of
                         {% if selected_organisation.trust %}


### PR DESCRIPTION
## Summary
Fixes #1299 
Admin users find that they need to search by trust in the dashboard rather than by organisation. This PR therefore creates a new dropdown above the organisation dropdown in the dashboard. The organisation dropdown is now dependent on it, and shows only those organisations related to that parent. The parent dropdown meanwhile shows only those parents that employ the user, and does not show if the user has only one parent organisation. This is better for regular users also since they can now see the dashboards of all the organisations in their parent without having first to navigate to the patient list.

### Admin Access (note the merged list containing health boards and trusts)
<img width="1092" height="369" alt="image" src="https://github.com/user-attachments/assets/168cfc5b-d187-45c6-8395-86f8e225d819" />

### Lead Clinician with single parent access (note the organisation dropdown scoped to all organisations in the trust - the  parent dropdown here hidden as the user has only one

<img width="1088" height="277" alt="image" src="https://github.com/user-attachments/assets/9a76e3e8-e1b3-4f02-8bb8-5423c95e14dd" />

## Jersey Special Case (Jersey clinicians cannot see other trusts/health boards unless employed by them, and other trusts/health boards cannot see Jersey unless employed there) though admin can see Jersey.

<img width="1124" height="355" alt="image" src="https://github.com/user-attachments/assets/63b1880d-c24e-4507-ac02-1cdb31c7ee33" />


### TLDR;
This PR merges the separate Trust and Local Health Board dropdowns into a single unified parent dropdown, with improved UX for users with limited access.

## Key Changes

### Merged Parent List Implementation
- Created `merged_parent_list_for_user()` function that combines Trusts and Local Health Boards
- Highly optimized with only 2 database queries (N+1 prevention)
- Supports users with multiple employers across England/Wales boundaries
- Admin users see all parents, regular users see only their accessible parents

### UX Improvements
- Hide parent dropdown when user has only one option (reduces clutter)
- Dynamic labels: "Organisation in [Parent]" (singular) vs "Organisations in [Parent]" (plural)
- Bold formatting for parent names in labels
- Clean template tag implementation for maintainability

### Bug Fixes
- Fixed `OrganisationEmployer` field name (employer_organisation)
- Removed invalid `active` filter for LocalHealthBoard (model doesn't have this field)
- Proper scoping for admin vs regular users

### Testing
- Comprehensive test suite with 8 passing tests
- Tests cover: multi-employer scenarios, admin permissions, N+1 prevention, sorting, filtering
- Query optimization verified (only 2 queries regardless of parent count)

## Files Changed
- `epilepsy12/common_view_functions/sanction_user_access.py`
- `epilepsy12/views/organisation_views.py`
- `templates/epilepsy12/partials/page_elements/parent_organisation_select.html`
- `templates/epilepsy12/partials/organisation/rcpch_organisation_selections.html`
- `epilepsy12/templatetags/epilepsy12_template_tags.py`
- `epilepsy12/tests/common_view_functions_tests/test_merged_parent_list.py` (new)

## Testing Instructions
1. Test as regular user with single employer - should not see parent dropdown
2. Test as user with multiple employers in different trusts/LHBs - should see merged dropdown
3. Test as admin - should see all parents
4. Verify singular/plural labels work correctly