### PR TITLE
2025 imd

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,178 @@
+# agents.md — RCPCH Audit Engine: Agent Orientation
+
+> This file is intended as a growing reference for AI agents and developers working on this codebase. It will be expanded over time to cover each major area of the project.
+
+---
+
+## Project Overview
+
+**rcpch-audit-engine** is the backend and web application for **Epilepsy12**, a national clinical audit run by the Royal College of Paediatrics and Child Health (RCPCH). It collects, validates, and reports on epilepsy care for children across England and Wales.
+
+- **Framework**: Django (Python)
+- **Database**: PostgreSQL with the PostGIS extension (spatial queries)
+- **Deployment target**: Azure Container Apps
+- **Container registry**: Azure Container Registry (ACR)
+- **Reverse proxy**: Caddy (handles HTTPS)
+- **Task queue**: Celery (celerybeat for scheduled tasks)
+- **Primary app**: `epilepsy12/` — all audit domain logic lives here
+- **Documentation**: MkDocs site, served via a separate Docker Compose service and built into the image at deploy time
+- **Full docs**: https://e12.rcpch.ac.uk/docs
+
+The main Django project config is in `rcpch-audit-engine/` (the inner directory), including `settings.py`, `urls.py`, `logging_settings.py`, and `build_info.py`.
+
+---
+
+## The `s/` Scripts Directory
+
+All developer and CI operations are driven by short shell scripts in `s/`. These exist to reduce typing, reduce errors, and ensure consistency. Scripts are plain bash; make them executable with `chmod +x s/<script>` if needed.
+
+| Script | Purpose |
+|---|---|
+| `s/up` | `docker compose up` — starts all services (caddy, django, postgis, mkdocs) |
+| `s/down` | `docker compose down` — stops services, does **not** destroy volumes or images |
+| `s/rebuild` | Destroys containers and images then calls `s/up` (runs `s/remove-containers-and-images` then `s/up`) |
+| `s/remove-containers-and-images` | Removes local containers and images without touching volumes |
+| `s/DELETE-LOCAL-DATA` | **Destructive** — prompts for confirmation, then runs `docker compose down -v --rmi local` removing volumes too. Never run on live/production. |
+| `s/start-dev` | Django entrypoint for development: `collectstatic`, `migrate`, seed groups/permissions, create dev users, then `runserver` |
+| `s/start-prod` | Django entrypoint for production |
+| `s/start-test` | Django entrypoint used during test runs: `collectstatic` then sleeps (keeps container alive for pytest) |
+| `s/seed` | Seeds 200 cases and registrations into a running django container via `manage.py seed` |
+| `s/test` | Runs `pytest -v` inside the running django container; passes all extra args through (e.g. `-m slow`) |
+| `s/pr-check` | Used in CI on PRs: spins up compose with `start-test`, runs `not slow` then `slow` test markers, tears down |
+| `s/ci` | Full deployment pipeline script (see CI section below) |
+| `s/logs` | Tails all compose service logs with timestamps |
+| `s/psql` | Opens a psql shell inside the postgis container |
+| `s/django-shell` | Opens a Django shell inside the django container |
+| `s/create-superuser` | Creates a Django superuser inside the running container |
+| `s/get-build-info` | Writes git metadata (hash, branch, etc.) to `build_info.json` for the build info page |
+| `s/push-envs-github-secret` | Pushes environment secrets to GitHub Actions secrets |
+| `s/trust-caddy-ca` | Trusts Caddy's local CA certificate for local HTTPS development |
+| `s/restart` | Restarts compose services |
+
+The `DJANGO_START_COMMAND` environment variable controls which start script the django container runs. It defaults to `s/start-dev`; CI overrides it to `s/start-test` when running tests.
+
+---
+
+## CI / Deployment Pipeline
+
+### GitHub Actions Workflows
+
+| Workflow file | Trigger | Purpose |
+|---|---|---|
+| `run-docker-compose-test-on-pr.yml` | PR to any branch | Runs the full pytest suite via `s/pr-check` |
+| `deploy.yml` | Push to `live` branch | Full build, test, and deploy to Azure via `s/ci` |
+| `staging_e12-staging-web-app-service.yml` | (see file) | Staging App Service deployment |
+| `auto-add-issues-to-project.yml` | Issue events | Automatically adds issues to the GitHub Project board |
+
+### The `s/ci` Deployment Script (called by `deploy.yml`)
+
+This is the authoritative deploy sequence executed on every push to `live`:
+
+1. **Login to Azure ACR** — `az acr login`
+2. **Download `.env` from Azure File Share** — production secrets are stored in Azure Storage, not in the repo
+3. **Burn in build info** — `s/get-build-info` writes git metadata to `build_info.json`
+4. **Build the Docker image** — `docker compose build`
+5. **Build the MkDocs documentation** — runs inside the image; docs are embedded into the static files
+6. **Rebuild the image** — a second build to embed the freshly built docs
+7. **Tag and push to ACR** — tagged with the Git SHA: `<registry>.azurecr.io/e12-django:<SHA>`
+8. **Run tests** — `s/test -m 'not slow'` then `s/test -m 'slow'` against a local Postgres container
+9. **Deploy to staging** — `az containerapp revision copy` creates a new revision on the staging Container App
+10. **Deploy to production** — same command targets the live Container App
+
+> Note: the image is pushed to ACR **before** tests run, so that an emergency deploy is possible from a known-good SHA even if tests are mid-flight.
+
+### Authentication to Azure
+
+The GitHub Actions workflow uses OIDC (`id-token: write` permission) with Azure federated credentials — no long-lived secrets for the Azure login itself. Remaining secrets (registry name, resource group, app names, storage account, etc.) are stored as GitHub Actions secrets and injected as environment variables into `s/ci`.
+
+---
+
+## Docker Compose Services
+
+| Service | Image / Build | Role |
+|---|---|---|
+| `caddy` | `caddy` (official) | Reverse proxy, TLS termination, serves static docs |
+| `django` | `e12-django:built` (local build) | Main Django application |
+| `postgis` | `postgis/postgis:15-3.3` | PostgreSQL + PostGIS |
+| `mkdocs` | `e12-django:built` | Builds and optionally serves the MkDocs documentation |
+
+All services share environment from `envs/.env` (not committed to git). Two named volumes are used: `caddy-data` and `postgis-data`.
+
+---
+
+## IMD Calculation — Design Notes
+
+### Background
+
+The **Index of Multiple Deprivation (IMD)** quintile is stored on `Case.index_of_multiple_deprivation_quintile`. The correct IMD year to use depends on the patient's **cohort**:
+
+- Cohort < 8 → 2019 IMD (England 2019 / Wales 2019, based on 2011 LSOA boundaries)
+- Cohort ≥ 8 → 2025 IMD (England 2025, based on 2021 LSOA boundaries; Wales still 2019)
+
+The cohort is stored on `Registration` and is derived from `Registration.first_paediatric_assessment_date`. The RCPCH Census Platform API was updated to **v2**, which now accepts a `year` parameter (`2019` or `2025`) in the IMD endpoint.
+
+### The problem with putting IMD in `Case.save()`
+
+`Case` and `Registration` have a 1-to-1 relation, but they can be created in either order. If IMD is calculated inside `Case.save()`, the Registration (and therefore the cohort) may not exist yet on first save, making it impossible to know the correct year. Workarounds inside `save()` grow complexity and can cause `ValueError` when filtering on an unsaved instance.
+
+### Current design: signal-driven utility
+
+IMD is calculated in a **single utility function** and triggered by **`post_save` signals** on both models:
+
+```
+epilepsy12/general_functions/index_multiple_deprivation.py
+  └── recalculate_imd_for_case(case)
+        - no-op if postcode missing or unknown
+        - no-op if Registration or cohort not yet available
+        - derives imd_year from registration.cohort
+        - calls imd_for_postcode(postcode, year=imd_year) once
+        - persists via queryset .update() to avoid re-triggering Case.save()
+```
+
+```
+epilepsy12/signals.py
+  ├── pre_save / post_save on Case
+  │     → fires recalculate_imd_for_case when postcode changes
+  └── pre_save / post_save on Registration
+        → fires recalculate_imd_for_case when first_paediatric_assessment_date changes
+```
+
+`Case.save()` itself only normalises the postcode (strip spaces/dashes, uppercase) and updates geolocation coordinates (`location_wgs84`, `location_bng`). It sets `index_of_multiple_deprivation_quintile = None` when postcode switches to an unknown/placeholder value.
+
+### Bulk recalculation
+
+To recalculate IMD for existing records (e.g. after a cohort boundary change or API update):
+
+```bash
+s/recalculate-imd          # all cohorts
+s/recalculate-imd 6        # cohort 6 only
+```
+
+This wraps `manage.py recalculate_imd --all` / `--cohort N` (`epilepsy12/management/commands/recalculate_imd.py`).
+
+### Key constants
+
+| Setting | Location |
+|---|---|
+| `RCPCH_CENSUS_PLATFORM_URL` | `settings.py` / `.env` |
+| `RCPCH_CENSUS_PLATFORM_TOKEN` | `settings.py` / `.env` |
+| `UNKNOWN_POSTCODES_NO_SPACES` | `epilepsy12/constants/postcodes.py` |
+
+---
+
+## Areas to Expand
+
+The following sections will be added over time:
+
+- `epilepsy12/` app structure (models, views, forms, KPIs, migrations)
+- `epilepsy12/models_folder/` — domain model breakdown
+- `epilepsy12/views/` — view organisation and HTMX patterns
+- `epilepsy12/constants/` — audit constants and clinical coding
+- `epilepsy12/management/commands/` — custom management commands including `seed`
+- `epilepsy12/tests/` — test structure and pytest markers
+- `epilepsy12/common_view_functions/` — shared view logic
+- KPI calculation logic (`kpi.py`, `organisational_audit.py`)
+- Permissions and decorator patterns
+- Celery / celerybeat scheduled tasks
+- REST API (serializers, DRF)
+- Template and HTMX patterns

--- a/documentation/docs/development/imd.md
+++ b/documentation/docs/development/imd.md
@@ -13,6 +13,6 @@ Index of multiple deprivation is dependent on geography, and the underlying assu
 
 The country is first broken into areas of similar population size, known as low layer super output areas (LSOAs) and the findings for each measure summarized at this level. The LSOAs are then ranked in order by raw score, with the lower raw scores representing the least deprived. These are then broken into quantiles, depending on the size of the population / reporting priorities. It is typical to report as deciles or quintiles.
 
-The last English data was published in 2019, with Wales the same year.
+The last English data was published in 2019 and updated in 2025. Wales was published in 2019.
 
 Jersey has recently been added to Epilepsy12 and is currently not supported by the RCPCH Census Platform. Because the population is small (~100,000), IMD is reported in vingtaines, rather than quintiles or deciles. The actual data is not published and is being requested for inclusion. In Epilepsy12 currently IMD quantiles are therefore not reported.

--- a/documentation/docs/development/postcodes.md
+++ b/documentation/docs/development/postcodes.md
@@ -12,3 +12,16 @@ Postcodes are used primarily to calculate indices of multiple deprivation, but a
 Postcodes are passed to `api.rcpch.ac.uk/postcodes`. This is an RCPCH managed instance of the `postcodes.io` and requires an api key. It reports information against postcode which include LSOA (see Indices of Multiple Deprivation) as well as longitude and latitude. These latter data points are used for scatter plots.
 
 Jersey is currently not supported as there is no open source solution for mapping currently though this is tracked in a [github issue](https://github.com/rcpch/rcpch-audit-engine/issues/1107)
+
+## Postcode and IMD
+
+To calculate an IMD we need the year for England as new data was published in 2025.
+
+If the patient is in cohort 8, this will by default use 2025 data. Earlier cohorts will use 2019.
+
+To recalculate all postcodes in a given cohort use the convenience script:
+
+```console
+s/recalculate-imd        # all cohorts
+s/recalculate-imd 6      # cohort 6 only
+```

--- a/epilepsy12/general_functions/index_multiple_deprivation.py
+++ b/epilepsy12/general_functions/index_multiple_deprivation.py
@@ -9,29 +9,85 @@ import requests
 # Third party imports
 from django.conf import settings
 
-# RCPCH imports
-
 # Logging setup
 logger = logging.getLogger(__name__)
 
 
-def imd_for_postcode(user_postcode: str) -> int:
+def imd_for_postcode(user_postcode: str, year: int = 2019) -> int | None:
     """
-    Makes an API call to the RCPCH Census Platform with postcode and quantile_type
+    Makes an API call to the RCPCH Census Platform with postcode, quantile_type and IMD year to get the quantile for the given postcode and quantile type.
+    The English IMD have 2019 and 2025 versions, the Welsh only 2019.
     Postcode - can have spaces or not - this is processed by the API
     Quantile - this is an integer representing what quantiles are requested (eg quintile, decile etc)
+    Returns the quantile for the given postcode and quantile type, or None if there was an error
     """
-
+    if year not in [2019, 2025]:
+        logger.error("Invalid year %s for IMD. Must be 2019 or 2025", year)
+        return None
     response = requests.get(
-        url=f"{settings.RCPCH_CENSUS_PLATFORM_URL}/index_of_multiple_deprivation_quantile?postcode={user_postcode}&quantile=5",
+        url=f"{settings.RCPCH_CENSUS_PLATFORM_URL}/index_of_multiple_deprivation_quantile?postcode={user_postcode}&quantile=5&year={year}",
         headers={"Subscription-Key": f"{settings.RCPCH_CENSUS_PLATFORM_TOKEN}"},
         timeout=10,  # times out after 10 seconds
     )
 
     if response.status_code != 200:
         logger.error(
-            "Could not get deprivation score for %s. Response status %s", user_postcode, response.status_code
+            "Could not get deprivation score for %s. Response status %s",
+            user_postcode,
+            response.status_code,
         )
         return None
 
     return response.json()["result"]["data_quantile"]
+
+
+def recalculate_imd_for_case(case) -> None:
+    """
+    Recalculates the IMD quintile for a Case and persists only that field.
+
+    No-op if any of the following are true:
+    - case.postcode is absent or an unknown/placeholder postcode
+    - case has no Registration yet, or Registration.cohort is not yet set
+
+    Uses queryset .update() rather than case.save() to avoid re-triggering
+    Case.post_save signals and coordinate lookups.
+    Also updates the in-memory instance so the caller sees the new value.
+    """
+    from ..constants import UNKNOWN_POSTCODES_NO_SPACES
+
+    postcode = case.postcode
+    if not postcode:
+        return
+
+    normalised = postcode.replace(" ", "").replace("-", "").upper()
+    if normalised in UNKNOWN_POSTCODES_NO_SPACES:
+        return
+
+    try:
+        registration = case.registration
+    except Exception:
+        # No registration exists yet — IMD will be recalculated once Registration is saved.
+        return
+
+    if registration is None or registration.cohort is None:
+        return
+
+    imd_year = 2025 if registration.cohort >= 8 else 2019
+
+    try:
+        quintile = imd_for_postcode(normalised, year=imd_year)
+    except Exception as error:
+        logger.exception(
+            "Cannot calculate deprivation score for %s: %s", normalised, error
+        )
+        quintile = None
+
+    # Use queryset update to skip Case.save() and its signals entirely.
+    from django.apps import apps
+
+    Case = apps.get_model("epilepsy12", "Case")
+    Case.objects.filter(pk=case.pk).update(
+        index_of_multiple_deprivation_quintile=quintile
+    )
+    # Keep the in-memory object consistent.
+    case.index_of_multiple_deprivation_quintile = quintile

--- a/epilepsy12/management/commands/recalculate_imd.py
+++ b/epilepsy12/management/commands/recalculate_imd.py
@@ -1,0 +1,97 @@
+"""
+Management command to recalculate the Index of Multiple Deprivation (IMD) quintile
+for all Cases in a given cohort (or all cohorts).
+
+Usage:
+    # All cases across all cohorts:
+    python manage.py recalculate_imd --all
+
+    # All cases in cohort 6:
+    python manage.py recalculate_imd --cohort 6
+
+Or via the convenience script:
+    s/recalculate-imd        # all cohorts
+    s/recalculate-imd 6      # cohort 6 only
+"""
+
+# Standard imports
+import logging
+
+# Django imports
+from django.core.management.base import BaseCommand, CommandError
+
+# RCPCH imports
+from epilepsy12.models import Case
+from epilepsy12.general_functions.index_multiple_deprivation import (
+    recalculate_imd_for_case,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Recalculate IMD quintile for all Cases in a given cohort (or all cohorts)."
+
+    def add_arguments(self, parser):
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument(
+            "--cohort",
+            type=int,
+            metavar="N",
+            help="Recalculate only for cases in this cohort number.",
+        )
+        group.add_argument(
+            "--all",
+            action="store_true",
+            dest="all_cohorts",
+            help="Recalculate for all cases regardless of cohort.",
+        )
+
+    def handle(self, *args, **options):
+        if options["all_cohorts"]:
+            cases = Case.objects.select_related("registration").all()
+            self.stdout.write("Recalculating IMD for all cases…")
+        else:
+            cohort = options["cohort"]
+            cases = Case.objects.select_related("registration").filter(
+                registration__cohort=cohort
+            )
+            self.stdout.write(f"Recalculating IMD for cohort {cohort}…")
+
+        total = cases.count()
+        if total == 0:
+            self.stdout.write(self.style.WARNING("No matching cases found."))
+            return
+
+        success = 0
+        skipped = 0
+        errors = 0
+
+        for ix, case in enumerate(cases, 1):
+            try:
+                before = case.index_of_multiple_deprivation_quintile
+                recalculate_imd_for_case(case)
+                after = case.index_of_multiple_deprivation_quintile
+
+                if after is None and not case.postcode:
+                    skipped += 1
+                    self.stdout.write(
+                        f"  [{ix}/{total}] Case {case.pk}: skipped (no postcode)"
+                    )
+                else:
+                    success += 1
+                    self.stdout.write(
+                        f"  [{ix}/{total}] Case {case.pk}: {before} → {after}"
+                    )
+            except Exception as exc:
+                errors += 1
+                self.stderr.write(
+                    self.style.ERROR(f"  [{ix}/{total}] Case {case.pk}: ERROR — {exc}")
+                )
+                logger.exception("recalculate_imd failed for case %s", case.pk)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\nDone. {success} updated, {skipped} skipped, {errors} errors (total {total})."
+            )
+        )

