### PR TITLE
Require two factor for report builder

### DIFF
--- a/epilepsy12/decorator.py
+++ b/epilepsy12/decorator.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import AccessMixin
 from .models import (
     FirstPaediatricAssessment,
     MultiaxialDiagnosis,
@@ -392,3 +393,35 @@ def login_and_otp_required():
         return login_required(wrapper)
 
     return decorator
+
+
+class LoginAndOTPRequiredMixin(AccessMixin):
+    def dispatch(self, request, *args, **kwargs):
+        user = request.user
+
+        # Check if the user is authenticated
+        if not user.is_authenticated:
+            return self.handle_no_permission()
+
+        # Bypass 2fa if local dev, with warning message
+        if settings.DEBUG and user.is_authenticated:
+            logger.warning(
+                "User %s has bypassed 2FA for %s as settings.DEBUG is %s",
+                user,
+                self.__class__.__name__,
+                settings.DEBUG,
+            )
+            return super().dispatch(request, *args, **kwargs)
+
+        # Prevent unverified users
+        if not user.is_verified():
+            user_list = user.__dict__
+            epilepsy12_user = user_list["_wrapped"]
+            logger.info(
+                "User %s is unverified. Tried accessing %s",
+                epilepsy12_user,
+                self.__class__.__name__,
+            )
+            raise PermissionDenied()
+
+        return super().dispatch(request, *args, **kwargs)

--- a/epilepsy12/views/case_views.py
+++ b/epilepsy12/views/case_views.py
@@ -36,6 +36,7 @@ from ..decorator import (
     user_may_view_this_organisation,
     user_may_view_this_child,
     login_and_otp_required,
+    LoginAndOTPRequiredMixin
 )
 
 from ..filtersets import *
@@ -1012,7 +1013,7 @@ def consent_confirmation(request, case_id, consent_type):
     return response
 
 
-class CaseListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
+class CaseListView(LoginAndOTPRequiredMixin, PermissionRequiredMixin, ListView):
     """
     View to display a list of cases for a given organisation.
     This view uses a faceted search for certain key metrics such as KPI


### PR DESCRIPTION
Before this change users could have manually navigated to the report builder and accessed data before they had registered for two factor authentication.

See also #1322 