### PR TITLE
Update Django version to 5.2.9

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,7 @@ requests==2.32.4
 # third party imports
 ## django and misc
 dj_database_url==2.3.0
-django==5.2.8
+django==5.2.9
 django-auto-logout==0.5.1
 django-filter==25.1
 django-htmx==1.23.0


### PR DESCRIPTION
Clears dependabot warnings

- https://github.com/rcpch/rcpch-audit-engine/security/dependabot/29
- https://github.com/rcpch/rcpch-audit-engine/security/dependabot/30