### PR TITLE
Mark another test as slow

### DIFF
--- a/epilepsy12/tests/common_view_functions_tests/aggregate_by_tests/test_calculate_kpi_value_counts_queryset.py
+++ b/epilepsy12/tests/common_view_functions_tests/aggregate_by_tests/test_calculate_kpi_value_counts_queryset.py
@@ -66,6 +66,9 @@ from .helpers import _clean_cases_from_test_db, _register_kpi_scored_cases
     ],
 )
 @pytest.mark.django_db
+# Run last as it can sometimes pick pathological query plans when running fresh before Postgres has properly
+# analysed the tables (https://github.com/rcpch/rcpch-audit-engine/issues/1119)
+@pytest.mark.slow
 def test_calculate_kpi_value_counts_queryset_all_levels(
     abstraction_level, abstraction_codes, ods_codes, e12_case_factory
 ):


### PR DESCRIPTION
Follow on from https://github.com/rcpch/rcpch-audit-engine/pull/1223.

[test_calculate_kpi_value_counts_queryset.py](https://github.com/rcpch/rcpch-audit-engine/compare/mbarton/sloooow?expand=1#diff-c1137b17c6fe6d5bc9a27f9e8485bbd374e5aea97ec5a8917d6ae4e59d5dc37e) was exhibiting the same pathological 100% CPU postgres behaviour on a fresh checkout on my machine.

So banish it to the slow tests tag so I can easily filter it out if needed.