### PR TITLE
Report-builder-rejig

### DIFF
--- a/epilepsy12/constants/kpi.py
+++ b/epilepsy12/constants/kpi.py
@@ -64,12 +64,12 @@ KPI_MAP = {
     "10": "school_individual_healthcare_plan",
 }
 KPI_LABEL_MAP = {
-    "1": "Paediatrician with expertise in epilepsies",
-    "2": "Epilepsy specialist nurse",
+    "1": "Paediatrician with expertise in epilepsies within 2 weeks",
+    "2": "Access to Epilepsy specialist nurse",
     "3": "Tertiary input",
     "3b": "Epilepsy surgery referral",
     "4": "ECG",
-    "5": "MRI",
+    "5": "MRI within 6 weeks",
     "6": "Assessment of mental health issues",
     "7": "Mental health support",
     "8": "Sodium valproate and topiramate",

--- a/epilepsy12/filtersets/case_filterset.py
+++ b/epilepsy12/filtersets/case_filterset.py
@@ -407,7 +407,7 @@ class CaseFilterMethods:
         Includes counts for: registration, audit progress, cohort
         """
 
-        cohort_list  = get_all_cohort_list()
+        cohort_list = get_all_cohort_list()
         base_filter = Q(
             epilepsy12_sites__site_is_primary_centre_of_epilepsy_care=True,
             epilepsy12_sites__site_is_actively_involved_in_epilepsy_care=True,
@@ -477,7 +477,10 @@ class CaseFilterMethods:
             "unregistered": raw_counts.get("unregistered_cases", 0),
             "cases_complete": raw_counts.get("audit_progress_complete", 0),
             "cases_incomplete": raw_counts.get("audit_progress_incomplete", 0),
-            "cohort_counts": {i['cohort']: raw_counts.get(f"cohort_{i['cohort']}", 0) for i in cohort_list},
+            "cohort_counts": {
+                i["cohort"]: raw_counts.get(f"cohort_{i['cohort']}", 0)
+                for i in cohort_list
+            },
         }
 
     @staticmethod
@@ -838,6 +841,7 @@ class CaseFilterMethods:
                 epilepsy12_sites__site_is_primary_centre_of_epilepsy_care=True,
                 epilepsy12_sites__site_is_actively_involved_in_epilepsy_care=True,
                 epilepsy12_sites__case__isnull=False,
+                epilepsy12_sites__organisation__trust__isnull=False,
             )
             .values(
                 "epilepsy12_sites__organisation__trust__id",
@@ -853,7 +857,7 @@ class CaseFilterMethods:
                 epilepsy12_sites__site_is_primary_centre_of_epilepsy_care=True,
                 epilepsy12_sites__site_is_actively_involved_in_epilepsy_care=True,
                 epilepsy12_sites__case__isnull=False,
-                epilepsy12_sites__case__registration__isnull=False,
+                epilepsy12_sites__organisation__local_health_board__isnull=False,
             )
             .values(
                 "epilepsy12_sites__organisation__local_health_board__id",
@@ -869,7 +873,7 @@ class CaseFilterMethods:
             result.append(
                 (
                     f"t_{trust['epilepsy12_sites__organisation__trust__id']}",
-                    f"Trust: {trust['epilepsy12_sites__organisation__trust__name']} ({trust['count']})",
+                    f"{trust['epilepsy12_sites__organisation__trust__name']} ({trust['count']})",
                 )
             )
         # Get counts for health boards
@@ -877,7 +881,7 @@ class CaseFilterMethods:
             result.append(
                 (
                     f"h_{hb['epilepsy12_sites__organisation__local_health_board__id']}",
-                    f"Local Health Board: {hb['epilepsy12_sites__organisation__local_health_board__name']} ({hb['count']})",
+                    f"{hb['epilepsy12_sites__organisation__local_health_board__name']} ({hb['count']})",
                 )
             )
 

--- a/epilepsy12/templatetags/epilepsy12_template_tags.py
+++ b/epilepsy12/templatetags/epilepsy12_template_tags.py
@@ -1,10 +1,12 @@
 import re
 import math
-import json
 
+from django.apps import apps
 from django import template
 from django.utils.safestring import mark_safe
 from django.conf import settings
+
+from epilepsy12.constants.kpi import KPI_MAP
 from ..models import (
     Country,
     IntegratedCareBoard,
@@ -721,6 +723,17 @@ def kpi_key_to_readable_name(kpi_key):
 
 
 @register.filter
+def kpi_key_to_help_text(kpi_key):
+    """
+    Convert a KPI key to a KPI helptext.
+    """
+    field = KPI_MAP.get(kpi_key)
+    KPI = apps.get_model("epilepsy12", "KPI")
+    help_text = KPI._meta.get_field(field).help_text["reference"]
+    return help_text if help_text else kpi_key
+
+
+@register.filter
 def field_key_to_readable_name(field_key):
     """
     Convert a field key to a human-readable name.
@@ -910,11 +923,11 @@ def organisation_label(parent_name, organisation_count):
     """
     Generate a label for the organisation dropdown based on the parent name
     and number of organisations.
-    
+
     Args:
         parent_name: Name of the parent (Trust or Local Health Board)
         organisation_count: Number of organisations in the parent
-    
+
     Returns:
         HTML-formatted label with proper singular/plural form
     """

--- a/epilepsy12/views/case_views.py
+++ b/epilepsy12/views/case_views.py
@@ -995,7 +995,7 @@ class CaseListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
     paginate_by = 50
     filterset_class = CaseFilter
     ordering = "surname"
-    permission_required = "epilepsy12.can_publish_epilepsy12_data"
+    permission_required = "epilepsy12.view_case"
     raise_exception = True
 
     def get_queryset(self):

--- a/templates/epilepsy12/cases/case_filter_table.html
+++ b/templates/epilepsy12/cases/case_filter_table.html
@@ -244,7 +244,11 @@
                                 {% endfor %}
                             {% endif %}
                         {% endfor %}
-                        
+                        <div class="field">
+                            <a href="{% url 'case_filter_list' organisation_id %}" class="ui left floated tiny rcpch_light_blue button">
+                                <i class="undo icon"></i> Reset
+                            </a>
+                        </div>
                     </div>
                 </div>
                 

--- a/templates/epilepsy12/cases/case_filter_table.html
+++ b/templates/epilepsy12/cases/case_filter_table.html
@@ -115,63 +115,6 @@
                     </div>
                     {% endif %}
 
-                </div><!--segment-->
-
-                <!-- Results Stats -->
-                <div class="ui statistics">
-                    <div class="statistic">
-                        <div class="value">{{ total_cases }}</div>
-                        <div class="label">Total Cases</div>
-                    </div>
-                    <div class="statistic">
-                        <div class="value">{{ registered_cases }}</div>
-                        <div class="label">Registered</div>
-                    </div>
-                    <div class="statistic">
-                        <div class="value">{{ total_episodes|default:"0" }}</div>
-                        <div class="label">Total Episodes</div>
-                    </div>
-                </div>
-
-                <!-- Filter Summary -->
-                {% if request.GET %}
-                <div class="ui rcpch_info message">
-                    <div class="header">Active Filters</div>
-                    <div class="ui horizontal list">
-                        {% for key, value_list in request.GET.lists %} {# Iterate through .lists() to get all values #}
-                            {% if key != 'page' %}
-                                {% for value in value_list %} {# Loop through potentially multiple values for the key #}
-                                    {% if value %} {# Ensure value is not empty #}
-                                        <div class="item">
-                                            <div class="ui rcpch_light_blue label">
-                                                {# Display the key and the specific value #}
-                                                {{ key|field_key_to_readable_name }}: {{ value|field_value_to_readable_name:key }}
-
-                                                {# Use build_url_parameters to generate the removal link #}
-                                                {# Pass the key and the specific value to remove/toggle - if kpi_failed then pass the kpi value, if not then pass None as a flag that this should be deleted #}
-                                                {% if key == 'kpi_failed' %}
-                                                <a href="{% build_url_parameters request key value %}">
-                                                    <i class="delete icon"></i>
-                                                </a>
-                                                {% else %}
-                                                <a href="{% build_url_parameters request key None %}">
-                                                    <i class="delete icon"></i>
-                                                </a>
-                                                {% endif %}
-                                            </div>
-                                        </div>
-                                    {% endif %}
-                                {% endfor %}
-                            {% endif %}
-                        {% endfor %}
-                    </div>
-                </div>
-                {% endif %}
-                {% for name, value in hidden_field_params %} <!-- this adds the facets to the form as hidden fields so that their filters are not ignored when the form is submitted-->
-                    <input type="hidden" name="{{ name }}" value="{{ value }}">
-                {% endfor %}
-
-                <div class="ui rcpch_grey segment">
                     <h5 class="header">
                         <span class="data-tooltip" data-tooltip="Apply filters by selecting the dropdowns and click `Apply Filters`" data-position="right center">Demographics <i class="rcpch question circle icon"></i></span>
                     </h5>
@@ -253,7 +196,62 @@
                             <i class="undo icon"></i> Reset
                         </a>
                     </div><!--fields-->
+
                 </div><!--segment-->
+
+                <!-- Results Stats -->
+                <div class="ui statistics">
+                    <div class="statistic">
+                        <div class="value">{{ total_cases }}</div>
+                        <div class="label">Total Cases</div>
+                    </div>
+                    <div class="statistic">
+                        <div class="value">{{ registered_cases }}</div>
+                        <div class="label">Registered</div>
+                    </div>
+                    <div class="statistic">
+                        <div class="value">{{ total_episodes|default:"0" }}</div>
+                        <div class="label">Total Episodes</div>
+                    </div>
+                </div>
+
+                <!-- Filter Summary -->
+                {% if request.GET %}
+                <div class="ui rcpch_info message">
+                    <div class="header">Active Filters</div>
+                    <div class="ui horizontal list">
+                        {% for key, value_list in request.GET.lists %} {# Iterate through .lists() to get all values #}
+                            {% if key != 'page' %}
+                                {% for value in value_list %} {# Loop through potentially multiple values for the key #}
+                                    {% if value %} {# Ensure value is not empty #}
+                                        <div class="item">
+                                            <div class="ui rcpch_light_blue label">
+                                                {# Display the key and the specific value #}
+                                                {{ key|field_key_to_readable_name }}: {{ value|field_value_to_readable_name:key }}
+
+                                                {# Use build_url_parameters to generate the removal link #}
+                                                {# Pass the key and the specific value to remove/toggle - if kpi_failed then pass the kpi value, if not then pass None as a flag that this should be deleted #}
+                                                {% if key == 'kpi_failed' %}
+                                                <a href="{% build_url_parameters request key value %}">
+                                                    <i class="delete icon"></i>
+                                                </a>
+                                                {% else %}
+                                                <a href="{% build_url_parameters request key None %}">
+                                                    <i class="delete icon"></i>
+                                                </a>
+                                                {% endif %}
+                                            </div>
+                                        </div>
+                                    {% endif %}
+                                {% endfor %}
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+                </div>
+                {% endif %}
+                {% for name, value in hidden_field_params %} <!-- this adds the facets to the form as hidden fields so that their filters are not ignored when the form is submitted-->
+                    <input type="hidden" name="{{ name }}" value="{{ value }}">
+                {% endfor %}
                 
             </form>
             

--- a/templates/epilepsy12/cases/case_filter_table.html
+++ b/templates/epilepsy12/cases/case_filter_table.html
@@ -192,9 +192,7 @@
                         <button type="submit" class="ui rcpch_light_blue button">
                             <i class="filter icon"></i> Apply Filters
                         </button>
-                        <a href="{% url 'case_filter_list' organisation_id %}" class="ui rcpch_light_blue button">
-                            <i class="undo icon"></i> Reset
-                        </a>
+                        
                     </div><!--fields-->
 
                 </div><!--segment-->
@@ -206,7 +204,7 @@
                         <div class="label">Total Cases</div>
                     </div>
                     <div class="statistic">
-                        <div class="value">{{ registered_cases }}</div>
+                        <div class="value">{{ registered_cases_count }}</div>
                         <div class="label">Registered</div>
                     </div>
                     <div class="statistic">
@@ -246,8 +244,10 @@
                                 {% endfor %}
                             {% endif %}
                         {% endfor %}
+                        
                     </div>
                 </div>
+                
                 {% endif %}
                 {% for name, value in hidden_field_params %} <!-- this adds the facets to the form as hidden fields so that their filters are not ignored when the form is submitted-->
                     <input type="hidden" name="{{ name }}" value="{{ value }}">

--- a/templates/epilepsy12/cases/case_filter_table.html
+++ b/templates/epilepsy12/cases/case_filter_table.html
@@ -367,14 +367,22 @@
                                             <a class="item active"
                                             href="{% build_url_parameters request 'kpi_failed' kpi_id %}">
                                             
-                                            <span data-tooltip="{{ kpi_id|kpi_key_to_readable_name }}" data-position="right center">KPI {{ kpi_id|kpi_key_formatted }} <i class="rcpch question circle icon"></i></span>
+                                            <span 
+                                            class="kpi-popup"
+                                            data-content="{{ kpi_id|kpi_key_to_help_text }}" data-position="top center" data-variation="wide"><b>{{ kpi_id|kpi_key_formatted }}</b> - {{kpi_id|kpi_key_to_readable_name}} <i class="rcpch question circle icon"></i></span>
                                                 <div class="ui left pointing rcpch facets label">{{ count }}</div>
                                             </a>
                                         {% else %}
                                             {# Add this KPI to the selection #}
                                             <a class="item"
-                                            href="{% build_url_parameters request 'kpi_failed' kpi_id %}">
-                                                <span data-tooltip="{{ kpi_id|kpi_key_to_readable_name }}" data-position="right center">KPI {{ kpi_id|kpi_key_formatted }} <i class="rcpch question circle icon"></i></span>
+                                                href="{% build_url_parameters request 'kpi_failed' kpi_id %}"
+                                            >
+                                                <span 
+                                                    class="kpi-popup"
+                                                    data-content="{{ kpi_id|kpi_key_to_help_text }}" 
+                                                    data-position="top center" data-variation="wide"
+                                                    _="init js $('.kpi-popup').popup(); end"
+                                                ><b>{{ kpi_id|kpi_key_formatted }}</b> - {{kpi_id|kpi_key_to_readable_name}} <i class="rcpch question circle icon"></i></span>
                                                 <div class="ui rcpch facets label">{{ count }}</div>
                                             </a>
                                         {% endif %}
@@ -631,6 +639,8 @@
 
             window.location.href = finalUrl;
         });
+        
     });
+    
 </script>
 {% endblock %}

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -7,7 +7,7 @@
             <div class='column'>
                 <div class="back link">
                     <button class="ui rcpch_positive button jump" _="on click go to top of #kpis">Jump to All KPI Metrics</button>
-                    {% if perms.epilepsy12.can_publish_epilepsy12_data %}
+                    
                     <a class="ui rcpch_positive button" href="{% url 'case_filter_list' organisation_id=selected_organisation.pk %}">
                         <i class="yellow wrench icon"></i>
                         Report Builder
@@ -15,7 +15,7 @@
                             NEW <i class="red star icon" style="margin: 0 0 0 4px;"></i>
                         </div>
                     </a>
-                    {% endif %}
+
                 </div>
             </div>
             <div class="ui rcpch_view label column" style="display: flex; align-items: center; justify-content: center; margin: 0; font-size: 25px;">


### PR DESCRIPTION
### Overview

closes #1317

styling changes to the report builder prior to publishing

Styling changes include:
1. moving demographics filters in to national view filters segment (national view items will not render for regular users)
2. move the remove filters button into the filters alert
3. move the apply filters into the filters segment
4. fix the registered totals missing in the stats
5. add the kpi label to the item
6. add the kpi reference text to the tooltip for KPIs
7. remove the guard from the report builder anchor button to be visible to all users
8. downgrade the permission required to access the CaseFilter list view to `view_case`.
9. remove the `Trust` and `Local Health Board` text prepended in the local health board/trust dropdown in the national filter

That's it ready to publish

<img width="1453" height="529" alt="image" src="https://github.com/user-attachments/assets/28d6a3b4-ae2d-4fbf-90c6-8f82e8884677" />

<img width="1470" height="384" alt="image" src="https://github.com/user-attachments/assets/a7d6200e-aca2-438e-b687-ebf193962ce3" />

<img width="1447" height="762" alt="image" src="https://github.com/user-attachments/assets/dfb969c3-7c26-462a-8dc2-3b83efb7d4b6" />

<img width="1470" height="471" alt="image" src="https://github.com/user-attachments/assets/188a8dce-978b-4bc5-9100-2382805382a3" />
