### PR TITLE
valproate-pink-tick

### DIFF
--- a/epilepsy12/common_view_functions/medicine_choices.py
+++ b/epilepsy12/common_view_functions/medicine_choices.py
@@ -14,6 +14,9 @@ def get_medicine_choices(management, antiepilepsy_medicine_id=None, is_rescue=Fa
     # Get all comorbidity entities that have been selected for this multiaxial diagnosis except the current one
     all_selected_medicines = (
         AntiEpilepsyMedicine.objects.filter(management=management)
+        .filter(
+            antiepilepsy_medicine_stop_date__isnull=True
+        )  # only exclude active medicines
         .exclude(pk=antiepilepsy_medicine_id)
         .values_list("medicine_entity", flat=True)
     )
@@ -23,10 +26,10 @@ def get_medicine_choices(management, antiepilepsy_medicine_id=None, is_rescue=Fa
         entity for entity in all_selected_medicines if entity is not None
     ]
 
-    comorbidity_choices = (
+    medicine_choices = (
         Medicine.objects.filter(is_rescue=is_rescue)
         .exclude(pk__in=all_selected_medicineentities)
         .order_by("preferredTerm")
     )
 
-    return comorbidity_choices
+    return medicine_choices

--- a/epilepsy12/common_view_functions/recalculate_form_generate_response.py
+++ b/epilepsy12/common_view_functions/recalculate_form_generate_response.py
@@ -1,5 +1,6 @@
 from dateutil import relativedelta
 from datetime import date
+import logging
 
 # 3rd Party Imports
 from django_htmx.http import trigger_client_event
@@ -27,6 +28,8 @@ from epilepsy12.constants import (
     Management_minimum_scorable_fields,
     AntiEpilepsyMedicine_minimum_scorable_fields,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def recalculate_form_generate_response(
@@ -85,6 +88,12 @@ def update_audit_progress(model_instance):
         registration = model_instance
     else:
         registration = model_instance.registration
+
+    # Logging step
+    if all_completed_fields > all_expected_fields:
+        logger.error(
+            f"Completed fields {all_completed_fields} exceed expected fields {all_expected_fields} for {verbose_name_underscored} for {registration.case} (e12id: {registration.case.pk}, registration ID {registration.id})"
+        )
 
     # update KPIs
     calculate_kpis(registration_instance=registration)

--- a/epilepsy12/templatetags/epilepsy12_template_tags.py
+++ b/epilepsy12/templatetags/epilepsy12_template_tags.py
@@ -209,7 +209,7 @@ def record_complete(model):
             )
             if (
                 model.management.registration.case.sex == 2
-                and model.medicine_entity.medicine_name == "Sodium valproate"
+                and model.medicine_entity.conceptId == "387481005"  # Sodium valproate
                 and model.management.registration.case.age_days() >= 365 * 12
             ):
                 return minimum_requirement_met and (

--- a/epilepsy12/views/management_views.py
+++ b/epilepsy12/views/management_views.py
@@ -241,16 +241,11 @@ def edit_antiepilepsy_medicine(request, antiepilepsy_medicine_id):
 
     # get all medicines excluding those already selected, and excluding this medicine
     management = antiepilepsy_medicine.management
-    all_selected_antiepilepsymedicines = (
-        AntiEpilepsyMedicine.objects.filter(management=management)
-        .exclude(pk=antiepilepsy_medicine_id)
-        .values_list("medicine_entity", flat=True)
-    )
 
-    choices = (
-        Medicine.objects.filter(is_rescue=antiepilepsy_medicine.is_rescue_medicine)
-        .exclude(pk__in=all_selected_antiepilepsymedicines)
-        .order_by("medicine_name")
+    choices = get_medicine_choices(
+        antiepilepsy_medicine_id=antiepilepsy_medicine.pk,
+        management=management,
+        is_rescue=antiepilepsy_medicine.is_rescue_medicine,
     )
 
     if antiepilepsy_medicine.antiepilepsy_medicine_stop_date:

--- a/epilepsy12/views/management_views.py
+++ b/epilepsy12/views/management_views.py
@@ -397,6 +397,11 @@ def medicine_id(request, antiepilepsy_medicine_id, medicine_status):
                 antiepilepsy_medicine.management.registration.case.date_of_birth,
             )
             sex = int(antiepilepsy_medicine.management.registration.case.sex)
+            # reset pregnancy prevention programme fields based on new medicine selection
+            antiepilepsy_medicine.is_a_pregnancy_prevention_programme_needed = None
+            antiepilepsy_medicine.has_a_valproate_annual_risk_acknowledgement_form_been_completed = (
+                None
+            )
             if requires_pregnancy_prevention_programme(
                 cohort=antiepilepsy_medicine.management.registration.cohort,
                 medicine_concept_id=antiepilepsy_medicine.medicine_entity.conceptId,

--- a/epilepsy12/views/management_views.py
+++ b/epilepsy12/views/management_views.py
@@ -397,27 +397,20 @@ def medicine_id(request, antiepilepsy_medicine_id, medicine_status):
             antiepilepsy_medicine.has_a_valproate_annual_risk_acknowledgement_form_been_completed = (
                 None
             )
-            if requires_pregnancy_prevention_programme(
-                cohort=antiepilepsy_medicine.management.registration.cohort,
-                medicine_concept_id=antiepilepsy_medicine.medicine_entity.conceptId,
-                age=calculated_age.years,
-                sex=sex,
-            ):
-                antiepilepsy_medicine.is_a_pregnancy_prevention_programme_needed = True
-                antiepilepsy_medicine.is_a_pregnancy_prevention_programme_in_place = (
-                    None
+            antiepilepsy_medicine.is_a_pregnancy_prevention_programme_needed = (
+                requires_pregnancy_prevention_programme(
+                    cohort=antiepilepsy_medicine.management.registration.cohort,
+                    medicine_concept_id=antiepilepsy_medicine.medicine_entity.conceptId,
+                    age=calculated_age.years,
+                    sex=sex,
                 )
-                antiepilepsy_medicine.has_a_valproate_annual_risk_acknowledgement_form_been_completed = (
-                    None
-                )
-            else:
-                antiepilepsy_medicine.is_a_pregnancy_prevention_programme_needed = False
-                antiepilepsy_medicine.is_a_pregnancy_prevention_programme_in_place = (
-                    None
-                )
-                antiepilepsy_medicine.has_a_valproate_annual_risk_acknowledgement_form_been_completed = (
-                    None
-                )
+            )
+
+            antiepilepsy_medicine.is_a_pregnancy_prevention_programme_in_place = None
+            antiepilepsy_medicine.has_a_valproate_annual_risk_acknowledgement_form_been_completed = (
+                None
+            )
+
     else:
         antiepilepsy_medicine.is_a_pregnancy_prevention_programme_needed = False
         antiepilepsy_medicine.is_a_pregnancy_prevention_programme_in_place = None


### PR DESCRIPTION
### Overview

Fixes two issues:

1. Antiepileptic medicines that had been discontinued (had a start and a stop date) were being excluded from the drop down if users subsequently wanted to add the medicine back. 
2. if valproate (or topiramate in cohort 7) were selected, the pink tick would appear after  the start date, safety declaration and medicine were selected. The additional fields (PPP and annual risk assessment form) were not included in the decision to show the pink tick. This meant users might not have completed the form but saw only pink ticks so had no visual cues as to where the missing fields were.

Code changes
1. `get_medicine_choices` helper now excludes only active medicines
2.  `medicine_id` resets the PPP and valproate risk acknowledgement to None on every call.
3. adds logging for future if form scoring finds score > expected
4. tidies some of the logic around PPP eligibility

<img width="712" height="242" alt="image" src="https://github.com/user-attachments/assets/45b61d12-582a-47ef-8c12-a38e0b77ebee" />

<img width="1033" height="679" alt="image" src="https://github.com/user-attachments/assets/ea5b76a2-5d96-4948-9997-a44127c51de0" />


closes #1327 
closes #1321
closes #1300