### PR TITLE
unfiltered-totals-not-scoping-to-organisation

### DIFF
--- a/epilepsy12/views/case_views.py
+++ b/epilepsy12/views/case_views.py
@@ -103,9 +103,6 @@ def case_list(request, organisation_id):
         Q(epilepsy12_sites__site_is_primary_centre_of_epilepsy_care=True)
         & Q(epilepsy12_sites__site_is_actively_involved_in_epilepsy_care=True)
     ).all()
-    registration_related_counts = CaseFilterMethods.get_all_registration_related_counts(
-        queryset=base_cases
-    )
 
     if filter_term:
         # filter_term is called if filtering by search box
@@ -363,27 +360,22 @@ def case_list(request, organisation_id):
 
     current_submitting_cohort = cohorts_and_dates(date.today()).get("submitting_cohort")
 
-    merged_cohort_counts = [
-        {
-            "cohort": cohort["cohort"],
-            "has_data": cohort["has_data"],
-            "count": registration_related_counts["cohort_counts"].get(
-                cohort["cohort"], 0
-            ),
-        }
-        for cohort in get_all_cohort_list()
-    ]
-
     filtered_totals = CaseFilterMethods.get_all_registration_related_counts(
         queryset=all_cases
     )
 
+    merged_cohort_counts = [
+        {
+            "cohort": cohort["cohort"],
+            "has_data": cohort["has_data"],
+            "count": filtered_totals["cohort_counts"].get(cohort["cohort"], 0),
+        }
+        for cohort in get_all_cohort_list()
+    ]
+
     context = {
         "case_list": case_list,
-        # "total_cases": case_count,
-        # "total_cases_in_current_submitting_cohort": current_cohort_total,
         "submitting_cohort": current_submitting_cohort,
-        # "total_registrations": registered_count,
         "sort_flag": sort_flag,
         "organisation": organisation,
         "organisation_children": organisation_children,
@@ -393,14 +385,8 @@ def case_list(request, organisation_id):
         "filtered_case_list": filter_term,
         "cohort_choices": merged_cohort_counts,
         "selected_cohort": selected_cohort,
-        "total_registered": registration_related_counts[
-            "registered"
-        ],  # all those registered in a cohort
-        "total_unregistered": registration_related_counts[
-            "unregistered"
-        ],  # all those not registered in a cohort
-        "all_unfiltered_counts": registration_related_counts["unregistered"]
-        + registration_related_counts[
+        "all_filtered_counts": filtered_totals["unregistered"]
+        + filtered_totals[
             "registered"
         ],  # all children who may not be yet be registered in a cohort as well as those who are
         "total_filtered_complete": filtered_totals["cases_complete"],

--- a/templates/epilepsy12/cases/cases.html
+++ b/templates/epilepsy12/cases/cases.html
@@ -31,8 +31,8 @@
 
         <div class="sixteen wide notupperpadded column" id='cohort_buttons'>
             <div class="ui rcpch_dark_blue buttons">
-              <a href="{% url 'cases' organisation_id=organisation.pk %}?cohort=all_children"><button class="ui mini compact {% if selected_cohort|default:''|stringformat:'s' == 'all_children' %}positive{% endif %} rcpch_dark_blue button">All Children ({{ all_unfiltered_counts }})</button></a>
-              <a href="{% url 'cases' organisation_id=organisation.pk %}?cohort=all_cohorts"><button class="ui mini compact {% if selected_cohort|default:''|stringformat:'s' == 'all_cohorts' %}positive{% endif %} rcpch_dark_blue button">All Cohorts ({{ total_registered }})</button></a>
+              <a href="{% url 'cases' organisation_id=organisation.pk %}?cohort=all_children"><button class="ui mini compact {% if selected_cohort|default:''|stringformat:'s' == 'all_children' %}positive{% endif %} rcpch_dark_blue button">All Children ({{ all_filtered_counts }})</button></a>
+              <a href="{% url 'cases' organisation_id=organisation.pk %}?cohort=all_cohorts"><button class="ui mini compact {% if selected_cohort|default:''|stringformat:'s' == 'all_cohorts' %}positive{% endif %} rcpch_dark_blue button">All Cohorts ({{ total_filtered_registered }})</button></a>
               {% for cohort in cohort_choices %}
                 {% if cohort.has_data %} 
                   <a href="{% url 'cases' organisation_id=organisation.pk %}?cohort={{cohort.cohort}}"><button class="ui mini compact {% if selected_cohort|default:''|stringformat:'s' == cohort.cohort|stringformat:'s' %}positive{% endif %} rcpch_dark_blue button">Cohort {{cohort.cohort}} ({{cohort.count}})</button></a>


### PR DESCRIPTION
FIX

While the facets were working and the tests are passing, i overlooked that fact that totals should filter depending on organisation / trust / national view

This removes the totals being calculated prefilters, and now applies them to the filtered 