### PR TITLE
Organisational Audit - fix submit button not appearing

### DIFF
--- a/epilepsy12/forms_folder/organisational_audit_form.py
+++ b/epilepsy12/forms_folder/organisational_audit_form.py
@@ -12,7 +12,8 @@ class OrganisationalAuditSubmissionForm(forms.ModelForm):
             "created_by",
             "updated_by",
             "created_at",
-            "updated_at"
+            "updated_at",
+            "submitted"
         ]
 
         help_texts = {

--- a/epilepsy12/views/organisational_audit_views.py
+++ b/epilepsy12/views/organisational_audit_views.py
@@ -73,7 +73,7 @@ def group_questions(fields_by_question_number):
 
 
 def group_form_fields(form):
-    # Loops trough the form fields and groups them by section and question number
+    # Loops through the form fields and groups them by section and question number
     # The question number is taken from the help text of the field
     # This function is called with every field updated in the form and rerenders the form partial
 
@@ -182,8 +182,11 @@ def get_submission(submission_period, group, group_field):
 def get_submission_form(submission, last_submission):
     data = {}
     
+    fields_not_to_copy_from_last_year = OrganisationalAuditSubmissionForm.Meta.exclude
+    fields_not_to_copy_from_last_year += ["id", "submitted"]
+
     for field in OrganisationalAuditSubmission._meta.fields:
-        if field.name != "id" and not field.name in OrganisationalAuditSubmissionForm.Meta.exclude:
+        if not field.name in fields_not_to_copy_from_last_year:
             field_value = getattr(submission, field.name) if submission else None
             
             if not field_value and last_submission:
@@ -237,6 +240,8 @@ def _organisational_audit(request, group_id, group_model, group_field):
 
         if number_completed != total_questions:
             form.instance.submitted = False
+        else:
+            form.instance.submitted = True
 
         context["questions_by_section"] = questions_by_section
         context["number_completed"] = number_completed

--- a/epilepsy12/views/organisational_audit_views.py
+++ b/epilepsy12/views/organisational_audit_views.py
@@ -182,8 +182,7 @@ def get_submission(submission_period, group, group_field):
 def get_submission_form(submission, last_submission):
     data = {}
     
-    fields_not_to_copy_from_last_year = OrganisationalAuditSubmissionForm.Meta.exclude
-    fields_not_to_copy_from_last_year += ["id", "submitted"]
+    fields_not_to_copy_from_last_year = OrganisationalAuditSubmissionForm.Meta.exclude + ["id"]
 
     for field in OrganisationalAuditSubmission._meta.fields:
         if not field.name in fields_not_to_copy_from_last_year:
@@ -238,10 +237,10 @@ def _organisational_audit(request, group_id, group_model, group_field):
             form
         )
 
-        if number_completed != total_questions:
-            form.instance.submitted = False
-        else:
+        if number_completed == total_questions and request.POST.get("action") == "submit":
             form.instance.submitted = True
+        else:
+            form.instance.submitted = False
 
         context["questions_by_section"] = questions_by_section
         context["number_completed"] = number_completed

--- a/static/styles/organisational-audit.css
+++ b/static/styles/organisational-audit.css
@@ -81,7 +81,7 @@
     font-family: var(--rcpch_standard_font) !important;
 }
 
-.org-audit-progress input[type="submit"] {
+.org-audit-progress--submit {
     font-family: var(--rcpch_standard_font) !important;
     color: white !important;
     font-size: 1.2em;

--- a/templates/epilepsy12/partials/organisational_audit_form.html
+++ b/templates/epilepsy12/partials/organisational_audit_form.html
@@ -13,8 +13,9 @@
         </div>
         <div>
             {% if not submitted and number_completed == total_questions %}
-                <input type="hidden" value="true" name="submitted" />
-                <input class="ui rcpch_primary button" type="submit" value="Submit data to the {{submission_period.year}} E12 organisational audit">
+                <button class="ui rcpch_primary button org-audit-progress--submit" name="action" value="submit">
+                    Submit data to the {{submission_period.year}} E12 organisational audit
+                </button>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
Fixes #1344
Fixes #1342

There was a silly bug where the submit button doesn't appear on the next years submission once complete if the previous year had a submission - it appears to be already submitted.

Debugging this was a bit of a nightmare as the `submitted` value used to control whether the submit button appeared came direct from the submission instance which was definitely `False` in the database.

However, calling `field.errors` when iterating through the fields on the `OrganisationalAuditSubmissionForm` would copy `submitted` from the initial data passed to it. This happened deep in the bowels of `group_form_fields`.

Also fixes flip flopping between submitted states by only setting `submitted=True` if the user for sure clicked the submit button.