--- a/epilepsy12/models_folder/case.py
+++ b/epilepsy12/models_folder/case.py
@@ -9,6 +9,7 @@ from django.contrib.gis.geos import Point
 from django.conf import settings
 
 # 3rd party
+from gunicorn import app
 from simple_history.models import HistoricalRecords
 
 # epilepsy12
@@ -23,7 +24,6 @@ from ..constants import (
     CAN_CONSENT_TO_AUDIT_PARTICIPATION,
 )
 from ..general_functions import (
-    imd_for_postcode,
     coordinates_for_postcode,
     stringify_time_elapsed,
 )
@@ -187,32 +187,20 @@ class Case(TimeStampAbstractBaseClass, UserStampAbstractBaseClass, HelpTextMixin
         return self.registration.days_remaining_before_submission > 0
 
     def save(self, *args, **kwargs) -> None:
-        # calculate the index of multiple deprivation quintile if the postcode is present
-        # Skips the calculation if the postcode is on the 'unknown' list
+        # Normalise postcode and update geolocation coordinates.
+        # IMD quintile is calculated separately via post_save signals on Case and Registration
+        # (see epilepsy12/signals.py and general_functions/index_multiple_deprivation.py).
         if self.postcode:
             if (
                 str(self.postcode).replace(" ", "").replace("-", "")
                 not in UNKNOWN_POSTCODES_NO_SPACES
             ):
-                # capitalize all characters, remove dashes and spaces
+                # Capitalise all characters, remove dashes and spaces
                 self.postcode = (
                     str(self.postcode).replace(" ", "").replace("-", "").upper()
                 )
 
-                # get IMD for postcode from census platform: note, assumes postcode is valid
-                try:
-                    self.index_of_multiple_deprivation_quintile = imd_for_postcode(
-                        self.postcode
-                    )
-                except Exception as error:
-                    # Deprivation score not persisted if deprivation score server down
-                    self.index_of_multiple_deprivation_quintile = None
-                    logger.exception(
-                        f"Cannot calculate deprivation score for {self.postcode}: {error}"
-                    )
-                    pass
-
-                # update the longitude and latitude
+                # Update the longitude and latitude
                 """
                 The SRID (Spatial Reference System Identifier) 27700 refers to the British National Grid (BNG), a common system used for mapping in the UK. It uses Eastings and Northings, rather than longitude & latitude.
                 This system is different from the more common geographic coordinate systems like WGS 84 (SRID 4326), which is used by most global datasets including GPS and many web APIs.
@@ -248,8 +236,7 @@ class Case(TimeStampAbstractBaseClass, UserStampAbstractBaseClass, HelpTextMixin
                     )
                     pass
             else:
-                # if the IMD quintile has previously been added and postcode now unknown, set
-                # index_of_multiple_deprivation_quintile back to None
+                # Postcode is an unknown/placeholder — clear IMD and location
                 self.index_of_multiple_deprivation_quintile = None
                 self.location_wgs84 = None
                 self.location_bng = None

--- a/epilepsy12/signals.py
+++ b/epilepsy12/signals.py
@@ -462,7 +462,9 @@ def _send_admin_notification(user, changes, current_user):
     try:
         if settings.CHANGE_NOTIFICATION_EMAILS:
             send_email_to_recipients(
-                recipients=settings.CHANGE_NOTIFICATION_EMAILS, subject=subject, message=message
+                recipients=settings.CHANGE_NOTIFICATION_EMAILS,
+                subject=subject,
+                message=message,
             )
             logger.info(f"Admin notification sent for user changes: {user.email}")
     except Exception as e:
@@ -486,7 +488,9 @@ def _send_user_creation_notification(user, current_user):
     try:
         if settings.CHANGE_NOTIFICATION_EMAILS:
             send_email_to_recipients(
-                recipients=settings.CHANGE_NOTIFICATION_EMAILS, subject=subject, message=message
+                recipients=settings.CHANGE_NOTIFICATION_EMAILS,
+                subject=subject,
+                message=message,
             )
             logger.info(f"User creation notification sent for: {user.email}")
     except Exception as e:
@@ -568,10 +572,80 @@ def _send_employer_assignment_notification(
     try:
         if settings.CHANGE_NOTIFICATION_EMAILS:
             send_email_to_recipients(
-                recipients=settings.CHANGE_NOTIFICATION_EMAILS, subject=subject, message=message
+                recipients=settings.CHANGE_NOTIFICATION_EMAILS,
+                subject=subject,
+                message=message,
             )
             logger.info(f"Employer assignment notification sent for: {user.email}")
     except Exception as e:
         logger.error(
             f"Failed to send Employer assignment notification for user {user.email}: {e}"
         )
+
+
+# ── IMD recalculation signals ─────────────────────────────────────────────────
+# IMD is computed in one place (recalculate_imd_for_case) and triggered by
+# two events: the postcode on Case changing, or the cohort-determining
+# first_paediatric_assessment_date on Registration changing.
+
+
+def _normalise_postcode(postcode: str | None) -> str | None:
+    """Return a space/dash/case-normalised postcode, or None."""
+    if postcode is None:
+        return None
+    return postcode.replace(" ", "").replace("-", "").upper()
+
+
+@receiver(pre_save, sender="epilepsy12.Case")
+def _capture_case_postcode(sender, instance, **kwargs):
+    """Store the current DB postcode before save so we can detect changes."""
+    if instance.pk:
+        try:
+            instance._original_postcode = sender.objects.get(pk=instance.pk).postcode
+        except sender.DoesNotExist:
+            instance._original_postcode = None
+    else:
+        instance._original_postcode = None
+
+
+@receiver(post_save, sender="epilepsy12.Case")
+def _recalculate_imd_on_case_save(sender, instance, created, **kwargs):
+    """Trigger IMD recalculation when the postcode has changed."""
+    original = _normalise_postcode(getattr(instance, "_original_postcode", None))
+    current = _normalise_postcode(instance.postcode)
+    if created or current != original:
+        from .general_functions.index_multiple_deprivation import (
+            recalculate_imd_for_case,
+        )
+
+        recalculate_imd_for_case(instance)
+
+
+@receiver(pre_save, sender="epilepsy12.Registration")
+def _capture_registration_assessment_date(sender, instance, **kwargs):
+    """Store the current first_paediatric_assessment_date before save."""
+    if instance.pk:
+        try:
+            instance._original_assessment_date = sender.objects.get(
+                pk=instance.pk
+            ).first_paediatric_assessment_date
+        except sender.DoesNotExist:
+            instance._original_assessment_date = None
+    else:
+        instance._original_assessment_date = None
+
+
+@receiver(post_save, sender="epilepsy12.Registration")
+def _recalculate_imd_on_registration_save(sender, instance, created, **kwargs):
+    """Trigger IMD recalculation when first_paediatric_assessment_date changes."""
+    original = getattr(instance, "_original_assessment_date", None)
+    if created or instance.first_paediatric_assessment_date != original:
+        from .general_functions.index_multiple_deprivation import (
+            recalculate_imd_for_case,
+        )
+
+        try:
+            recalculate_imd_for_case(instance.case)
+        except Exception:
+            # case may not be accessible on the instance in unusual states
+            pass

--- a/epilepsy12/tests/model_tests/test_case.py
+++ b/epilepsy12/tests/model_tests/test_case.py
@@ -55,8 +55,17 @@ def test_case_save_unknown_postcode(e12_case_factory):
 
 
 @pytest.mark.django_db
-def test_case_save_unknown_postcode_when_imd_not_none(e12_case_factory):
-    # Tests that the save method works as expected using one of the 'unknown' postcodes
+@patch("epilepsy12.models_folder.case.coordinates_for_postcode")
+@patch("epilepsy12.general_functions.index_multiple_deprivation.imd_for_postcode")
+def test_case_save_unknown_postcode_when_imd_not_none(
+    mock_imd_for_postcode, mock_coordinates_for_postcode, e12_case_factory
+):
+    # Tests that switching to an unknown postcode clears the IMD quintile.
+    # Mocks are needed because factory creates a Case with a real postcode,
+    # which triggers an IMD lookup via the Registration post_save signal.
+    mock_coordinates_for_postcode.return_value = (-0.1234, 51.5678)
+    mock_imd_for_postcode.return_value = 4
+
     e12Case = e12_case_factory(
         postcode="WC1X 8SH", index_of_multiple_deprivation_quintile=4
     )
@@ -67,13 +76,14 @@ def test_case_save_unknown_postcode_when_imd_not_none(e12_case_factory):
 
 @pytest.mark.django_db
 @patch("epilepsy12.models_folder.case.coordinates_for_postcode")
-@patch("epilepsy12.models_folder.case.imd_for_postcode")
+@patch("epilepsy12.general_functions.index_multiple_deprivation.imd_for_postcode")
 def test_case_save_postcode_obtain_imdq(
     mock_imd_for_postcode, mock_coordinates_for_postcode, e12_case_factory
 ):
     """
     Tests that the save method works as expected using a known postcode IMD.
     Mocks both the coordinates API and the IMD calculation API.
+    IMD is now calculated via recalculate_imd_for_case (called from post_save signal).
     """
     # Mock the coordinates API response
     mock_coordinates_for_postcode.return_value = (-0.1234, 51.5678)
@@ -87,15 +97,19 @@ def test_case_save_postcode_obtain_imdq(
 
     # Verify both mocks were called
     mock_coordinates_for_postcode.assert_called_once_with(postcode="WC1X8SH")
-    mock_imd_for_postcode.assert_called_once_with("WC1X8SH")
+    mock_imd_for_postcode.assert_called_once_with("WC1X8SH", year=2019)
 
     # Verify the IMD was set correctly
     assert e12Case.index_of_multiple_deprivation_quintile == 4
 
 
 @pytest.mark.django_db
-def test_case_save_invalid_postcode(e12_case_factory):
-    # Tests that the save method works as expected using an invalid postcode
+@patch("epilepsy12.general_functions.index_multiple_deprivation.imd_for_postcode")
+def test_case_save_invalid_postcode(mock_imd_for_postcode, e12_case_factory):
+    # Tests that the save method works as expected using an invalid postcode.
+    # IMD is mocked to avoid real network calls; invalid postcodes return None.
+    mock_imd_for_postcode.return_value = None
+
     e12Case = e12_case_factory(index_of_multiple_deprivation_quintile=None)
     e12Case.postcode = "GARBAGE"
     e12Case.save()
@@ -105,7 +119,7 @@ def test_case_save_invalid_postcode(e12_case_factory):
 
 @pytest.mark.django_db
 @patch("epilepsy12.models_folder.case.coordinates_for_postcode")
-@patch("epilepsy12.models_folder.case.imd_for_postcode")
+@patch("epilepsy12.general_functions.index_multiple_deprivation.imd_for_postcode")
 def test_case_overwrite_index_of_multiple_deprivation_quintile(
     mock_imd_for_postcode, mock_coordinates_for_postcode, e12_case_factory
 ):
@@ -121,6 +135,6 @@ def test_case_overwrite_index_of_multiple_deprivation_quintile(
     e12Case.save()
     # Verify both mocks were called
     mock_coordinates_for_postcode.assert_called_once_with(postcode="WC1X8SH")
-    mock_imd_for_postcode.assert_called_once_with("WC1X8SH")
+    mock_imd_for_postcode.assert_called_once_with("WC1X8SH", year=2019)
     assert e12Case.postcode == "WC1X8SH"
     assert e12Case.index_of_multiple_deprivation_quintile == 4

--- a/epilepsy12/tests/model_tests/test_imd.py
+++ b/epilepsy12/tests/model_tests/test_imd.py
@@ -20,7 +20,9 @@ from datetime import date
 from unittest.mock import patch, call
 
 # RCPCH imports
-from epilepsy12.general_functions.index_multiple_deprivation import recalculate_imd_for_case
+from epilepsy12.general_functions.index_multiple_deprivation import (
+    recalculate_imd_for_case,
+)
 
 IMD_PATCH = "epilepsy12.general_functions.index_multiple_deprivation.imd_for_postcode"
 COORDS_PATCH = "epilepsy12.models_folder.case.coordinates_for_postcode"
@@ -32,9 +34,7 @@ COORDS_PATCH = "epilepsy12.models_folder.case.coordinates_for_postcode"
 @pytest.mark.django_db
 @patch(COORDS_PATCH)
 @patch(IMD_PATCH)
-def test_imd_uses_2019_for_cohort_below_8(
-    mock_imd, mock_coords, e12_case_factory
-):
+def test_imd_uses_2019_for_cohort_below_8(mock_imd, mock_coords, e12_case_factory):
     """Cohort 7 (assessment date in 2024) should call the API with year=2019."""
     mock_coords.return_value = (-0.1234, 51.5678)
     mock_imd.return_value = 3
@@ -53,9 +53,7 @@ def test_imd_uses_2019_for_cohort_below_8(
 @pytest.mark.django_db
 @patch(COORDS_PATCH)
 @patch(IMD_PATCH)
-def test_imd_uses_2025_for_cohort_8_and_above(
-    mock_imd, mock_coords, e12_case_factory
-):
+def test_imd_uses_2025_for_cohort_8_and_above(mock_imd, mock_coords, e12_case_factory):
     """Cohort 8 (assessment date in 2025) should call the API with year=2025."""
     mock_coords.return_value = (-0.1234, 51.5678)
     mock_imd.return_value = 2
@@ -185,6 +183,7 @@ def test_imd_not_calculated_when_no_registration(
     # cache is cleared (otherwise case.registration still returns the cached instance).
     case.registration.delete()
     from epilepsy12.models import Case
+
     case = Case.objects.get(pk=case.pk)
     mock_imd.reset_mock()
 
@@ -210,6 +209,7 @@ def test_imd_not_calculated_when_cohort_is_none(
 
     # Force cohort to None without triggering signals
     from epilepsy12.models import Registration
+
     Registration.objects.filter(pk=case.registration.pk).update(cohort=None)
     case.registration.refresh_from_db()
     mock_imd.reset_mock()
@@ -235,6 +235,7 @@ def test_imd_persisted_to_database(mock_imd, mock_coords, e12_case_factory):
     )
 
     from epilepsy12.models import Case
+
     db_value = Case.objects.get(pk=case.pk).index_of_multiple_deprivation_quintile
     assert db_value == 5
 
@@ -242,9 +243,7 @@ def test_imd_persisted_to_database(mock_imd, mock_coords, e12_case_factory):
 @pytest.mark.django_db
 @patch(COORDS_PATCH)
 @patch(IMD_PATCH)
-def test_imd_set_to_none_when_api_returns_none(
-    mock_imd, mock_coords, e12_case_factory
-):
+def test_imd_set_to_none_when_api_returns_none(mock_imd, mock_coords, e12_case_factory):
     """If the API returns None (e.g. postcode not found), IMD should be None."""
     mock_coords.return_value = (-0.1234, 51.5678)
     mock_imd.return_value = None

--- a/epilepsy12/tests/model_tests/test_imd.py
+++ b/epilepsy12/tests/model_tests/test_imd.py
@@ -1,0 +1,258 @@
+"""
+Tests for IMD (Index of Multiple Deprivation) calculation.
+
+IMD is calculated by recalculate_imd_for_case(), triggered via post_save
+signals on Case (postcode change) and Registration (first_paediatric_assessment_date
+change).  The RCPCH Census Platform API accepts a `year` parameter:
+  - cohort < 8  → year=2019
+  - cohort >= 8 → year=2025
+
+All tests mock imd_for_postcode so no real network calls are made.
+
+Cohort reference:
+  Cohort 7: first_paediatric_assessment_date in Dec 2023 – Nov 2024  (year=2019)
+  Cohort 8: first_paediatric_assessment_date in Dec 2024 – Nov 2025  (year=2025)
+"""
+
+# Standard imports
+import pytest
+from datetime import date
+from unittest.mock import patch, call
+
+# RCPCH imports
+from epilepsy12.general_functions.index_multiple_deprivation import recalculate_imd_for_case
+
+IMD_PATCH = "epilepsy12.general_functions.index_multiple_deprivation.imd_for_postcode"
+COORDS_PATCH = "epilepsy12.models_folder.case.coordinates_for_postcode"
+
+
+# ── Correct year selection ──────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+@patch(COORDS_PATCH)
+@patch(IMD_PATCH)
+def test_imd_uses_2019_for_cohort_below_8(
+    mock_imd, mock_coords, e12_case_factory
+):
+    """Cohort 7 (assessment date in 2024) should call the API with year=2019."""
+    mock_coords.return_value = (-0.1234, 51.5678)
+    mock_imd.return_value = 3
+
+    case = e12_case_factory(
+        postcode="WC1X8SH",
+        registration__first_paediatric_assessment_date=date(2024, 6, 1),  # cohort 7
+    )
+
+    case.refresh_from_db()
+    assert case.registration.cohort == 7
+    mock_imd.assert_called_with("WC1X8SH", year=2019)
+    assert case.index_of_multiple_deprivation_quintile == 3
+
+
+@pytest.mark.django_db
+@patch(COORDS_PATCH)
+@patch(IMD_PATCH)
+def test_imd_uses_2025_for_cohort_8_and_above(
+    mock_imd, mock_coords, e12_case_factory
+):
+    """Cohort 8 (assessment date in 2025) should call the API with year=2025."""
+    mock_coords.return_value = (-0.1234, 51.5678)
+    mock_imd.return_value = 2
+
+    case = e12_case_factory(
+        postcode="WC1X8SH",
+        registration__first_paediatric_assessment_date=date(2025, 3, 1),  # cohort 8
+    )
+
+    case.refresh_from_db()
+    assert case.registration.cohort == 8
+    mock_imd.assert_called_with("WC1X8SH", year=2025)
+    assert case.index_of_multiple_deprivation_quintile == 2
+
+
+@pytest.mark.django_db
+@patch(COORDS_PATCH)
+@patch(IMD_PATCH)
+def test_imd_recalculated_when_assessment_date_changes_cohort(
+    mock_imd, mock_coords, e12_case_factory
+):
+    """Changing first_paediatric_assessment_date across the cohort 7→8 boundary
+    should trigger a new IMD call with year=2025."""
+    mock_coords.return_value = (-0.1234, 51.5678)
+    mock_imd.return_value = 1
+
+    case = e12_case_factory(
+        postcode="WC1X8SH",
+        registration__first_paediatric_assessment_date=date(2024, 6, 1),  # cohort 7
+    )
+
+    registration = case.registration
+    assert registration.cohort == 7
+
+    # Advance into cohort 8
+    mock_imd.return_value = 5
+    registration.first_paediatric_assessment_date = date(2025, 3, 1)
+    registration.save()
+
+    case.refresh_from_db()
+    assert case.registration.cohort == 8
+    mock_imd.assert_called_with("WC1X8SH", year=2025)
+    assert case.index_of_multiple_deprivation_quintile == 5
+
+
+# ── Postcode triggers ───────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+@patch(COORDS_PATCH)
+@patch(IMD_PATCH)
+def test_imd_recalculated_when_postcode_changes(
+    mock_imd, mock_coords, e12_case_factory
+):
+    """Saving a Case with a new postcode should trigger a fresh IMD lookup."""
+    mock_coords.return_value = (-0.1234, 51.5678)
+    mock_imd.return_value = 2
+
+    case = e12_case_factory(
+        postcode="WC1X8SH",
+        registration__first_paediatric_assessment_date=date(2024, 6, 1),
+    )
+
+    mock_imd.return_value = 4
+    case.postcode = "EC1A1BB"
+    case.save()
+
+    case.refresh_from_db()
+    mock_imd.assert_called_with("EC1A1BB", year=2019)
+    assert case.index_of_multiple_deprivation_quintile == 4
+
+
+# ── No-op cases ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+@patch(IMD_PATCH)
+def test_imd_not_calculated_when_postcode_is_none(mock_imd, e12_case_factory):
+    """A case with no postcode should never call the IMD API."""
+    case = e12_case_factory(postcode=None, index_of_multiple_deprivation_quintile=None)
+    mock_imd.assert_not_called()
+    assert case.index_of_multiple_deprivation_quintile is None
+
+
+@pytest.mark.django_db
+@patch(COORDS_PATCH)
+@patch(IMD_PATCH)
+def test_imd_not_calculated_for_unknown_postcode(
+    mock_imd, mock_coords, e12_case_factory
+):
+    """A case with an 'unknown' placeholder postcode should not call the API."""
+    mock_coords.return_value = (-0.1234, 51.5678)
+    mock_imd.return_value = 3
+
+    # Start with a real postcode (triggers a call on creation)
+    case = e12_case_factory(
+        postcode="WC1X8SH",
+        registration__first_paediatric_assessment_date=date(2024, 6, 1),
+    )
+    mock_imd.reset_mock()
+
+    # Switch to an unknown postcode
+    case.postcode = "ZZ99 3CZ"
+    case.save()
+
+    mock_imd.assert_not_called()
+    case.refresh_from_db()
+    assert case.index_of_multiple_deprivation_quintile is None
+
+
+@pytest.mark.django_db
+@patch(COORDS_PATCH)
+@patch(IMD_PATCH)
+def test_imd_not_calculated_when_no_registration(
+    mock_imd, mock_coords, e12_case_factory
+):
+    """recalculate_imd_for_case should be a no-op when no Registration exists."""
+    mock_coords.return_value = (-0.1234, 51.5678)
+    mock_imd.return_value = 3
+
+    case = e12_case_factory(
+        postcode="WC1X8SH",
+        registration__first_paediatric_assessment_date=date(2024, 6, 1),
+    )
+
+    # Delete the registration, then re-fetch the case so Django's related-object
+    # cache is cleared (otherwise case.registration still returns the cached instance).
+    case.registration.delete()
+    from epilepsy12.models import Case
+    case = Case.objects.get(pk=case.pk)
+    mock_imd.reset_mock()
+
+    # Call utility directly — should exit early without calling the API
+    recalculate_imd_for_case(case)
+    mock_imd.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch(COORDS_PATCH)
+@patch(IMD_PATCH)
+def test_imd_not_calculated_when_cohort_is_none(
+    mock_imd, mock_coords, e12_case_factory
+):
+    """recalculate_imd_for_case should be a no-op when the cohort is not yet set."""
+    mock_coords.return_value = (-0.1234, 51.5678)
+    mock_imd.return_value = 3
+
+    case = e12_case_factory(
+        postcode="WC1X8SH",
+        registration__first_paediatric_assessment_date=date(2024, 6, 1),
+    )
+
+    # Force cohort to None without triggering signals
+    from epilepsy12.models import Registration
+    Registration.objects.filter(pk=case.registration.pk).update(cohort=None)
+    case.registration.refresh_from_db()
+    mock_imd.reset_mock()
+
+    recalculate_imd_for_case(case)
+    mock_imd.assert_not_called()
+
+
+# ── Persistence ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+@patch(COORDS_PATCH)
+@patch(IMD_PATCH)
+def test_imd_persisted_to_database(mock_imd, mock_coords, e12_case_factory):
+    """The IMD quintile returned by the API should be written to the database."""
+    mock_coords.return_value = (-0.1234, 51.5678)
+    mock_imd.return_value = 5
+
+    case = e12_case_factory(
+        postcode="WC1X8SH",
+        registration__first_paediatric_assessment_date=date(2024, 6, 1),
+    )
+
+    from epilepsy12.models import Case
+    db_value = Case.objects.get(pk=case.pk).index_of_multiple_deprivation_quintile
+    assert db_value == 5
+
+
+@pytest.mark.django_db
+@patch(COORDS_PATCH)
+@patch(IMD_PATCH)
+def test_imd_set_to_none_when_api_returns_none(
+    mock_imd, mock_coords, e12_case_factory
+):
+    """If the API returns None (e.g. postcode not found), IMD should be None."""
+    mock_coords.return_value = (-0.1234, 51.5678)
+    mock_imd.return_value = None
+
+    case = e12_case_factory(
+        postcode="WC1X8SH",
+        registration__first_paediatric_assessment_date=date(2024, 6, 1),
+    )
+
+    case.refresh_from_db()
+    assert case.index_of_multiple_deprivation_quintile is None

--- a/epilepsy12/tests/view_tests/db_actions/test_create_actions.py
+++ b/epilepsy12/tests/view_tests/db_actions/test_create_actions.py
@@ -1,5 +1,6 @@
 import pytest
 import nhs_number
+from unittest.mock import patch
 
 from django.urls import reverse
 
@@ -94,9 +95,11 @@ def test_mainland_patients_cant_have_urn(
 
 
 @pytest.mark.django_db
+@patch("epilepsy12.models_folder.case.coordinates_for_postcode")
 def test_mix_of_mainland_and_jersey_patients(
-    client, seed_groups_fixture, seed_users_fixture
+    mock_coords, client, seed_groups_fixture, seed_users_fixture
 ):
+    mock_coords.return_value = (-0.1234, 51.5678)
     KINGS = Organisation.objects.get(ods_code="RJZ01")
     JERSEY = Organisation.objects.get(ods_code="RGT1W")
 
@@ -147,7 +150,11 @@ def test_mix_of_mainland_and_jersey_patients(
 
 # https://github.com/rcpch/rcpch-audit-engine/issues/1190
 @pytest.mark.django_db
-def test_create_two_patients(client, seed_groups_fixture, seed_users_fixture):
+@patch("epilepsy12.models_folder.case.coordinates_for_postcode")
+def test_create_two_patients(
+    mock_coords, client, seed_groups_fixture, seed_users_fixture
+):
+    mock_coords.return_value = (-0.1234, 51.5678)
     KINGS = Organisation.objects.get(ods_code="RJZ01")
 
     test_user = Epilepsy12User.objects.filter(role=AUDIT_CENTRE_LEAD_CLINICIAN).first()

--- a/epilepsy12/tests/view_tests/permissions_tests/test_permissions_create.py
+++ b/epilepsy12/tests/view_tests/permissions_tests/test_permissions_create.py
@@ -94,6 +94,7 @@
 import pytest
 from http import HTTPStatus
 from datetime import date
+from unittest.mock import patch
 
 # django imports
 from django.urls import reverse
@@ -427,9 +428,12 @@ def test_rcpch_staff_can_create_rcpch_staff_user(
 
 
 @pytest.mark.django_db
+@patch("epilepsy12.models_folder.case.coordinates_for_postcode")
 def test_patient_create_success(
+    mock_coords,
     client,
 ):
+    mock_coords.return_value = (-0.1234, 51.5678)
     """Integration test checking functionality of view and form.
 
     Simulating different E12 users with different roles attempting to create Patients inside own trust.

--- a/epilepsy12/views/organisation_views.py
+++ b/epilepsy12/views/organisation_views.py
@@ -1,7 +1,10 @@
 # Python imports
 from datetime import date
+import json
+import math
 
 # third party libraries
+from django.conf import settings
 from django.shortcuts import render
 from django.urls import reverse
 from django.contrib.auth.decorators import permission_required
@@ -16,7 +19,13 @@ from epilepsy12.models_folder.entities.local_health_board import LocalHealthBoar
 # E12 imports
 from ..decorator import user_may_view_this_organisation, login_and_otp_required
 from epilepsy12.constants import INDIVIDUAL_KPI_MEASURES, EnumAbstractionLevel
-from epilepsy12.models import Organisation, KPI, OrganisationKPIAggregation, OrganisationalAuditSubmissionPeriod, Trust
+from epilepsy12.models import (
+    Organisation,
+    KPI,
+    OrganisationKPIAggregation,
+    OrganisationalAuditSubmissionPeriod,
+    Trust,
+)
 from ..common_view_functions import (
     cases_aggregated_by_sex,
     cases_aggregated_by_ethnicity,
@@ -27,7 +36,6 @@ from ..common_view_functions import (
     logged_in_user_may_access_this_organisation,
     filter_all_registered_cases_by_active_lead_site_and_cohort_and_level_of_abstraction,
     generate_dataframe_and_aggregated_distance_data_from_cases,
-    generate_distance_from_organisation_scatterplot_figure,
     generate_case_count_choropleth_map,
     piechart_plot_cases_by_ethnicity,
     piechart_plot_cases_by_index_of_multiple_deprivation,
@@ -65,44 +73,49 @@ def selected_organisation_summary_select(request):
     )
     return HttpResponseClientRedirect(response)
 
+
 @login_and_otp_required()
 def filter_organisations_by_parent(request, parent_id, parent_type):
     """
     HTMX callback when parent dropdown changes.
     Since the entire dashboard is tied to the selected organisation,
     we redirect to the first organisation in the selected parent.
-    
+
     Params:
     parent_id: primary key of selected parent trust or local health board
     parent_type: string, one of ['trust', 'local_health_board']
     """
-    
+
     # If HTMX posts the selected parent in the body, extract both id and type
     # Format: "parent_id:parent_type" (e.g., "5:trust" or "12:local_health_board")
     posted_parent = request.POST.get("selected_parent_summary_select")
-    if posted_parent and ':' in posted_parent:
+    if posted_parent and ":" in posted_parent:
         try:
-            parent_id_str, parent_type = posted_parent.split(':', 1)
+            parent_id_str, parent_type = posted_parent.split(":", 1)
             parent_id = int(parent_id_str)
         except (ValueError, TypeError):
             # Ignore and use URL parameters
             pass
 
     # Filter organisations by parent type
-    if parent_type == 'trust':
+    if parent_type == "trust":
         organisations = Organisation.objects.filter(trust__id=parent_id, active=True)
     else:  # local_health_board
-        organisations = Organisation.objects.filter(local_health_board__id=parent_id, active=True)
+        organisations = Organisation.objects.filter(
+            local_health_board__id=parent_id, active=True
+        )
 
     # Apply user access restrictions if not admin
     if not (request.user.is_rcpch_staff or request.user.is_superuser):
         allowed_orgs = organisation_white_list_for_user(request.user)
-        organisations = organisations.filter(id__in=allowed_orgs.values_list('id', flat=True))
-    
+        organisations = organisations.filter(
+            id__in=allowed_orgs.values_list("id", flat=True)
+        )
+
     # Get the first organisation in the filtered list and redirect to it
     # This triggers a full page reload with all the organisation-specific data
-    selected_organisation = organisations.order_by('name').first()
-    
+    selected_organisation = organisations.order_by("name").first()
+
     if selected_organisation:
         response = reverse(
             "selected_organisation_summary",
@@ -113,10 +126,11 @@ def filter_organisations_by_parent(request, parent_id, parent_type):
         # No organisations found for this parent
         # This should not happen if parent_list is properly filtered
         from django.http import HttpResponse
+
         return HttpResponse(
             f"No organisations found for the selected {'trust' if parent_type == 'trust' else 'local health board'}. "
-            "Please contact support if this issue persists.", 
-            status=404
+            "Please contact support if this issue persists.",
+            status=404,
         )
 
 
@@ -167,12 +181,47 @@ def selected_organisation_summary(request, organisation_id):
         )
     )
 
-    # generate scatterplot of cases by distance from the selected organisation
+    # IMD tile era: cohorts < 8 use 2011 LSOA boundaries (2019 IMD),
+    # cohorts >= 8 use 2021 LSOA boundaries (2025 IMD)
+    imd_tile_era = "2011" if cohort_number < 8 else "2021"
 
-    scatterplot_of_cases_for_selected_organisation = (
-        generate_distance_from_organisation_scatterplot_figure(
-            geo_df=case_distances_dataframe, organisation=selected_organisation
-        )
+    # Serialise case locations as GeoJSON for the MapLibre deprivation map
+    _case_features = []
+    if not case_distances_dataframe.empty:
+        _required = {"latitude", "longitude"}
+        if _required.issubset(case_distances_dataframe.columns):
+            for _, _row in case_distances_dataframe.dropna(
+                subset=["latitude", "longitude"]
+            ).iterrows():
+                _props = {}
+                for _col in (
+                    "pk",
+                    "distance_mi",
+                    "distance_km",
+                    "epilepsy12_sites__organisation__name",
+                ):
+                    if _col in case_distances_dataframe.columns:
+                        _val = _row[_col]
+                        _props[_col] = (
+                            None
+                            if (isinstance(_val, float) and math.isnan(_val))
+                            else _val
+                        )
+                _case_features.append(
+                    {
+                        "type": "Feature",
+                        "geometry": {
+                            "type": "Point",
+                            "coordinates": [
+                                float(_row["longitude"]),
+                                float(_row["latitude"]),
+                            ],
+                        },
+                        "properties": _props,
+                    }
+                )
+    cases_geojson = json.dumps(
+        {"type": "FeatureCollection", "features": _case_features}
     )
 
     # differentiate between England and Wales
@@ -283,8 +332,7 @@ def selected_organisation_summary(request, organisation_id):
         organisation_list = Organisation.objects.get_organisation_list()
         # Get merged parent list for all active organisations
         parent_list = merged_parent_list_for_user(
-            epilepsy12_user=request.user,
-            organisation_list=organisation_list
+            epilepsy12_user=request.user, organisation_list=organisation_list
         )
     else:
         # Regular users: organisation list is scoped to the organisations in the user's organisation_employer list and their siblings
@@ -293,26 +341,23 @@ def selected_organisation_summary(request, organisation_id):
         )
         # Get merged parent list only for organisations the user has access to
         parent_list = merged_parent_list_for_user(
-            epilepsy12_user=request.user,
-            organisation_list=organisation_list
+            epilepsy12_user=request.user, organisation_list=organisation_list
         )
 
     # Filter organisation_list to only show organisations within the selected parent
     # This makes the organisation dropdown dependent on the parent dropdown
     if selected_organisation.trust:
         organisation_list = organisation_list.filter(trust=selected_parent)
-        parent_type = 'trust'
+        parent_type = "trust"
     elif selected_organisation.local_health_board:
         organisation_list = organisation_list.filter(local_health_board=selected_parent)
-        parent_type = 'local_health_board'
+        parent_type = "local_health_board"
     else:
         # Organisation has no parent (shouldn't happen in practice)
         parent_type = None
 
     organisational_audit_submission_period = (
-        OrganisationalAuditSubmissionPeriod.objects
-        .order_by("-year")
-        .first()
+        OrganisationalAuditSubmissionPeriod.objects.order_by("-year").first()
     )
 
     context = {
@@ -353,7 +398,12 @@ def selected_organisation_summary(request, organisation_id):
         "count_of_all_current_cohort_registered_cases_in_this_trust": count_of_all_current_cohort_registered_cases_in_this_trust,
         "count_of_current_cohort_registered_completed_cases_in_this_trust": count_of_current_cohort_registered_completed_cases_in_this_trust,
         "individual_kpi_choices": INDIVIDUAL_KPI_MEASURES,
-        "organisation_cases_map": scatterplot_of_cases_for_selected_organisation,
+        "cases_geojson": cases_geojson,
+        "imd_tile_era": imd_tile_era,
+        "deprivation_tiles_url": settings.RCPCH_DEPRIVATION_TILES_URL,
+        "org_lat": selected_organisation.latitude,
+        "org_lng": selected_organisation.longitude,
+        "org_name": selected_organisation.name,
         "aggregated_distances": aggregated_distances,
         "country_heatmap": country_heatmap,
         "organisational_audit_submission_period": organisational_audit_submission_period,
@@ -418,7 +468,9 @@ def publish_kpis(request, organisation_id):
     organisation = Organisation.objects.get(pk=organisation_id)
 
     # perform aggregations and update all the KPIAggregation models only for clinicians
-    update_all_kpi_agg_models(organisation=organisation, cohort=cohort_number, open_access=True)
+    update_all_kpi_agg_models(
+        organisation=organisation, cohort=cohort_number, open_access=True
+    )
 
     return render(
         request=request,
@@ -472,7 +524,9 @@ def selected_trust_kpis(request, organisation_id, access):
 
         if access == "private":
             # perform aggregations and update all the KPIAggregation models only for clinicians
-            update_all_kpi_agg_models(organisation=organisation, cohort=cohort_number, open_access=False)
+            update_all_kpi_agg_models(
+                organisation=organisation, cohort=cohort_number, open_access=False
+            )
 
         # Gather relevant data specific for this view - still show only published data if this is public view
         all_data = get_all_kpi_aggregation_data_for_view(

--- a/epilepsy12/views/organisation_views.py
+++ b/epilepsy12/views/organisation_views.py
@@ -36,7 +36,6 @@ from ..common_view_functions import (
     logged_in_user_may_access_this_organisation,
     filter_all_registered_cases_by_active_lead_site_and_cohort_and_level_of_abstraction,
     generate_dataframe_and_aggregated_distance_data_from_cases,
-    generate_case_count_choropleth_map,
     piechart_plot_cases_by_ethnicity,
     piechart_plot_cases_by_index_of_multiple_deprivation,
     piechart_plot_cases_by_sex,
@@ -54,6 +53,10 @@ from ..general_functions import (
 from ..kpi import download_kpi_summary_as_csv
 from epilepsy12.common_view_functions.aggregate_by import (
     update_all_kpi_agg_models,
+)
+from epilepsy12.common_view_functions.tiles_for_region import return_tile_for_region
+from epilepsy12.common_view_functions.map_from_shape_file import (
+    generate_case_counts_for_each_region_in_each_abstraction_level,
 )
 
 
@@ -227,42 +230,98 @@ def selected_organisation_summary(request, organisation_id):
         {"type": "FeatureCollection", "features": _case_features}
     )
 
-    # differentiate between England and Wales
+    def _build_boundary_overlay(
+        *,
+        overlay_id,
+        boundary_type,
+        region_key,
+        abstraction_enum,
+        identifier_property,
+        line_color,
+    ):
+        """Create a boundary overlay payload for the frontend map."""
+        region_geojson = json.loads(return_tile_for_region(region_key))
+        case_counts_df = generate_case_counts_for_each_region_in_each_abstraction_level(
+            abstraction_level=abstraction_enum,
+            cohort=cohort_number,
+            organisation=selected_organisation,
+        )
+
+        case_count_by_identifier = {}
+        if not case_counts_df.empty:
+            for _, count_row in case_counts_df.iterrows():
+                identifier = count_row.get("identifier")
+                if identifier is None:
+                    continue
+                raw_cases = count_row.get("cases", 0)
+                case_count_by_identifier[str(identifier)] = int(raw_cases or 0)
+
+        for feature in region_geojson.get("features", []):
+            props = feature.setdefault("properties", {})
+            identifier = props.get(identifier_property)
+            props["boundary_type"] = boundary_type
+            props["boundary_name"] = props.get("name", "Unknown boundary")
+            props["boundary_code"] = identifier if identifier is not None else "N/A"
+            props["case_count"] = case_count_by_identifier.get(str(identifier), 0)
+
+        return {
+            "id": overlay_id,
+            "sourceType": "geojson",
+            "data": region_geojson,
+            "beforeLayerId": "cases-layer",
+            "linePaint": {
+                "line-color": line_color,
+                "line-width": 2,
+                "line-opacity": 0.85,
+            },
+            "fillPaint": {
+                "fill-color": "#000000",
+                "fill-opacity": 0.0,
+            },
+        }
+
+    boundary_overlays = []
+
+    # Always provide Welsh LHB boundaries so they are visible when zooming out from any centre.
+    boundary_overlays.append(
+        _build_boundary_overlay(
+            overlay_id="lhb-boundaries",
+            boundary_type="Local Health Board",
+            region_key="lhb",
+            abstraction_enum=EnumAbstractionLevel.LOCAL_HEALTH_BOARD,
+            identifier_property="ods_code",
+            line_color="#2e7d32",
+        )
+    )
+
+    # Use centre geography to choose trust/LHB denominator for completion summary cards.
     if selected_organisation.country.boundary_identifier == "W92000004":  # Wales
         abstraction_level = "local_health_board"
-        # generate choropleth map of case counts for each level of abstraction
-        lhb_heatmap = generate_case_count_choropleth_map(
-            properties="ods_code",
-            abstraction_level=EnumAbstractionLevel.LOCAL_HEALTH_BOARD,
-            organisation=selected_organisation,
-            cohort=cohort_number,
-        )
     else:
-        # generate choropleth map of case counts for each level of abstraction
-        if selected_organisation.ods_code == "RGT1W":
-            # Jersey is a special case and although is mapped to England, is in the Channel Islands and has no ICB, NHS Region or LHB
-            abstraction_level = "trust"
-        else:
-            abstraction_level = "trust"
-            icb_heatmap = generate_case_count_choropleth_map(
-                properties="ods_code",
-                abstraction_level=EnumAbstractionLevel.ICB,
-                organisation=selected_organisation,
-                cohort=cohort_number,
-            )
-            nhsregion_heatmap = generate_case_count_choropleth_map(
-                properties="region_code",
-                abstraction_level=EnumAbstractionLevel.NHS_ENGLAND_REGION,
-                organisation=selected_organisation,
-                cohort=cohort_number,
-            )
+        abstraction_level = "trust"
 
-    country_heatmap = generate_case_count_choropleth_map(
-        properties="boundary_identifier",
-        abstraction_level=EnumAbstractionLevel.COUNTRY,
-        organisation=selected_organisation,
-        cohort=cohort_number,
-    )
+    # Add English hierarchy overlays for contextual tooltips (not applicable to Jersey).
+    if selected_organisation.ods_code != "RGT1W":
+        boundary_overlays.append(
+            _build_boundary_overlay(
+                overlay_id="icb-boundaries",
+                boundary_type="Integrated Care Board",
+                region_key="icb",
+                abstraction_enum=EnumAbstractionLevel.ICB,
+                identifier_property="ods_code",
+                line_color="#7a1f2b",
+            )
+        )
+        boundary_overlays.append(
+            _build_boundary_overlay(
+                overlay_id="nhs-region-boundaries",
+                boundary_type="NHS England Region",
+                region_key="nhs_england_region",
+                abstraction_enum=EnumAbstractionLevel.NHS_ENGLAND_REGION,
+                identifier_property="region_code",
+                line_color="#6b7280",
+            )
+        )
 
     # query to return all completed E12 cases in the current cohort in this organisation
     count_of_current_cohort_registered_completed_cases_in_this_organisation = (
@@ -402,30 +461,15 @@ def selected_organisation_summary(request, organisation_id):
         "count_of_current_cohort_registered_completed_cases_in_this_trust": count_of_current_cohort_registered_completed_cases_in_this_trust,
         "individual_kpi_choices": INDIVIDUAL_KPI_MEASURES,
         "cases_geojson": cases_geojson,
+        "boundary_overlays_geojson": json.dumps(boundary_overlays),
         "imd_tile_era": imd_tile_era,
         "deprivation_tiles_url": settings.RCPCH_DEPRIVATION_TILES_URL,
         "org_lat": selected_organisation.latitude,
         "org_lng": selected_organisation.longitude,
         "org_name": selected_organisation.name,
         "aggregated_distances": aggregated_distances,
-        "country_heatmap": country_heatmap,
         "organisational_audit_submission_period": organisational_audit_submission_period,
     }
-    if selected_organisation.country.boundary_identifier == "W92000004":
-        context["lhb_heatmap"] = lhb_heatmap
-        context["trust_heatmap"] = None
-        context["icb_heatmap"] = None
-        context["nhsregion_heatmap"] = None
-    else:
-        if selected_organisation.ods_code == "RGT1W":
-            # Jersey is a special case as it is in the Channel Islands and has no ICB, NHS Region or LHB
-            context["trust_heatmap"] = None
-            context["icb_heatmap"] = None
-            context["nhsregion_heatmap"] = None
-        else:
-            context["lhb_heatmap"] = None
-            context["icb_heatmap"] = icb_heatmap
-            context["nhsregion_heatmap"] = nhsregion_heatmap
 
     return render(
         request=request,

--- a/epilepsy12/views/organisation_views.py
+++ b/epilepsy12/views/organisation_views.py
@@ -181,9 +181,12 @@ def selected_organisation_summary(request, organisation_id):
         )
     )
 
-    # IMD tile era: cohorts < 8 use 2011 LSOA boundaries (2019 IMD),
-    # cohorts >= 8 use 2021 LSOA boundaries (2025 IMD)
-    imd_tile_era = "2011" if cohort_number < 8 else "2021"
+    # IMD tile era selection:
+    # - England: cohort < 8 -> 2011 boundaries (2019 IMD), cohort >= 8 -> 2021 boundaries (2025 IMD)
+    # - Wales: all cohorts -> 2011 boundaries (2019 WIMD)
+    # - Other nations: default to 2011 boundaries
+    is_england = selected_organisation.country.boundary_identifier == "E92000001"
+    imd_tile_era = "2021" if (is_england and cohort_number >= 8) else "2011"
 
     # Serialise case locations as GeoJSON for the MapLibre deprivation map
     _case_features = []

--- a/rcpch-audit-engine/settings.py
+++ b/rcpch-audit-engine/settings.py
@@ -86,6 +86,12 @@ RCPCH_HERMES_SERVER_URL = os.getenv("RCPCH_HERMES_SERVER_URL")
 # Mapbox
 MAPBOX_API_KEY = os.getenv("MAPBOX_API_KEY")
 
+# RCPCH Census Platform - deprivation vector tile service
+RCPCH_DEPRIVATION_TILES_URL = os.getenv(
+    "RCPCH_DEPRIVATION_TILES_URL",
+    "https://api.rcpch.ac.uk/deprivation/v2/tiles",
+)
+
 # Application definition
 
 INSTALLED_APPS = [

--- a/s/recalculate-imd
+++ b/s/recalculate-imd
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e  # Exit on error
+
+# Recalculates the IMD (Index of Multiple Deprivation) quintile for Cases.
+# *** The project's containers MUST BE RUNNING! ***
+#
+# Usage:
+#   s/recalculate-imd          — recalculate for ALL cases across all cohorts
+#   s/recalculate-imd 6        — recalculate only for cohort 6
+
+if [ -n "$1" ]; then
+    echo "Recalculating IMD for cohort $1..."
+    docker compose exec django python manage.py recalculate_imd --cohort "$1"
+else
+    echo "Recalculating IMD for all cohorts..."
+    docker compose exec django python manage.py recalculate_imd --all
+fi

--- a/static/js/maps/organisation_cases_map.js
+++ b/static/js/maps/organisation_cases_map.js
@@ -530,6 +530,7 @@
         const laCode = props["la_code"] || "N/A";
         const decile =
           props["imd_decile"] === 0 ? "No data" : props["imd_decile"];
+        const imdYear = props["imd_year"] || props["year"] || "N/A";
 
         const boundaryByType = {};
         if (boundaryContextLayerIds.length > 0) {
@@ -592,7 +593,7 @@
         popup
           .setLngLat(e.lngLat)
           .setHTML(
-            `<strong>${areaName}</strong><br>Code: ${areaCode}<br>LA: ${laName} (${laCode})<br>IMD decile: ${decile}<sup>†</sup>${boundaryContextHtml}`,
+            `<strong>${areaName}</strong><br>Code: ${areaCode}<br>LA: ${laName} (${laCode})<br>IMD year: ${imdYear}<br>IMD decile: ${decile}<sup>†</sup>${boundaryContextHtml}`,
           )
           .addTo(map);
       }

--- a/static/js/maps/organisation_cases_map.js
+++ b/static/js/maps/organisation_cases_map.js
@@ -145,6 +145,8 @@
     const DEPRIVATION_SECONDARY_LAYER_ID = "deprivation-layer-secondary";
     let activeLayerSignature = null;
     let forcedPrimaryLayerName = null;
+    const boundaryContextLayerIds = [];
+    const boundaryOverlayLayerIdsById = {};
 
     function addBoundaryOverlays(overlays) {
       if (!Array.isArray(overlays) || overlays.length === 0) {
@@ -152,53 +154,142 @@
       }
 
       overlays.forEach(function (overlay) {
-        if (
-          !overlay ||
-          !overlay.id ||
-          !overlay.tilesBaseUrl ||
-          !overlay.sourceLayer
-        ) {
+        if (!overlay || !overlay.id) {
           return;
         }
 
         const sourceId = `${overlay.id}-source`;
-        const layerId = `${overlay.id}-layer`;
-        const layerType = overlay.layerType || "line";
-        const paint = overlay.paint || {
-          "line-color": "#003087",
-          "line-width": 1.5,
-          "line-opacity": 0.8,
+        const lineLayerId = `${overlay.id}-line`;
+        const fillLayerId = `${overlay.id}-fill`;
+        const linePaint = overlay.linePaint ||
+          overlay.paint || {
+            "line-color": "#003087",
+            "line-width": 1.5,
+            "line-opacity": 0.8,
+          };
+        const fillPaint = overlay.fillPaint || {
+          "fill-color": "#000000",
+          "fill-opacity": 0,
         };
 
-        if (map.getLayer(layerId)) {
-          map.removeLayer(layerId);
+        if (map.getLayer(fillLayerId)) {
+          map.removeLayer(fillLayerId);
+        }
+        if (map.getLayer(lineLayerId)) {
+          map.removeLayer(lineLayerId);
         }
         if (map.getSource(sourceId)) {
           map.removeSource(sourceId);
         }
 
-        map.addSource(sourceId, {
-          type: "vector",
-          tiles: [overlay.tilesBaseUrl],
-          minzoom: overlay.minzoom != null ? overlay.minzoom : 0,
-          maxzoom: overlay.maxzoom != null ? overlay.maxzoom : 14,
-        });
+        if (overlay.sourceType === "geojson") {
+          map.addSource(sourceId, {
+            type: "geojson",
+            data: overlay.data || { type: "FeatureCollection", features: [] },
+          });
+        } else {
+          if (!overlay.tilesBaseUrl || !overlay.sourceLayer) {
+            return;
+          }
+          map.addSource(sourceId, {
+            type: "vector",
+            tiles: [overlay.tilesBaseUrl],
+            minzoom: overlay.minzoom != null ? overlay.minzoom : 0,
+            maxzoom: overlay.maxzoom != null ? overlay.maxzoom : 14,
+          });
+        }
 
         const beforeId =
           overlay.beforeLayerId && map.getLayer(overlay.beforeLayerId)
             ? overlay.beforeLayerId
             : undefined;
 
-        map.addLayer(
-          {
-            id: layerId,
-            type: layerType,
-            source: sourceId,
-            "source-layer": overlay.sourceLayer,
-            paint: paint,
-          },
-          beforeId,
+        const fillLayerConfig = {
+          id: fillLayerId,
+          type: "fill",
+          source: sourceId,
+          paint: fillPaint,
+        };
+        const lineLayerConfig = {
+          id: lineLayerId,
+          type: "line",
+          source: sourceId,
+          paint: linePaint,
+        };
+
+        if (overlay.sourceType !== "geojson") {
+          fillLayerConfig["source-layer"] = overlay.sourceLayer;
+          lineLayerConfig["source-layer"] = overlay.sourceLayer;
+        }
+
+        map.addLayer(fillLayerConfig, beforeId);
+        map.addLayer(lineLayerConfig, beforeId);
+        boundaryContextLayerIds.push(fillLayerId);
+        boundaryOverlayLayerIdsById[overlay.id] = {
+          fillLayerId: fillLayerId,
+          lineLayerId: lineLayerId,
+          visible: true,
+        };
+      });
+    }
+
+    function setBoundaryOverlayVisibility(overlayId, isVisible) {
+      const overlayLayers = boundaryOverlayLayerIdsById[overlayId];
+      if (!overlayLayers) {
+        return;
+      }
+
+      const visibility = isVisible ? "visible" : "none";
+
+      if (map.getLayer(overlayLayers.fillLayerId)) {
+        map.setLayoutProperty(
+          overlayLayers.fillLayerId,
+          "visibility",
+          visibility,
         );
+      }
+      if (map.getLayer(overlayLayers.lineLayerId)) {
+        map.setLayoutProperty(
+          overlayLayers.lineLayerId,
+          "visibility",
+          visibility,
+        );
+      }
+
+      overlayLayers.visible = isVisible;
+    }
+
+    function wireBoundaryLegendToggles() {
+      const toggleButtons = document.querySelectorAll("[data-boundary-toggle]");
+      if (!toggleButtons || toggleButtons.length === 0) {
+        return;
+      }
+
+      toggleButtons.forEach(function (button) {
+        const overlayId = button.getAttribute("data-boundary-toggle");
+        if (!overlayId || !boundaryOverlayLayerIdsById[overlayId]) {
+          button.style.opacity = "0.45";
+          button.style.cursor = "not-allowed";
+          return;
+        }
+
+        const setLegendState = function (isVisible) {
+          button.setAttribute("aria-pressed", isVisible ? "true" : "false");
+          button.style.opacity = isVisible ? "1" : "0.5";
+          button.style.filter = isVisible ? "none" : "grayscale(100%)";
+        };
+
+        setLegendState(true);
+
+        button.addEventListener("click", function () {
+          const current = boundaryOverlayLayerIdsById[overlayId];
+          if (!current) {
+            return;
+          }
+          const nextVisibility = !current.visible;
+          setBoundaryOverlayVisibility(overlayId, nextVisibility);
+          setLegendState(nextVisibility);
+        });
       });
     }
 
@@ -358,6 +449,7 @@
 
       // 4. Optional generic boundary overlays for gradual migration from Plotly maps.
       addBoundaryOverlays(boundaryOverlays);
+      wireBoundaryLegendToggles();
 
       // 5. Popups on hover
       const popup = new maplibregl.Popup({
@@ -438,10 +530,69 @@
         const laCode = props["la_code"] || "N/A";
         const decile =
           props["imd_decile"] === 0 ? "No data" : props["imd_decile"];
+
+        const boundaryByType = {};
+        if (boundaryContextLayerIds.length > 0) {
+          const boundaryFeatures = map.queryRenderedFeatures(e.point, {
+            layers: boundaryContextLayerIds,
+          });
+          (boundaryFeatures || []).forEach(function (feature) {
+            const featureProps = feature.properties || {};
+            const boundaryType = featureProps["boundary_type"] || "Boundary";
+            if (!boundaryByType[boundaryType]) {
+              boundaryByType[boundaryType] = featureProps;
+            }
+          });
+        }
+
+        function formatBoundaryLine(label, boundaryProps) {
+          if (!boundaryProps) {
+            return "";
+          }
+          const name =
+            boundaryProps["boundary_name"] ||
+            boundaryProps["name"] ||
+            "Unknown";
+          const code =
+            boundaryProps["boundary_code"] ||
+            boundaryProps["ods_code"] ||
+            boundaryProps["region_code"] ||
+            "N/A";
+          const cases =
+            boundaryProps["case_count"] != null
+              ? boundaryProps["case_count"]
+              : "0";
+          return `${label}: ${name} (${code}) [${cases} cases]`;
+        }
+
+        const nhsRegionLine = formatBoundaryLine(
+          "NHS Region",
+          boundaryByType["NHS England Region"],
+        );
+        const icbLine = formatBoundaryLine(
+          "ICB",
+          boundaryByType["Integrated Care Board"],
+        );
+        const lhbLine = formatBoundaryLine(
+          "LHB",
+          boundaryByType["Local Health Board"],
+        );
+
+        let boundaryContextHtml = "";
+        if (nhsRegionLine) {
+          boundaryContextHtml += `<br>${nhsRegionLine}`;
+        }
+        if (icbLine) {
+          boundaryContextHtml += `<br>${icbLine}`;
+        }
+        if (lhbLine) {
+          boundaryContextHtml += `<br>${lhbLine}`;
+        }
+
         popup
           .setLngLat(e.lngLat)
           .setHTML(
-            `<strong>${areaName}</strong><br>Code: ${areaCode}<br>LA: ${laName} (${laCode})<br>IMD decile: ${decile}`,
+            `<strong>${areaName}</strong><br>Code: ${areaCode}<br>LA: ${laName} (${laCode})<br>IMD decile: ${decile}<sup>†</sup>${boundaryContextHtml}`,
           )
           .addTo(map);
       }

--- a/static/js/maps/organisation_cases_map.js
+++ b/static/js/maps/organisation_cases_map.js
@@ -1,0 +1,377 @@
+(function () {
+  function getLayerName(era, zoom) {
+    // Keep z8 in the medium bucket to avoid expensive z8_10 fetches at boundary zoom.
+    const bucket = zoom <= 4 ? "z0_4" : zoom <= 8 ? "z5_7" : "z8_10";
+    return `public.uk_master_${era}_${bucket}`;
+  }
+
+  function imdFillColor() {
+    return [
+      "case",
+      ["==", ["get", "imd_decile"], 0],
+      "#cccccc",
+      // England - reds
+      ["==", ["get", "nation"], "england"],
+      [
+        "interpolate",
+        ["linear"],
+        ["get", "imd_decile"],
+        1,
+        "#67000d",
+        3,
+        "#a50f15",
+        5,
+        "#ef3b2c",
+        7,
+        "#fb6a4a",
+        10,
+        "#fee5d9",
+      ],
+      // Scotland - blues
+      ["==", ["get", "nation"], "scotland"],
+      [
+        "interpolate",
+        ["linear"],
+        ["get", "imd_decile"],
+        1,
+        "#08306b",
+        3,
+        "#2171b5",
+        5,
+        "#6baed6",
+        7,
+        "#bdd7e7",
+        10,
+        "#eff3ff",
+      ],
+      // Wales - greens
+      ["==", ["get", "nation"], "wales"],
+      [
+        "interpolate",
+        ["linear"],
+        ["get", "imd_decile"],
+        1,
+        "#00441b",
+        3,
+        "#238b45",
+        5,
+        "#74c476",
+        7,
+        "#bae4b3",
+        10,
+        "#edf8e9",
+      ],
+      // N. Ireland - oranges
+      ["==", ["get", "nation"], "northern_ireland"],
+      [
+        "interpolate",
+        ["linear"],
+        ["get", "imd_decile"],
+        1,
+        "#7f2704",
+        3,
+        "#d94801",
+        5,
+        "#fd8d3c",
+        7,
+        "#fdbe85",
+        10,
+        "#feedde",
+      ],
+      "#cccccc",
+    ];
+  }
+
+  function initialiseOrganisationCasesMap(config) {
+    const {
+      containerId,
+      tilesBaseUrl,
+      imdEra,
+      orgLng,
+      orgLat,
+      orgName,
+      casesGeojson,
+      boundaryOverlays,
+    } = config;
+
+    const container = document.getElementById(containerId);
+    if (!container) {
+      return;
+    }
+
+    // Bail out gracefully if no organisation coordinates.
+    if (orgLng === null || orgLat === null) {
+      container.innerHTML =
+        '<p style="padding:1em;color:#666;">Map unavailable: organisation has no coordinates.</p>';
+      return;
+    }
+
+    const map = new maplibregl.Map({
+      container: containerId,
+      // Use an inline style so we do not depend on fetching an external style.json,
+      // which can delay or block map.on("load") when the URL is slow or fails.
+      style: {
+        version: 8,
+        glyphs: "https://fonts.openmaptiles.org/{fontstack}/{range}.pbf",
+        sources: {
+          basemap: {
+            type: "raster",
+            tiles: [
+              "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
+              "https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
+            ],
+            tileSize: 256,
+            attribution:
+              "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors © <a href='https://carto.com/'>CARTO</a>",
+          },
+        },
+        layers: [
+          {
+            id: "basemap-layer",
+            type: "raster",
+            source: "basemap",
+            minzoom: 0,
+            maxzoom: 19,
+          },
+        ],
+      },
+      center: [orgLng, orgLat],
+      zoom: 8,
+    });
+
+    let activeLayerName = null;
+
+    function addBoundaryOverlays(overlays) {
+      if (!Array.isArray(overlays) || overlays.length === 0) {
+        return;
+      }
+
+      overlays.forEach(function (overlay) {
+        if (
+          !overlay ||
+          !overlay.id ||
+          !overlay.tilesBaseUrl ||
+          !overlay.sourceLayer
+        ) {
+          return;
+        }
+
+        const sourceId = `${overlay.id}-source`;
+        const layerId = `${overlay.id}-layer`;
+        const layerType = overlay.layerType || "line";
+        const paint = overlay.paint || {
+          "line-color": "#003087",
+          "line-width": 1.5,
+          "line-opacity": 0.8,
+        };
+
+        if (map.getLayer(layerId)) {
+          map.removeLayer(layerId);
+        }
+        if (map.getSource(sourceId)) {
+          map.removeSource(sourceId);
+        }
+
+        map.addSource(sourceId, {
+          type: "vector",
+          tiles: [overlay.tilesBaseUrl],
+          minzoom: overlay.minzoom != null ? overlay.minzoom : 0,
+          maxzoom: overlay.maxzoom != null ? overlay.maxzoom : 14,
+        });
+
+        const beforeId =
+          overlay.beforeLayerId && map.getLayer(overlay.beforeLayerId)
+            ? overlay.beforeLayerId
+            : undefined;
+
+        map.addLayer(
+          {
+            id: layerId,
+            type: layerType,
+            source: sourceId,
+            "source-layer": overlay.sourceLayer,
+            paint: paint,
+          },
+          beforeId,
+        );
+      });
+    }
+
+    function addDeprivationLayer(beforeId, forcedLayerName) {
+      const layerName = forcedLayerName || getLayerName(imdEra, map.getZoom());
+
+      // Avoid rebuilding the same layer/source on every zoomend.
+      if (activeLayerName === layerName && map.getLayer("deprivation-layer")) {
+        return;
+      }
+
+      if (map.getLayer("deprivation-layer")) {
+        map.removeLayer("deprivation-layer");
+      }
+      if (map.getSource("deprivation-source")) {
+        map.removeSource("deprivation-source");
+      }
+
+      map.addSource("deprivation-source", {
+        type: "vector",
+        tiles: [`${tilesBaseUrl}/${layerName}/{z}/{x}/{y}.pbf`],
+        minzoom: 0,
+        maxzoom: 14,
+      });
+
+      map.addLayer(
+        {
+          id: "deprivation-layer",
+          type: "fill",
+          source: "deprivation-source",
+          "source-layer": layerName,
+          paint: {
+            "fill-color": imdFillColor(),
+            "fill-opacity": 0.45,
+            "fill-outline-color": "rgba(255,255,255,0.15)",
+          },
+        },
+        beforeId,
+      );
+
+      activeLayerName = layerName;
+    }
+
+    map.on("error", function (e) {
+      const msg = e && e.error && e.error.message ? e.error.message : "";
+
+      // If the high-detail layer intermittently 500s, gracefully fall back.
+      if (msg.includes("public.uk_master_") && msg.includes("_z8_10")) {
+        addDeprivationLayer("cases-layer", `public.uk_master_${imdEra}_z5_7`);
+      }
+    });
+
+    map.on("load", function () {
+      // 1. Deprivation tiles (no beforeId yet - cases-layer added next)
+      addDeprivationLayer();
+      map.on("zoomend", function () {
+        addDeprivationLayer("cases-layer");
+      });
+
+      // 2. Case locations (patients)
+      map.addSource("cases-source", {
+        type: "geojson",
+        data: casesGeojson,
+      });
+      map.addLayer({
+        id: "cases-layer",
+        type: "circle",
+        source: "cases-source",
+        paint: {
+          "circle-radius": 7,
+          "circle-color": "#e91e8c", // RCPCH pink
+          "circle-opacity": 0.9,
+          "circle-stroke-width": 1,
+          "circle-stroke-color": "#ffffff",
+        },
+      });
+
+      // 3. Selected organisation marker (dark blue)
+      map.addLayer({
+        id: "org-layer",
+        type: "circle",
+        source: {
+          type: "geojson",
+          data: {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [orgLng, orgLat] },
+            properties: { name: orgName },
+          },
+        },
+        paint: {
+          "circle-radius": 10,
+          "circle-color": "#003087", // RCPCH dark blue
+          "circle-opacity": 1,
+          "circle-stroke-width": 2,
+          "circle-stroke-color": "#ffffff",
+        },
+      });
+
+      // 4. Optional generic boundary overlays for gradual migration from Plotly maps.
+      addBoundaryOverlays(boundaryOverlays);
+
+      // 5. Popups on hover
+      const popup = new maplibregl.Popup({
+        closeButton: false,
+        closeOnClick: false,
+      });
+
+      map.on("mousemove", "cases-layer", function (e) {
+        map.getCanvas().style.cursor = "pointer";
+        const props = e.features[0].properties;
+        const caseOrgName = props["epilepsy12_sites__organisation__name"] || "";
+        const distMi =
+          props["distance_mi"] != null
+            ? Number(props["distance_mi"]).toFixed(2)
+            : "-";
+        const distKm =
+          props["distance_km"] != null
+            ? Number(props["distance_km"]).toFixed(2)
+            : "-";
+        popup
+          .setLngLat(e.lngLat)
+          .setHTML(
+            `<strong>${caseOrgName}</strong><br>Distance: ${distMi} mi (${distKm} km)`,
+          )
+          .addTo(map);
+      });
+      map.on("mouseleave", "cases-layer", function () {
+        map.getCanvas().style.cursor = "";
+        popup.remove();
+      });
+
+      map.on("mousemove", "org-layer", function (e) {
+        map.getCanvas().style.cursor = "pointer";
+        const props = e.features[0].properties;
+        popup
+          .setLngLat(e.lngLat)
+          .setHTML(`<strong>Lead centre</strong><br>${props.name || orgName}`)
+          .addTo(map);
+      });
+      map.on("mouseleave", "org-layer", function () {
+        map.getCanvas().style.cursor = "";
+        popup.remove();
+      });
+
+      map.on("mousemove", "deprivation-layer", function (e) {
+        // If cursor is over a case/lead-centre point, keep point popups on top.
+        const topPointFeatures = map.queryRenderedFeatures(e.point, {
+          layers: ["org-layer", "cases-layer"],
+        });
+        if (topPointFeatures && topPointFeatures.length > 0) {
+          return;
+        }
+
+        map.getCanvas().style.cursor = "pointer";
+        const props = e.features[0].properties;
+        const areaName = props["area_name"] || "Unknown area";
+        const areaCode = props["code"] || "-";
+        const laName = props["la_name"] || "N/A";
+        const laCode = props["la_code"] || "N/A";
+        const decile =
+          props["imd_decile"] === 0 ? "No data" : props["imd_decile"];
+        popup
+          .setLngLat(e.lngLat)
+          .setHTML(
+            `<strong>${areaName}</strong><br>Code: ${areaCode}<br>LA: ${laName} (${laCode})<br>IMD decile: ${decile}`,
+          )
+          .addTo(map);
+      });
+      map.on("mouseleave", "deprivation-layer", function () {
+        map.getCanvas().style.cursor = "";
+        popup.remove();
+      });
+    });
+
+    map.addControl(new maplibregl.NavigationControl(), "top-right");
+  }
+
+  window.RCPCHMaps = window.RCPCHMaps || {};
+  window.RCPCHMaps.initialiseOrganisationCasesMap =
+    initialiseOrganisationCasesMap;
+})();

--- a/static/js/maps/organisation_cases_map.js
+++ b/static/js/maps/organisation_cases_map.js
@@ -139,7 +139,12 @@
       zoom: 8,
     });
 
-    let activeLayerName = null;
+    const DEPRIVATION_PRIMARY_SOURCE_ID = "deprivation-source-primary";
+    const DEPRIVATION_PRIMARY_LAYER_ID = "deprivation-layer-primary";
+    const DEPRIVATION_SECONDARY_SOURCE_ID = "deprivation-source-secondary";
+    const DEPRIVATION_SECONDARY_LAYER_ID = "deprivation-layer-secondary";
+    let activeLayerSignature = null;
+    let forcedPrimaryLayerName = null;
 
     function addBoundaryOverlays(overlays) {
       if (!Array.isArray(overlays) || overlays.length === 0) {
@@ -197,44 +202,101 @@
       });
     }
 
-    function addDeprivationLayer(beforeId, forcedLayerName) {
-      const layerName = forcedLayerName || getLayerName(imdEra, map.getZoom());
-
-      // Avoid rebuilding the same layer/source on every zoomend.
-      if (activeLayerName === layerName && map.getLayer("deprivation-layer")) {
-        return;
+    function removeDeprivationLayersAndSources() {
+      if (map.getLayer(DEPRIVATION_PRIMARY_LAYER_ID)) {
+        map.removeLayer(DEPRIVATION_PRIMARY_LAYER_ID);
       }
-
-      if (map.getLayer("deprivation-layer")) {
-        map.removeLayer("deprivation-layer");
+      if (map.getLayer(DEPRIVATION_SECONDARY_LAYER_ID)) {
+        map.removeLayer(DEPRIVATION_SECONDARY_LAYER_ID);
       }
-      if (map.getSource("deprivation-source")) {
-        map.removeSource("deprivation-source");
+      if (map.getSource(DEPRIVATION_PRIMARY_SOURCE_ID)) {
+        map.removeSource(DEPRIVATION_PRIMARY_SOURCE_ID);
       }
+      if (map.getSource(DEPRIVATION_SECONDARY_SOURCE_ID)) {
+        map.removeSource(DEPRIVATION_SECONDARY_SOURCE_ID);
+      }
+    }
 
-      map.addSource("deprivation-source", {
+    function addDeprivationFillLayer(
+      sourceId,
+      layerId,
+      sourceLayer,
+      beforeId,
+      filter,
+    ) {
+      map.addSource(sourceId, {
         type: "vector",
-        tiles: [`${tilesBaseUrl}/${layerName}/{z}/{x}/{y}.pbf`],
+        tiles: [`${tilesBaseUrl}/${sourceLayer}/{z}/{x}/{y}.pbf`],
         minzoom: 0,
         maxzoom: 14,
       });
 
-      map.addLayer(
-        {
-          id: "deprivation-layer",
-          type: "fill",
-          source: "deprivation-source",
-          "source-layer": layerName,
-          paint: {
-            "fill-color": imdFillColor(),
-            "fill-opacity": 0.45,
-            "fill-outline-color": "rgba(255,255,255,0.15)",
-          },
+      const layerConfig = {
+        id: layerId,
+        type: "fill",
+        source: sourceId,
+        "source-layer": sourceLayer,
+        paint: {
+          "fill-color": imdFillColor(),
+          "fill-opacity": 0.45,
+          "fill-outline-color": "rgba(255,255,255,0.15)",
         },
-        beforeId,
-      );
+      };
 
-      activeLayerName = layerName;
+      if (filter) {
+        layerConfig.filter = filter;
+      }
+
+      map.addLayer(layerConfig, beforeId);
+    }
+
+    function addDeprivationLayers(beforeId) {
+      const primaryLayerName =
+        forcedPrimaryLayerName || getLayerName(imdEra, map.getZoom());
+      const useEngland2025OverlayMode = imdEra === "2021";
+      const secondaryLayerName = getLayerName("2011", map.getZoom());
+      const nextSignature = useEngland2025OverlayMode
+        ? `${primaryLayerName}|${secondaryLayerName}`
+        : primaryLayerName;
+
+      // Avoid rebuilding the same layer/source on every zoomend.
+      if (
+        activeLayerSignature === nextSignature &&
+        map.getLayer(DEPRIVATION_PRIMARY_LAYER_ID)
+      ) {
+        return;
+      }
+
+      removeDeprivationLayersAndSources();
+
+      if (useEngland2025OverlayMode) {
+        // Draw non-England nations from 2011-era (Wales/Scotland/N. Ireland).
+        addDeprivationFillLayer(
+          DEPRIVATION_SECONDARY_SOURCE_ID,
+          DEPRIVATION_SECONDARY_LAYER_ID,
+          secondaryLayerName,
+          beforeId,
+          ["!=", ["get", "nation"], "england"],
+        );
+
+        // Draw England from 2021-era (2025 IMD) on top.
+        addDeprivationFillLayer(
+          DEPRIVATION_PRIMARY_SOURCE_ID,
+          DEPRIVATION_PRIMARY_LAYER_ID,
+          primaryLayerName,
+          beforeId,
+          ["==", ["get", "nation"], "england"],
+        );
+      } else {
+        addDeprivationFillLayer(
+          DEPRIVATION_PRIMARY_SOURCE_ID,
+          DEPRIVATION_PRIMARY_LAYER_ID,
+          primaryLayerName,
+          beforeId,
+        );
+      }
+
+      activeLayerSignature = nextSignature;
     }
 
     map.on("error", function (e) {
@@ -242,15 +304,17 @@
 
       // If the high-detail layer intermittently 500s, gracefully fall back.
       if (msg.includes("public.uk_master_") && msg.includes("_z8_10")) {
-        addDeprivationLayer("cases-layer", `public.uk_master_${imdEra}_z5_7`);
+        forcedPrimaryLayerName = `public.uk_master_${imdEra}_z5_7`;
+        addDeprivationLayers("cases-layer");
       }
     });
 
     map.on("load", function () {
       // 1. Deprivation tiles (no beforeId yet - cases-layer added next)
-      addDeprivationLayer();
+      addDeprivationLayers();
       map.on("zoomend", function () {
-        addDeprivationLayer("cases-layer");
+        forcedPrimaryLayerName = null;
+        addDeprivationLayers("cases-layer");
       });
 
       // 2. Case locations (patients)
@@ -338,7 +402,18 @@
         popup.remove();
       });
 
-      map.on("mousemove", "deprivation-layer", function (e) {
+      function handleDeprivationHover(e) {
+        const availableDeprivationLayers = [
+          DEPRIVATION_PRIMARY_LAYER_ID,
+          DEPRIVATION_SECONDARY_LAYER_ID,
+        ].filter(function (layerId) {
+          return !!map.getLayer(layerId);
+        });
+
+        if (availableDeprivationLayers.length === 0) {
+          return;
+        }
+
         // If cursor is over a case/lead-centre point, keep point popups on top.
         const topPointFeatures = map.queryRenderedFeatures(e.point, {
           layers: ["org-layer", "cases-layer"],
@@ -347,8 +422,16 @@
           return;
         }
 
+        const deprivationFeatures = map.queryRenderedFeatures(e.point, {
+          layers: availableDeprivationLayers,
+        });
+        if (!deprivationFeatures || deprivationFeatures.length === 0) {
+          popup.remove();
+          return;
+        }
+
         map.getCanvas().style.cursor = "pointer";
-        const props = e.features[0].properties;
+        const props = deprivationFeatures[0].properties;
         const areaName = props["area_name"] || "Unknown area";
         const areaCode = props["code"] || "-";
         const laName = props["la_name"] || "N/A";
@@ -361,8 +444,12 @@
             `<strong>${areaName}</strong><br>Code: ${areaCode}<br>LA: ${laName} (${laCode})<br>IMD decile: ${decile}`,
           )
           .addTo(map);
+      }
+
+      map.on("mousemove", function (e) {
+        handleDeprivationHover(e);
       });
-      map.on("mouseleave", "deprivation-layer", function () {
+      map.on("mouseout", function () {
         map.getCanvas().style.cursor = "";
         popup.remove();
       });

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -328,142 +328,74 @@
     
                 </div>
                 
-                <div class="column" style="height:100%;">
-
-                    <div class="ui rcpch_light_blue fluid card" style="height: 715px;">
-                        <div class="content">
-                            <h3>{{selected_organisation}}
-                                <i
-                                    class="info circle icon"
-                                    id='organisation_cases_help'
-                                    data-title='Epilepsy12 Cases Distribution'
-                                    data-content="Distribution of children with epilepsy registered within Cohort {{cohort_number}} at {{selected_organisation}} in the Epilepsy12 audit."
-                                    data-position='top right'
-                                    _="init js $('#organisation_cases_help').popup(); end"
-                                ></i>
-                            </h3>
-                        </div>
-                        <div id="organisation_cases_map" style="width:100%; height: 700px;"></div>
-                        <div class="extra content">
-                            <p style="color: white; font-family: Montserrat-Regular;">
-                                Max: {{ aggregated_distances.max_distance_travelled_mi }} mi 
-                                ({{ aggregated_distances.max_distance_travelled_km }} km)
-                            </p>
-                            <p style="color: white; font-family: Montserrat-Regular;">
-                                Mean: {{ aggregated_distances.mean_distance_travelled_mi }} mi 
-                                ({{ aggregated_distances.mean_distance_travelled_km }} km)
-                            </p>
-                            <p style="color: white; font-family: Montserrat-Regular;">
-                                Median: {{ aggregated_distances.median_distance_travelled_mi }} mi 
-                                ({{ aggregated_distances.median_distance_travelled_km }} km)
-                            </p>
-                            <p style="color: white; font-family: Montserrat-Regular;">
-                                Std: {{ aggregated_distances.std_distance_travelled_mi }} mi 
-                                ({{ aggregated_distances.std_distance_travelled_km }} km)
-                            </p>
-                        </div>
-                    </div>
-
-                </div>
-
-            
             
         </div>
 
         <div class="sixteen wide right fluid column">
-            <div class="ui three stackable cards">
-
-                {% if selected_organisation.country.name != "Jersey" %}
-                
-                <!-- Trust of Local Health Board tile -->
-                <div class="ui rcpch_light_blue fluid card">
-                    <div class="content">
-                        <!-- ENGLISH ORG -->
-                        {% if selected_organisation.trust %}
-                            <h3>
-                                Integrated Care Board
-                                <i
-                                    class="info circle icon"
-                                    id='icb_help'
-                                    data-title='Epilepsy12 Cases Distribution'
-                                    data-content="Density of children with epilepsy across ICBs, registered within Cohort {{cohort_number}} only and who have completed one year of care at {{selected_organisation}} in the Epilepsy12 audit."
-                                    data-position='top right'
-                                    _="init js $('#icb_help').popup(); end"
-                                ></i>
-                            </h3>
-                            
-                        <!-- WELSH ORG -->
-                        {% elif selected_organisation.local_health_board %}
-                            <h3>Local Health Board</h3>
-                        {% endif %}
-                    </div>
-                    <div>
-                        {% if  selected_organisation.trust %}
-                        <div 
-                            id="icb_map" 
-                            style="width:100%;height:600px;"
-                        ></div>
-                        {% elif selected_organisation.local_health_board %}
-                        <div 
-                            id="lhb_map" 
-                            style="width:100%;height:600px;"
-                            _='init js 
-                                var lhb_plotly_map = {{ lhb_heatmap|safe }}; 
-                                Plotly.newPlot("lhb_map", lhb_plotly_map.data, lhb_plotly_map.layout);
-                                end'></div>
-                        {% endif %}
+            <div class="ui rcpch_light_blue fluid card">
+                <div class="content">
+                    <h3>{{selected_organisation}}
+                        <i
+                            class="info circle icon"
+                            id='organisation_cases_help'
+                            data-title='Epilepsy12 Cases Distribution'
+                            data-content="Distribution of children with epilepsy registered within Cohort {{cohort_number}} at {{selected_organisation}} in the Epilepsy12 audit."
+                            data-position='top right'
+                            _="init js $('#organisation_cases_help').popup(); end"
+                        ></i>
+                    </h3>
+                </div>
+                <div style="position: relative; width: 100%; height: 760px;">
+                    <div id="organisation_cases_map" style="width:100%; height: 100%;"></div>
+                    <div
+                        style="position:absolute; left:12px; bottom:12px; z-index:2; max-width:340px; background:rgba(255,255,255,0.92); color:#222; border-radius:0; padding:10px 12px; box-shadow:0 2px 8px rgba(0,0,0,0.2); font-family:Montserrat-Regular; font-size:0.85rem; line-height:1.35;"
+                    >
+                        <details open>
+                            <summary style="font-weight:700; cursor:pointer; margin-bottom:6px;">Map legend</summary>
+                            <div style="margin-bottom:6px;">
+                                <strong>IMD:</strong> dark = more deprived, light = least deprived
+                            </div>
+                            <div style="margin-bottom:6px; font-size:0.8rem;">
+                                <strong>†</strong> IMD Decile 1 = most deprived, 10 = least deprived
+                            </div>
+                            <div style="margin-bottom:6px;">
+                                <strong>Nations:</strong> England reds, Wales greens, Scotland blues, N. Ireland oranges
+                            </div>
+                            <div>
+                                <strong>Boundaries:</strong>
+                                <div style="margin-top:6px; display:flex; flex-wrap:wrap; gap:6px;">
+                                    <button type="button" data-boundary-toggle="nhs-region-boundaries" aria-pressed="true" style="border:1px solid #aaa; background:#fff; padding:2px 6px; cursor:pointer; font-family:Montserrat-Regular; font-size:0.8rem;">
+                                        <span style="display:inline-block;width:12px;height:3px;background:#6b7280;vertical-align:middle;margin-right:6px;"></span>NHS Region
+                                    </button>
+                                    <button type="button" data-boundary-toggle="icb-boundaries" aria-pressed="true" style="border:1px solid #aaa; background:#fff; padding:2px 6px; cursor:pointer; font-family:Montserrat-Regular; font-size:0.8rem;">
+                                        <span style="display:inline-block;width:12px;height:3px;background:#7a1f2b;vertical-align:middle;margin-right:6px;"></span>ICB
+                                    </button>
+                                    <button type="button" data-boundary-toggle="lhb-boundaries" aria-pressed="true" style="border:1px solid #aaa; background:#fff; padding:2px 6px; cursor:pointer; font-family:Montserrat-Regular; font-size:0.8rem;">
+                                        <span style="display:inline-block;width:12px;height:3px;background:#2e7d32;vertical-align:middle;margin-right:6px;"></span>LHB
+                                    </button>
+                                </div>
+                            </div>
+                        </details>
                     </div>
                 </div>
-
-                <!-- NHS England Region tile -->
-                {% if selected_organisation.trust %}
-                <div class="ui rcpch_light_blue fluid card">
-                    <div class="content">
-                        <h3>
-                            NHS England Region
-                            <i
-                                class="info circle icon"
-                                id='nhsregion_help'
-                                data-title='Epilepsy12 Cases Distribution'
-                                data-content="Density of children with epilepsy across NHS England Regions, registered within Cohort {{cohort_number}} only and who have completed one year of care at {{selected_organisation}} in the Epilepsy12 audit."
-                                data-position='top right'
-                                _="init js $('#nhsregion_help').popup(); end"
-                            ></i>
-                        </h3>
-                    </div>
-                    <div>
-                        <div 
-                            id="nhs_region_map" style="width:100%;height:600px;"
-                        ></div>
-                    </div>
+                <div class="extra content">
+                    <p style="color: white; font-family: Montserrat-Regular;">
+                        Max: {{ aggregated_distances.max_distance_travelled_mi }} mi 
+                        ({{ aggregated_distances.max_distance_travelled_km }} km)
+                    </p>
+                    <p style="color: white; font-family: Montserrat-Regular;">
+                        Mean: {{ aggregated_distances.mean_distance_travelled_mi }} mi 
+                        ({{ aggregated_distances.mean_distance_travelled_km }} km)
+                    </p>
+                    <p style="color: white; font-family: Montserrat-Regular;">
+                        Median: {{ aggregated_distances.median_distance_travelled_mi }} mi 
+                        ({{ aggregated_distances.median_distance_travelled_km }} km)
+                    </p>
+                    <p style="color: white; font-family: Montserrat-Regular;">
+                        Std: {{ aggregated_distances.std_distance_travelled_mi }} mi 
+                        ({{ aggregated_distances.std_distance_travelled_km }} km)
+                    </p>
                 </div>
-                {% else %}
-                <!-- leave a blank space in welsh orgs -->
-                {% endif %}
-
-            {% endif %}
-
-                <div class="ui rcpch_light_blue fluid card">
-                    <div class="content">
-                        <h3>
-                            Country
-                            <i
-                                class="info circle icon"
-                                id='country_help'
-                                data-title='Epilepsy12 Cases Distribution'
-                                data-content="Density of children with epilepsy across countries, registered within Cohort {{cohort_number}} only and who have completed one year of care at {{selected_organisation}} in the Epilepsy12 audit."
-                                data-position='top right'
-                                _="init js $('#country_help').popup(); end"
-                            ></i>
-                        </h3>
-                    </div>
-                    <div>
-                        <div 
-                            id="country_map" 
-                            style="width:100%;height:600px;"></div>
-                    </div>
-                </div>
-
             </div>
         </div>
 
@@ -520,17 +452,10 @@
         orgLat: {{ org_lat|default:"null" }},
         orgName: "{{ org_name|escapejs }}",
         casesGeojson: {{ cases_geojson|safe }},
+        boundaryOverlays: {{ boundary_overlays_geojson|safe }},
     });
 
     // ── Remaining Plotly charts ───────────────────────────────────────────────
-    var country_plotly_map = {{ country_heatmap|safe }};
-    Plotly.newPlot("country_map", country_plotly_map.data, country_plotly_map.layout);
-
-    var nhs_region_data = {{ nhsregion_heatmap|safe }};
-    var icb_data = {{ icb_heatmap|safe }};
-    Plotly.react("icb_map", icb_data.data, icb_data.layout);
-    Plotly.react("nhs_region_map", nhs_region_data.data, nhs_region_data.layout);
-
     var index_of_multiple_deprivation_score_piechart = {{ index_of_multiple_deprivation_score_piechart|safe }};
     var ethnicity_piechart = {{ ethnicity_piechart|safe }};
     var sex_piechart = {{ sex_piechart|safe }};

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -612,7 +612,7 @@
                 "source-layer": layerName,
                 paint: {
                     "fill-color": imdFillColor(),
-                    "fill-opacity": 0.65,
+                    "fill-opacity": 0.45,
                     "fill-outline-color": "rgba(255,255,255,0.15)",
                 },
             }, beforeId);   // insert below case dots when beforeId is provided
@@ -691,12 +691,36 @@
                 popup.remove();
             });
 
+            map.on("mousemove", "org-layer", function (e) {
+                map.getCanvas().style.cursor = "pointer";
+                const props = e.features[0].properties;
+                popup.setLngLat(e.lngLat)
+                    .setHTML(`<strong>Lead centre</strong><br>${props.name || ORG_NAME}`)
+                    .addTo(map);
+            });
+            map.on("mouseleave", "org-layer", function () {
+                map.getCanvas().style.cursor = "";
+                popup.remove();
+            });
+
             map.on("mousemove", "deprivation-layer", function (e) {
+                // If cursor is over a case/lead-centre point, keep point popups on top.
+                const topPointFeatures = map.queryRenderedFeatures(e.point, {
+                    layers: ["org-layer", "cases-layer"],
+                });
+                if (topPointFeatures && topPointFeatures.length > 0) {
+                    return;
+                }
+
                 map.getCanvas().style.cursor = "pointer";
                 const props  = e.features[0].properties;
+                const areaName = props["area_name"] || "Unknown area";
+                const areaCode = props["code"] || "—";
+                const laName = props["la_name"] || "N/A";
+                const laCode = props["la_code"] || "N/A";
                 const decile = props["imd_decile"] === 0 ? "No data" : props["imd_decile"];
                 popup.setLngLat(e.lngLat)
-                    .setHTML(`<strong>${(props["nation"] || "").toUpperCase()} LSOA</strong><br>IMD decile: ${decile}`)
+                    .setHTML(`<strong>${areaName}</strong><br>Code: ${areaCode}<br>LA: ${laName} (${laCode})<br>IMD decile: ${decile}`)
                     .addTo(map);
             });
             map.on("mouseleave", "deprivation-layer", function () {

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -2,6 +2,10 @@
 {% load epilepsy12_template_tags %}
 {% csrf_token %}
 
+{# MapLibre GL JS — loaded here so it is available for the deprivation map below #}
+<link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" />
+<script src="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.js"></script>
+
 <div class="ui grid container selected_organisation_container">
         <div class="fluid row stackable three column grid">
             <div class='column'>
@@ -506,12 +510,208 @@
 </div>
 
 <script>
-    var organisation_plotly_map = {{ organisation_cases_map|safe }}
-    
-    var country_plotly_map = {{ country_heatmap|safe }}; 
+    // ── Deprivation + Cases map (MapLibre GL JS) ──────────────────────────────
+    (function () {
+        const TILES_BASE_URL = "{{ deprivation_tiles_url }}";
+        const IMD_ERA       = "{{ imd_tile_era }}";   // "2011" or "2021"
+        const ORG_LNG       = {{ org_lng|default:"null" }};
+        const ORG_LAT       = {{ org_lat|default:"null" }};
+        const ORG_NAME      = "{{ org_name|escapejs }}";
+
+        // Bail out gracefully if no organisation coordinates
+        if (ORG_LNG === null || ORG_LAT === null) {
+            document.getElementById("organisation_cases_map").innerHTML =
+                '<p style="padding:1em;color:#666;">Map unavailable: organisation has no coordinates.</p>';
+            return;
+        }
+        const CASES_GEOJSON = {{ cases_geojson|safe }};
+
+        // Layer name follows pg_tileserv view naming: public.uk_master_{era}_{zoomBucket}
+        function getLayerName(era, zoom) {
+            // Keep z8 in the medium bucket to avoid expensive z8_10 fetches at boundary zoom.
+            const bucket = zoom <= 4 ? "z0_4" : zoom <= 8 ? "z5_7" : "z8_10";
+            return `public.uk_master_${era}_${bucket}`;
+        }
+
+        function imdFillColor() {
+            return [
+                "case",
+                ["==", ["get", "imd_decile"], 0], "#cccccc",
+                // England — reds
+                ["==", ["get", "nation"], "england"],
+                ["interpolate", ["linear"], ["get", "imd_decile"],
+                    1, "#67000d", 3, "#a50f15", 5, "#ef3b2c", 7, "#fb6a4a", 10, "#fee5d9"],
+                // Scotland — blues
+                ["==", ["get", "nation"], "scotland"],
+                ["interpolate", ["linear"], ["get", "imd_decile"],
+                    1, "#08306b", 3, "#2171b5", 5, "#6baed6", 7, "#bdd7e7", 10, "#eff3ff"],
+                // Wales — greens
+                ["==", ["get", "nation"], "wales"],
+                ["interpolate", ["linear"], ["get", "imd_decile"],
+                    1, "#00441b", 3, "#238b45", 5, "#74c476", 7, "#bae4b3", 10, "#edf8e9"],
+                // N. Ireland — oranges
+                ["==", ["get", "nation"], "northern_ireland"],
+                ["interpolate", ["linear"], ["get", "imd_decile"],
+                    1, "#7f2704", 3, "#d94801", 5, "#fd8d3c", 7, "#fdbe85", 10, "#feedde"],
+                "#cccccc"
+            ];
+        }
+
+        const map = new maplibregl.Map({
+            container: "organisation_cases_map",
+            // Use an inline style so we don't depend on fetching an external style.json,
+            // which delays / silently blocks map.on("load") if the URL is slow or fails.
+            style: {
+                version: 8,
+                glyphs: "https://fonts.openmaptiles.org/{fontstack}/{range}.pbf",
+                sources: {
+                    "basemap": {
+                        type: "raster",
+                        tiles: [
+                            "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
+                            "https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
+                        ],
+                        tileSize: 256,
+                        attribution: "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors © <a href='https://carto.com/'>CARTO</a>",
+                    },
+                },
+                layers: [{
+                    id: "basemap-layer",
+                    type: "raster",
+                    source: "basemap",
+                    minzoom: 0,
+                    maxzoom: 19,
+                }],
+            },
+            center: [ORG_LNG, ORG_LAT],
+            zoom: 8,
+        });
+
+        let activeLayerName = null;
+
+        function addDeprivationLayer(beforeId, forcedLayerName) {
+            const layerName = forcedLayerName || getLayerName(IMD_ERA, map.getZoom());
+
+            // Avoid rebuilding the same layer/source on every zoomend.
+            if (activeLayerName === layerName && map.getLayer("deprivation-layer")) {
+                return;
+            }
+
+            if (map.getLayer("deprivation-layer")) map.removeLayer("deprivation-layer");
+            if (map.getSource("deprivation-source")) map.removeSource("deprivation-source");
+            map.addSource("deprivation-source", {
+                type: "vector",
+                tiles: [`${TILES_BASE_URL}/${layerName}/{z}/{x}/{y}.pbf`],
+                minzoom: 0,
+                maxzoom: 14,
+            });
+            map.addLayer({
+                id: "deprivation-layer",
+                type: "fill",
+                source: "deprivation-source",
+                "source-layer": layerName,
+                paint: {
+                    "fill-color": imdFillColor(),
+                    "fill-opacity": 0.65,
+                    "fill-outline-color": "rgba(255,255,255,0.15)",
+                },
+            }, beforeId);   // insert below case dots when beforeId is provided
+
+            activeLayerName = layerName;
+        }
+
+        map.on("error", function (e) {
+            const msg = (e && e.error && e.error.message) ? e.error.message : "";
+
+            // If the high-detail layer intermittently 500s, gracefully fall back.
+            if (msg.includes("public.uk_master_") && msg.includes("_z8_10")) {
+                addDeprivationLayer("cases-layer", `public.uk_master_${IMD_ERA}_z5_7`);
+            }
+        });
+
+        map.on("load", function () {
+            // 1. Deprivation tiles (no beforeId yet — cases-layer added next)
+            addDeprivationLayer();
+            map.on("zoomend", function () { addDeprivationLayer("cases-layer"); });
+
+            // 2. Case locations (patients)
+            map.addSource("cases-source", {
+                type: "geojson",
+                data: CASES_GEOJSON,
+            });
+            map.addLayer({
+                id: "cases-layer",
+                type: "circle",
+                source: "cases-source",
+                paint: {
+                    "circle-radius": 7,
+                    "circle-color": "#e91e8c",   // RCPCH pink
+                    "circle-opacity": 0.9,
+                    "circle-stroke-width": 1,
+                    "circle-stroke-color": "#ffffff",
+                },
+            });
+
+            // 3. Selected organisation marker (dark blue)
+            map.addLayer({
+                id: "org-layer",
+                type: "circle",
+                source: {
+                    type: "geojson",
+                    data: {
+                        type: "Feature",
+                        geometry: { type: "Point", coordinates: [ORG_LNG, ORG_LAT] },
+                        properties: { name: ORG_NAME },
+                    },
+                },
+                paint: {
+                    "circle-radius": 10,
+                    "circle-color": "#003087",   // RCPCH dark blue
+                    "circle-opacity": 1,
+                    "circle-stroke-width": 2,
+                    "circle-stroke-color": "#ffffff",
+                },
+            });
+
+            // 4. Popups on hover
+            const popup = new maplibregl.Popup({ closeButton: false, closeOnClick: false });
+
+            map.on("mousemove", "cases-layer", function (e) {
+                map.getCanvas().style.cursor = "pointer";
+                const props = e.features[0].properties;
+                const orgName = props["epilepsy12_sites__organisation__name"] || "";
+                const distMi  = props["distance_mi"] != null ? Number(props["distance_mi"]).toFixed(2) : "—";
+                const distKm  = props["distance_km"] != null ? Number(props["distance_km"]).toFixed(2) : "—";
+                popup.setLngLat(e.lngLat)
+                    .setHTML(`<strong>${orgName}</strong><br>Distance: ${distMi} mi (${distKm} km)`)
+                    .addTo(map);
+            });
+            map.on("mouseleave", "cases-layer", function () {
+                map.getCanvas().style.cursor = "";
+                popup.remove();
+            });
+
+            map.on("mousemove", "deprivation-layer", function (e) {
+                map.getCanvas().style.cursor = "pointer";
+                const props  = e.features[0].properties;
+                const decile = props["imd_decile"] === 0 ? "No data" : props["imd_decile"];
+                popup.setLngLat(e.lngLat)
+                    .setHTML(`<strong>${(props["nation"] || "").toUpperCase()} LSOA</strong><br>IMD decile: ${decile}`)
+                    .addTo(map);
+            });
+            map.on("mouseleave", "deprivation-layer", function () {
+                map.getCanvas().style.cursor = "";
+                popup.remove();
+            });
+        });
+
+        map.addControl(new maplibregl.NavigationControl(), "top-right");
+    })();
+
+    // ── Remaining Plotly charts ───────────────────────────────────────────────
+    var country_plotly_map = {{ country_heatmap|safe }};
     Plotly.newPlot("country_map", country_plotly_map.data, country_plotly_map.layout);
-    Plotly.react('organisation_cases_map', organisation_plotly_map.data, organisation_plotly_map.layout)
-    
+
     var nhs_region_data = {{ nhsregion_heatmap|safe }};
     var icb_data = {{ icb_heatmap|safe }};
     Plotly.react("icb_map", icb_data.data, icb_data.layout);

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -5,6 +5,7 @@
 {# MapLibre GL JS — loaded here so it is available for the deprivation map below #}
 <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" />
 <script src="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.js"></script>
+<script src="{% static 'js/maps/organisation_cases_map.js' %}"></script>
 
 <div class="ui grid container selected_organisation_container">
         <div class="fluid row stackable three column grid">
@@ -510,227 +511,16 @@
 </div>
 
 <script>
-    // ── Deprivation + Cases map (MapLibre GL JS) ──────────────────────────────
-    (function () {
-        const TILES_BASE_URL = "{{ deprivation_tiles_url }}";
-        const IMD_ERA       = "{{ imd_tile_era }}";   // "2011" or "2021"
-        const ORG_LNG       = {{ org_lng|default:"null" }};
-        const ORG_LAT       = {{ org_lat|default:"null" }};
-        const ORG_NAME      = "{{ org_name|escapejs }}";
-
-        // Bail out gracefully if no organisation coordinates
-        if (ORG_LNG === null || ORG_LAT === null) {
-            document.getElementById("organisation_cases_map").innerHTML =
-                '<p style="padding:1em;color:#666;">Map unavailable: organisation has no coordinates.</p>';
-            return;
-        }
-        const CASES_GEOJSON = {{ cases_geojson|safe }};
-
-        // Layer name follows pg_tileserv view naming: public.uk_master_{era}_{zoomBucket}
-        function getLayerName(era, zoom) {
-            // Keep z8 in the medium bucket to avoid expensive z8_10 fetches at boundary zoom.
-            const bucket = zoom <= 4 ? "z0_4" : zoom <= 8 ? "z5_7" : "z8_10";
-            return `public.uk_master_${era}_${bucket}`;
-        }
-
-        function imdFillColor() {
-            return [
-                "case",
-                ["==", ["get", "imd_decile"], 0], "#cccccc",
-                // England — reds
-                ["==", ["get", "nation"], "england"],
-                ["interpolate", ["linear"], ["get", "imd_decile"],
-                    1, "#67000d", 3, "#a50f15", 5, "#ef3b2c", 7, "#fb6a4a", 10, "#fee5d9"],
-                // Scotland — blues
-                ["==", ["get", "nation"], "scotland"],
-                ["interpolate", ["linear"], ["get", "imd_decile"],
-                    1, "#08306b", 3, "#2171b5", 5, "#6baed6", 7, "#bdd7e7", 10, "#eff3ff"],
-                // Wales — greens
-                ["==", ["get", "nation"], "wales"],
-                ["interpolate", ["linear"], ["get", "imd_decile"],
-                    1, "#00441b", 3, "#238b45", 5, "#74c476", 7, "#bae4b3", 10, "#edf8e9"],
-                // N. Ireland — oranges
-                ["==", ["get", "nation"], "northern_ireland"],
-                ["interpolate", ["linear"], ["get", "imd_decile"],
-                    1, "#7f2704", 3, "#d94801", 5, "#fd8d3c", 7, "#fdbe85", 10, "#feedde"],
-                "#cccccc"
-            ];
-        }
-
-        const map = new maplibregl.Map({
-            container: "organisation_cases_map",
-            // Use an inline style so we don't depend on fetching an external style.json,
-            // which delays / silently blocks map.on("load") if the URL is slow or fails.
-            style: {
-                version: 8,
-                glyphs: "https://fonts.openmaptiles.org/{fontstack}/{range}.pbf",
-                sources: {
-                    "basemap": {
-                        type: "raster",
-                        tiles: [
-                            "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-                            "https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-                        ],
-                        tileSize: 256,
-                        attribution: "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors © <a href='https://carto.com/'>CARTO</a>",
-                    },
-                },
-                layers: [{
-                    id: "basemap-layer",
-                    type: "raster",
-                    source: "basemap",
-                    minzoom: 0,
-                    maxzoom: 19,
-                }],
-            },
-            center: [ORG_LNG, ORG_LAT],
-            zoom: 8,
-        });
-
-        let activeLayerName = null;
-
-        function addDeprivationLayer(beforeId, forcedLayerName) {
-            const layerName = forcedLayerName || getLayerName(IMD_ERA, map.getZoom());
-
-            // Avoid rebuilding the same layer/source on every zoomend.
-            if (activeLayerName === layerName && map.getLayer("deprivation-layer")) {
-                return;
-            }
-
-            if (map.getLayer("deprivation-layer")) map.removeLayer("deprivation-layer");
-            if (map.getSource("deprivation-source")) map.removeSource("deprivation-source");
-            map.addSource("deprivation-source", {
-                type: "vector",
-                tiles: [`${TILES_BASE_URL}/${layerName}/{z}/{x}/{y}.pbf`],
-                minzoom: 0,
-                maxzoom: 14,
-            });
-            map.addLayer({
-                id: "deprivation-layer",
-                type: "fill",
-                source: "deprivation-source",
-                "source-layer": layerName,
-                paint: {
-                    "fill-color": imdFillColor(),
-                    "fill-opacity": 0.45,
-                    "fill-outline-color": "rgba(255,255,255,0.15)",
-                },
-            }, beforeId);   // insert below case dots when beforeId is provided
-
-            activeLayerName = layerName;
-        }
-
-        map.on("error", function (e) {
-            const msg = (e && e.error && e.error.message) ? e.error.message : "";
-
-            // If the high-detail layer intermittently 500s, gracefully fall back.
-            if (msg.includes("public.uk_master_") && msg.includes("_z8_10")) {
-                addDeprivationLayer("cases-layer", `public.uk_master_${IMD_ERA}_z5_7`);
-            }
-        });
-
-        map.on("load", function () {
-            // 1. Deprivation tiles (no beforeId yet — cases-layer added next)
-            addDeprivationLayer();
-            map.on("zoomend", function () { addDeprivationLayer("cases-layer"); });
-
-            // 2. Case locations (patients)
-            map.addSource("cases-source", {
-                type: "geojson",
-                data: CASES_GEOJSON,
-            });
-            map.addLayer({
-                id: "cases-layer",
-                type: "circle",
-                source: "cases-source",
-                paint: {
-                    "circle-radius": 7,
-                    "circle-color": "#e91e8c",   // RCPCH pink
-                    "circle-opacity": 0.9,
-                    "circle-stroke-width": 1,
-                    "circle-stroke-color": "#ffffff",
-                },
-            });
-
-            // 3. Selected organisation marker (dark blue)
-            map.addLayer({
-                id: "org-layer",
-                type: "circle",
-                source: {
-                    type: "geojson",
-                    data: {
-                        type: "Feature",
-                        geometry: { type: "Point", coordinates: [ORG_LNG, ORG_LAT] },
-                        properties: { name: ORG_NAME },
-                    },
-                },
-                paint: {
-                    "circle-radius": 10,
-                    "circle-color": "#003087",   // RCPCH dark blue
-                    "circle-opacity": 1,
-                    "circle-stroke-width": 2,
-                    "circle-stroke-color": "#ffffff",
-                },
-            });
-
-            // 4. Popups on hover
-            const popup = new maplibregl.Popup({ closeButton: false, closeOnClick: false });
-
-            map.on("mousemove", "cases-layer", function (e) {
-                map.getCanvas().style.cursor = "pointer";
-                const props = e.features[0].properties;
-                const orgName = props["epilepsy12_sites__organisation__name"] || "";
-                const distMi  = props["distance_mi"] != null ? Number(props["distance_mi"]).toFixed(2) : "—";
-                const distKm  = props["distance_km"] != null ? Number(props["distance_km"]).toFixed(2) : "—";
-                popup.setLngLat(e.lngLat)
-                    .setHTML(`<strong>${orgName}</strong><br>Distance: ${distMi} mi (${distKm} km)`)
-                    .addTo(map);
-            });
-            map.on("mouseleave", "cases-layer", function () {
-                map.getCanvas().style.cursor = "";
-                popup.remove();
-            });
-
-            map.on("mousemove", "org-layer", function (e) {
-                map.getCanvas().style.cursor = "pointer";
-                const props = e.features[0].properties;
-                popup.setLngLat(e.lngLat)
-                    .setHTML(`<strong>Lead centre</strong><br>${props.name || ORG_NAME}`)
-                    .addTo(map);
-            });
-            map.on("mouseleave", "org-layer", function () {
-                map.getCanvas().style.cursor = "";
-                popup.remove();
-            });
-
-            map.on("mousemove", "deprivation-layer", function (e) {
-                // If cursor is over a case/lead-centre point, keep point popups on top.
-                const topPointFeatures = map.queryRenderedFeatures(e.point, {
-                    layers: ["org-layer", "cases-layer"],
-                });
-                if (topPointFeatures && topPointFeatures.length > 0) {
-                    return;
-                }
-
-                map.getCanvas().style.cursor = "pointer";
-                const props  = e.features[0].properties;
-                const areaName = props["area_name"] || "Unknown area";
-                const areaCode = props["code"] || "—";
-                const laName = props["la_name"] || "N/A";
-                const laCode = props["la_code"] || "N/A";
-                const decile = props["imd_decile"] === 0 ? "No data" : props["imd_decile"];
-                popup.setLngLat(e.lngLat)
-                    .setHTML(`<strong>${areaName}</strong><br>Code: ${areaCode}<br>LA: ${laName} (${laCode})<br>IMD decile: ${decile}`)
-                    .addTo(map);
-            });
-            map.on("mouseleave", "deprivation-layer", function () {
-                map.getCanvas().style.cursor = "";
-                popup.remove();
-            });
-        });
-
-        map.addControl(new maplibregl.NavigationControl(), "top-right");
-    })();
+    // Deprivation + Cases map initialised from local static frontend module.
+    window.RCPCHMaps.initialiseOrganisationCasesMap({
+        containerId: "organisation_cases_map",
+        tilesBaseUrl: "{{ deprivation_tiles_url }}",
+        imdEra: "{{ imd_tile_era }}",
+        orgLng: {{ org_lng|default:"null" }},
+        orgLat: {{ org_lat|default:"null" }},
+        orgName: "{{ org_name|escapejs }}",
+        casesGeojson: {{ cases_geojson|safe }},
+    });
 
     // ── Remaining Plotly charts ───────────────────────────────────────────────
     var country_plotly_map = {{ country_heatmap|safe }};


### PR DESCRIPTION
refactor(imd): move IMD calculation out of Case.save() into signal-driven utility

closes #1302

## Motivation

`Case.save()` called `imd_for_postcode()` directly, but the correct IMD
year depends on `Registration.cohort`, which may not exist when a Case is
first saved. This caused a `ValueError` ("Model instances passed to related
filters must be saved") and incorrect IMD lookups when the Registration
arrived after the Case.

## Changes

### Core architecture
- **`epilepsy12/models_folder/case.py`** — stripped all IMD logic from
  `Case.save()`. The method now only normalises the postcode and calls
  `coordinates_for_postcode`. Sets `index_of_multiple_deprivation_quintile`
  to `None` when postcode switches to an unknown/placeholder value.
- **`epilepsy12/general_functions/index_multiple_deprivation.py`** 
  - added year parameter to `imd_for_postcode(postcode, year=imd_year)`: **NOTE** env must be updated with new census api URL
   — added`recalculate_imd_for_case(case)`: single source of truth for IMD
  calculation. No-ops when postcode is missing/unknown or Registration/cohort
  is not yet available. Derives `imd_year` from cohort (≥8 → 2025, else
  2019), calls `imd_for_postcode(postcode, year=imd_year)`, and persists via
  `queryset.update()` to avoid re-triggering `Case.save()`. Also fixed a
  stray `?` in the API URL.
- **`epilepsy12/signals.py`** — added four signal handlers:
  - `_capture_case_postcode` (pre_save Case)
  - `_recalculate_imd_on_case_save` (post_save Case) — fires when postcode changes
  - `_capture_registration_assessment_date` (pre_save Registration)
  - `_recalculate_imd_on_registration_save` (post_save Registration) — fires when assessment date changes

### Bulk recalculation tooling
- **`epilepsy12/management/commands/recalculate_imd.py`** — new management
  command (`manage.py recalculate_imd --all` / `--cohort N`) for
  backfilling IMD on existing records after a cohort boundary change or API
  update.
- **`s/recalculate-imd`** — convenience wrapper script.

### Tests
- **`epilepsy12/tests/model_tests/test_case.py`** — updated patch targets
  from `epilepsy12.models_folder.case.imd_for_postcode` to
  `epilepsy12.general_functions.index_multiple_deprivation.imd_for_postcode`;
  updated `assert_called_once_with` calls to include `year=2019`.
- **`epilepsy12/tests/model_tests/test_imd.py`** — new file; 10 tests
  covering: correct year selection per cohort, recalculation on postcode and
  assessment-date changes, no-ops for missing postcode / unknown postcode / no
  registration / None cohort, DB persistence, and `None` API response handling.
- **`epilepsy12/tests/view_tests/db_actions/test_create_actions.py`** —
  added `@patch("epilepsy12.models_folder.case.coordinates_for_postcode")`
  to `test_mix_of_mainland_and_jersey_patients` and `test_create_two_patients`
  to prevent live network calls.
- **`epilepsy12/tests/view_tests/permissions_tests/test_permissions_create.py`**
  — same patch applied to `test_patient_create_success`.

### Documentation
- **`agents.md`** — added "IMD Calculation — Design Notes" section covering
  background, cohort-to-year mapping, why `Case.save()` is the wrong place,
  the signal-driven architecture, bulk recalculation usage, and key constants.

## Result

- 483 tests pass, 0 failures (`pytest -m "not slow"`)
- No live API calls in the test suite
- IMD is recalculated correctly regardless of whether Case or Registration
  is created first

---

### Tests

| # | File | Test | New / Modified | What it verifies |
|---|------|------|:-:|-----------------|
| 1 | `test_imd.py` | `test_imd_uses_2019_for_cohort_below_8` | New | Cohort 7 triggers `imd_for_postcode` with `year=2019` |
| 2 | `test_imd.py` | `test_imd_uses_2025_for_cohort_8_and_above` | New | Cohort 8 triggers `imd_for_postcode` with `year=2025` |
| 3 | `test_imd.py` | `test_imd_recalculated_when_assessment_date_changes_cohort` | New | Saving a new `first_paediatric_assessment_date` that crosses the cohort 7→8 boundary re-runs IMD with `year=2025` |
| 4 | `test_imd.py` | `test_imd_recalculated_when_postcode_changes` | New | Saving a new postcode on an existing Case triggers a fresh IMD lookup |
| 5 | `test_imd.py` | `test_imd_not_calculated_when_postcode_is_none` | New | `imd_for_postcode` is never called when `postcode` is `None` |
| 6 | `test_imd.py` | `test_imd_not_calculated_for_unknown_postcode` | New | Switching to a placeholder postcode (`ZZ99 3CZ` etc.) does not call the API |
| 7 | `test_imd.py` | `test_imd_not_calculated_when_no_registration` | New | `recalculate_imd_for_case` is a no-op when no `Registration` exists |
| 8 | `test_imd.py` | `test_imd_not_calculated_when_cohort_is_none` | New | `recalculate_imd_for_case` is a no-op when `Registration.cohort` is `None` |
| 9 | `test_imd.py` | `test_imd_persisted_to_database` | New | The quintile returned by the API is written to the DB via `queryset.update()` |
| 10 | `test_imd.py` | `test_imd_set_to_none_when_api_returns_none` | New | A `None` API response results in `index_of_multiple_deprivation_quintile = None` |
| 11 | `test_case.py` | `test_case_save_unknown_postcode_when_imd_not_none` | Modified | Switching to an unknown postcode clears IMD; now mocks both `coordinates_for_postcode` and `imd_for_postcode` (previously unmocked, causing live calls) |
| 12 | `test_case.py` | `test_case_save_postcode_obtain_imdq` | Modified | `imd_for_postcode` patch target updated; assertion now includes `year=2019` |
| 13 | `test_case.py` | `test_case_save_invalid_postcode` | Modified | `imd_for_postcode` patch target updated to `general_functions` module |
| 14 | `test_case.py` | `test_case_overwrite_index_of_multiple_deprivation_quintile` | Modified | `imd_for_postcode` patch target updated; assertion now includes `year=2019` |
| 15 | `test_create_actions.py` | `test_mix_of_mainland_and_jersey_patients` | Modified | Added `@patch` for `coordinates_for_postcode` to prevent live geocoding call when mainland case is saved |
| 16 | `test_create_actions.py` | `test_create_two_patients` | Modified | Added `@patch` for `coordinates_for_postcode` to prevent live geocoding calls for two `WC1X 8SH` case creations |
| 17 | `test_permissions_create.py` | `test_patient_create_success` | Modified | Added `@patch` for `coordinates_for_postcode` to prevent live geocoding call across all five user roles |