### PR TITLE
Fix org permission checks in report builder

### DIFF
--- a/epilepsy12/decorator.py
+++ b/epilepsy12/decorator.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import AccessMixin
 from .models import (
     FirstPaediatricAssessment,
     MultiaxialDiagnosis,
@@ -140,6 +141,44 @@ def group_required(*group_names):
     return decorator
 
 
+def _user_may_view_this_organisation(request, kwargs):
+    user = request.user
+    if kwargs.get("organisation_id") is not None:
+        organisation_requested = Organisation.objects.get(
+            pk=kwargs.get("organisation_id")
+        )
+        organisation_list = organisation_white_list_for_user(
+            epilepsy12_user=user
+        )
+        if (
+            (
+                organisation_requested in organisation_list
+                and user.is_active
+                and user.email_confirmed
+            )
+            or user.is_superuser
+            or user.is_rcpch_audit_team_member
+        ):
+            # user's has an organisation employer in the same trust or LHB as the organisation requested
+            if kwargs.get("user_type") is not None:
+                if kwargs.get("user_type") == "rcpch-staff":
+                    # this route is for rcpch staff to create new rcpch staff members only
+                    raise PermissionDenied()
+            # user is allowed
+        else:
+            raise PermissionDenied()
+    else:
+        # organisation requested does not exist
+        raise ValueError("Organisation requested does not exist!")
+
+
+class OrganisationAccessMixin(AccessMixin):
+    def dispatch(self, request, *args, **kwargs):
+        # Raises PermissionDenied
+        _user_may_view_this_organisation(request, kwargs)
+        return super().dispatch(request, *args, **kwargs)
+
+
 def user_may_view_this_organisation():
     # decorator receives organisation_id.
     # access is granted only to users who are either:
@@ -148,35 +187,8 @@ def user_may_view_this_organisation():
     # 3. Active trust/LHB level users where any trust/LHB they have access to includes the id of the organisation requested
     def decorator(view):
         def wrapper(request, *args, **kwargs):
-            user = request.user
-            if kwargs.get("organisation_id") is not None:
-                organisation_requested = Organisation.objects.get(
-                    pk=kwargs.get("organisation_id")
-                )
-                organisation_list = organisation_white_list_for_user(
-                    epilepsy12_user=user
-                )
-                if (
-                    (
-                        organisation_requested in organisation_list
-                        and user.is_active
-                        and user.email_confirmed
-                    )
-                    or user.is_superuser
-                    or user.is_rcpch_audit_team_member
-                ):
-                    # user's has an organisation employer in the same trust or LHB as the organisation requested
-                    if kwargs.get("user_type") is not None:
-                        if kwargs.get("user_type") == "rcpch-staff":
-                            # this route is for rcpch staff to create new rcpch staff members only
-                            raise PermissionDenied()
-                    # user is allowed
-                    return view(request, *args, **kwargs)
-                else:
-                    raise PermissionDenied()
-            else:
-                # organisation requested does not exist
-                raise ValueError("Organisation requested does not exist!")
+            _user_may_view_this_organisation(request, kwargs)
+            return view(request, *args, **kwargs)
 
         return wrapper
 

--- a/epilepsy12/views/case_views.py
+++ b/epilepsy12/views/case_views.py
@@ -36,6 +36,7 @@ from ..decorator import (
     user_may_view_this_organisation,
     user_may_view_this_child,
     login_and_otp_required,
+    OrganisationAccessMixin
 )
 
 from ..filtersets import *
@@ -1012,7 +1013,7 @@ def consent_confirmation(request, case_id, consent_type):
     return response
 
 
-class CaseListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
+class CaseListView(LoginRequiredMixin, PermissionRequiredMixin, OrganisationAccessMixin, ListView):
     """
     View to display a list of cases for a given organisation.
     This view uses a faceted search for certain key metrics such as KPI


### PR DESCRIPTION
Before this change users could have used the report builder to view data outside of their unit by changing the organisation ID in the URL.