### PR TITLE
removes the snomed causes from multiaxial diagnosis

### DIFF
--- a/documentation/docs/development/dropdowns.md
+++ b/documentation/docs/development/dropdowns.md
@@ -51,7 +51,10 @@ eg: `extra_causes_without_concept_ids = [...., {"preferredTerm": "Cause name", "
 
 Note that the function expects a list, even if only one item is supplied.
 
-<!-- There will need to be further documentation added here for new organisations and trust, as well as new comorbidities, and possibly medications and so on. For now, this is the workflow for EpilepsyCauses -->
+> [!NOTE]
+> Epilepsy Causes have as of #1224 been deprecated pending a better solution.
+
+
 
 ### Organisations
 

--- a/epilepsy12/models_folder/multiaxial_diagnosis.py
+++ b/epilepsy12/models_folder/multiaxial_diagnosis.py
@@ -143,7 +143,7 @@ class MultiaxialDiagnosis(
         related_name="multiaxialdiagnosis",
     )
 
-    epilepsy_cause = models.ForeignKey(
+    epilepsy_cause = models.ForeignKey(  # DEPRECATED - as of #1224: to be removed in a future release
         "epilepsy12.EpilepsyCause",
         on_delete=models.PROTECT,
         help_text={

--- a/epilepsy12/tests/view_tests/db_actions/test_update_actions.py
+++ b/epilepsy12/tests/view_tests/db_actions/test_update_actions.py
@@ -6,7 +6,7 @@
     [] Assert user can change user email
     [] Assert user can change user role
     [] Assert user can resend create_user email
-    
+
 
 # Cases
     [] Assert user can change child first_name
@@ -20,7 +20,7 @@
     [] Assert user can change child nhs_number
     [] Assert user can change child ethnicity
     [] Assert user can opt child out of Epilepsy12
-    
+
 
 # First Paediatric Assessment
     for field in fields: [
@@ -44,10 +44,10 @@
     [x] Assert user can change 'developmental_learning_or_schooling_problems' to False
     [x] Assert user can change 'behavioural_or_emotional_problems' to True
     [x] Assert user can change 'behavioural_or_emotional_problems' to False
-    
+
 # Epilepsy Context
     for field in fields: [
-        'previous_febrile_seizure',                                 single_choice_multiple_toggle_button 
+        'previous_febrile_seizure',                                 single_choice_multiple_toggle_button
         'previous_acute_symptomatic_seizure',                       single_choice_multiple_toggle_button
         'is_there_a_family_history_of_epilepsy',                    single_choice_multiple_toggle_button
         'previous_neonatal_seizures',                               single_choice_multiple_toggle_button
@@ -182,11 +182,11 @@
     [x] Assert user can change 'nonepileptic_seizure_subtype' to NON_EPILEPSY_SEIZURE_TYPE[5][0]=='PMD' ('Paroxysmal Movement Disorders')]], tuple[Literal['Oth'], Literal['Other']]]
     [x] Assert user can change 'nonepileptic_seizure_subtype' to NON_EPILEPSY_SEIZURE_TYPE[6][0]=='Oth' ('Other')
 
-    
+
     [] Assert user cannot change 'seizure_onset_date' to before Case.date_of_birth (raise ValidationError)
     [] Assert user cannot change 'seizure_onset_date' to before Registration.first_paediatric_assessment_date (raise ValidationError)
     [] Assert user cannot change 'seizure_onset_date' to future date (raise ValidationError)
-    
+
 
 # Comorbidity
     for field in fields: [
@@ -208,7 +208,7 @@
     ]
     [] Assert user can change  ..
     [] Assert user can change  ..
-    
+
 
 # Assessment
     for field in fields: [
@@ -222,17 +222,17 @@
         'paediatric_neurologist_referral_date',                                 date_field
         'paediatric_neurologist_input_date',                                    date_field
         'paediatric_neurology_centre',                                          button click
-        'edit_paediatric_neurology_centre',                                     button click    
+        'edit_paediatric_neurology_centre',                                     button click
         'update_paediatric_neurology_centre_pressed',                           button click (action:edit/cancel)
-        'childrens_epilepsy_surgical_service_referral_criteria_met',            toggle_button                
-        'childrens_epilepsy_surgical_service_referral_made',                    toggle_button        
-        'childrens_epilepsy_surgical_service_referral_date',                    date_field    
+        'childrens_epilepsy_surgical_service_referral_criteria_met',            toggle_button
+        'childrens_epilepsy_surgical_service_referral_made',                    toggle_button
+        'childrens_epilepsy_surgical_service_referral_date',                    date_field
         'childrens_epilepsy_surgical_service_input_date',                       date_field
         'epilepsy_surgery_centre',                                              button click
         'edit_epilepsy_surgery_centre',                                         button click
-        'update_epilepsy_surgery_centre_pressed',                               button click (action:edit/cancel)            
+        'update_epilepsy_surgery_centre_pressed',                               button click (action:edit/cancel)
         'epilepsy_specialist_nurse_referral_made',                              toggle_button
-        'epilepsy_specialist_nurse_referral_date',                              date_field    
+        'epilepsy_specialist_nurse_referral_date',                              date_field
         'epilepsy_specialist_nurse_input_date',                                 date_field
     ]
     [x] Assert user can change 'consultant_paediatrician_referral_made' to True
@@ -268,10 +268,10 @@
     for field in fields: [
         'eeg_indicated',                                                        toggle_button
         'eeg_request_date',                                                     date_field
-        'eeg_performed_date',                                                   date_field    
+        'eeg_performed_date',                                                   date_field
         'eeg_declined',                                                         button click (confirm:edit/decline)
-        'twelve_lead_ecg_status',                                               toggle_button        
-        'ct_head_scan_status',                                                  toggle_button    
+        'twelve_lead_ecg_status',                                               toggle_button
+        'ct_head_scan_status',                                                  toggle_button
         'mri_indicated',                                                        toggle_button
         'mri_brain_requested_date',                                             date_field
         'mri_brain_reported_date',                                              date_field
@@ -302,10 +302,10 @@
         'individualised_care_plan_parental_prolonged_seizure_care',             toggle_button
         'individualised_care_plan_includes_general_participation_risk',         toggle_button
         'individualised_care_plan_addresses_water_safety',                      toggle_button
-        'individualised_care_plan_addresses_sudep',                             toggle_button    
-        'individualised_care_plan_includes_ehcp',                               toggle_button    
-        'has_individualised_care_plan_been_updated_in_the_last_year',           toggle_button                        
-        'has_been_referred_for_mental_health_support',                          toggle_button        
+        'individualised_care_plan_addresses_sudep',                             toggle_button
+        'individualised_care_plan_includes_ehcp',                               toggle_button
+        'has_individualised_care_plan_been_updated_in_the_last_year',           toggle_button
+        'has_been_referred_for_mental_health_support',                          toggle_button
         'has_support_for_mental_health_support',                                toggle_button
         'has_an_aed_been_given',                                                toggle_button
         'has_rescue_medication_been_prescribed',                                toggle_button
@@ -706,12 +706,6 @@ TOGGLES = (
 )
 
 SELECTS = (
-    {
-        "field_name": "epilepsy_cause",
-        "param": "multiaxial_diagnosis_id",
-        "model": "multiaxialdiagnosis",
-        "choices": None,
-    },
     {
         "field_name": "comorbidity_diagnosis",
         "param": "comorbidity_id",
@@ -1177,13 +1171,7 @@ def test_user_updates_select_fail(
                 model_name=url.get("model"),
             )
 
-            if url.get("field_name") == "epilepsy_cause":
-                data = {"epilepsy_cause": 134}  # Aicardi's sy.
-                expected_result = EpilepsyCause.objects.get(
-                    pk=135
-                )  # Dysmorphic sialidosis with renal involvement
-                htmx_trigger = "epilepsy_cause"
-            elif url.get("field_name") == "comorbidity_diagnosis":
+            if url.get("field_name") == "comorbidity_diagnosis":
                 data = {"comorbidityentity": 134}
                 expected_result = ComorbidityList.objects.get(
                     pk=35

--- a/epilepsy12/tests/view_tests/permissions_tests/test_permissions_update.py
+++ b/epilepsy12/tests/view_tests/permissions_tests/test_permissions_update.py
@@ -1147,7 +1147,6 @@ def test_users_update_first_multiaxial_diagnosis_forbidden(client, e12_case_fact
 
     URLS = [
         "epilepsy_cause_known",
-        "epilepsy_cause",
         "epilepsy_cause_categories",
         "relevant_impairments_behavioural_educational",
         "mental_health_screen",
@@ -1217,7 +1216,6 @@ def test_users_update_multiaxial_diagnosis_success(client, e12_case_factory):
 
     URLS = [
         "epilepsy_cause_known",
-        "epilepsy_cause",
         "epilepsy_cause_categories",
         "relevant_impairments_behavioural_educational",
         "mental_health_screen",
@@ -1313,7 +1311,6 @@ def test_update_multiaxial_diagnosis_cause_success(client, e12_case_factory):
 
         'epilepsy_cause_known',
         'epilepsy_cause_categories',
-        'epilepsy_cause'
     """
 
     # GOSH
@@ -1338,7 +1335,7 @@ def test_update_multiaxial_diagnosis_cause_success(client, e12_case_factory):
         user_first_names_for_test
     ), f"Incorrect queryset of test users. Requested {len(user_first_names_for_test)} users, queryset includes {len(users)}: {users}"
 
-    EPILEPSY_CAUSE_ENTITY = EpilepsyCause.objects.first()
+    #  EPILEPSY_CAUSE_ENTITY = EpilepsyCause.objects.first()
 
     for test_user in users:
         client.force_login(test_user)
@@ -1383,24 +1380,6 @@ def test_update_multiaxial_diagnosis_cause_success(client, e12_case_factory):
         ).epilepsy_cause_categories == [
             "Gen"
         ], f"{test_user} from {test_user.organisation_employer} attempted POST `Gen` to epilepsy_cause_categories but model did not update."
-
-        response_epilepsy_cause = client.post(
-            reverse(
-                "epilepsy_cause",
-                kwargs={
-                    "multiaxial_diagnosis_id": CASE_FROM_SAME_ORG.registration.multiaxialdiagnosis.id,
-                },
-            ),
-            headers={"Hx-Trigger-Name": "epilepsy_cause", "Hx-Request": "true"},
-            data={"epilepsy_cause": f"{EPILEPSY_CAUSE_ENTITY.id}"},
-        )
-
-        assert (
-            MultiaxialDiagnosis.objects.get(
-                registration=CASE_FROM_SAME_ORG.registration
-            ).epilepsy_cause
-            == EPILEPSY_CAUSE_ENTITY
-        ), f"{test_user} from {test_user.organisation_employer} attempted POST `epilepsy_cause:{EPILEPSY_CAUSE_ENTITY.id}` but MultiaxialDiagnosis model field did not update."
 
         # Reset answers for next User
         MultiaxialDiagnosis.objects.filter(

--- a/epilepsy12/urls.py
+++ b/epilepsy12/urls.py
@@ -323,7 +323,7 @@ organisation_patterns = [
         name="child_organisation_select",
     ),
     path(
-    "organisations/filter_by_parent/<int:parent_id>/<str:parent_type>",
+        "organisations/filter_by_parent/<int:parent_id>/<str:parent_type>",
         view=filter_organisations_by_parent,
         name="filter_organisations_by_parent",
     ),
@@ -937,11 +937,6 @@ epilepsy_causes_patterns = [
         "multiaxial_diagnosis/<int:multiaxial_diagnosis_id>/epilepsy_cause_known",
         epilepsy_cause_known,
         name="epilepsy_cause_known",
-    ),
-    path(
-        "multiaxial_diagnosis/<int:multiaxial_diagnosis_id>/epilepsy_cause",
-        epilepsy_cause,
-        name="epilepsy_cause",
     ),
     path(
         "multiaxial_diagnosis/<int:multiaxial_diagnosis_id>/epilepsy_cause_categories",

--- a/epilepsy12/views/multiaxial_diagnosis_views.py
+++ b/epilepsy12/views/multiaxial_diagnosis_views.py
@@ -114,7 +114,7 @@ def multiaxial_diagnosis(request, case_id):
 
     keyword_choices = Keyword.objects.all()
 
-    epilepsy_causes = EpilepsyCause.objects.all().order_by("preferredTerm")
+    # epilepsy_causes = EpilepsyCause.objects.all().order_by("preferredTerm")
 
     site = Site.objects.filter(
         site_is_actively_involved_in_epilepsy_care=True,
@@ -132,7 +132,7 @@ def multiaxial_diagnosis(request, case_id):
         "comorbidities": comorbidities,
         "keyword_choices": keyword_choices,
         "epilepsy_cause_selection": EPILEPSY_CAUSES,
-        "epilepsy_causes": epilepsy_causes,
+        # "epilepsy_causes": epilepsy_causes,
         "case_id": case_id,
         "audit_progress": registration.audit_progress,
         "active_template": "multiaxial_diagnosis",
@@ -1362,12 +1362,12 @@ def epilepsy_cause_known(request, multiaxial_diagnosis_id):
 
     multiaxial_diagnosis = MultiaxialDiagnosis.objects.get(pk=multiaxial_diagnosis_id)
 
-    epilepsy_causes = EpilepsyCause.objects.all().order_by("preferredTerm")
+    # epilepsy_causes = EpilepsyCause.objects.all().order_by("preferredTerm")
 
     context = {
         "multiaxial_diagnosis": multiaxial_diagnosis,
         "epilepsy_cause_selection": EPILEPSY_CAUSES,
-        "epilepsy_causes": epilepsy_causes,
+        # "epilepsy_causes": epilepsy_causes,
     }
 
     response = recalculate_form_generate_response(
@@ -1380,46 +1380,46 @@ def epilepsy_cause_known(request, multiaxial_diagnosis_id):
     return response
 
 
-@login_and_otp_required()
-@user_may_view_this_child()
-@permission_required("epilepsy12.change_multiaxialdiagnosis", raise_exception=True)
-def epilepsy_cause(request, multiaxial_diagnosis_id):
-    """
-    POST request on change select from epilepsy_causes partial
-    Choices for causes come from EpilepsyCause table
-    """
+# @login_and_otp_required()
+# @user_may_view_this_child()
+# @permission_required("epilepsy12.change_multiaxialdiagnosis", raise_exception=True)
+# def epilepsy_cause(request, multiaxial_diagnosis_id):
+#     """
+#     POST request on change select from epilepsy_causes partial
+#     Choices for causes come from EpilepsyCause table
+#     """
 
-    try:
-        error_message = None
-        validate_and_update_model(
-            request=request,
-            model=MultiaxialDiagnosis,
-            model_id=multiaxial_diagnosis_id,
-            field_name="epilepsy_cause",
-            page_element="select",
-        )
-    except ValueError as error:
-        error_message = error
+#     try:
+#         error_message = None
+#         validate_and_update_model(
+#             request=request,
+#             model=MultiaxialDiagnosis,
+#             model_id=multiaxial_diagnosis_id,
+#             field_name="epilepsy_cause",
+#             page_element="select",
+#         )
+#     except ValueError as error:
+#         error_message = error
 
-    epilepsy_causes = EpilepsyCause.objects.all().order_by("preferredTerm")
+#     # epilepsy_causes = EpilepsyCause.objects.all().order_by("preferredTerm")
 
-    multiaxial_diagnosis = MultiaxialDiagnosis.objects.get(pk=multiaxial_diagnosis_id)
+#     multiaxial_diagnosis = MultiaxialDiagnosis.objects.get(pk=multiaxial_diagnosis_id)
 
-    context = {
-        "epilepsy_causes": epilepsy_causes,
-        "multiaxial_diagnosis": multiaxial_diagnosis,
-        "epilepsy_cause_selection": EPILEPSY_CAUSES,
-    }
+#     context = {
+#         # "epilepsy_causes": epilepsy_causes,
+#         "multiaxial_diagnosis": multiaxial_diagnosis,
+#         "epilepsy_cause_selection": EPILEPSY_CAUSES,
+#     }
 
-    response = recalculate_form_generate_response(
-        model_instance=multiaxial_diagnosis,
-        request=request,
-        template="epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_causes.html",
-        context=context,
-        error_message=error_message,
-    )
+#     response = recalculate_form_generate_response(
+#         model_instance=multiaxial_diagnosis,
+#         request=request,
+#         template="epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_causes.html",
+#         context=context,
+#         error_message=error_message,
+#     )
 
-    return response
+#     return response
 
 
 @login_and_otp_required()
@@ -1697,7 +1697,7 @@ def comorbidity_diagnosis_date(request, comorbidity_id):
 def comorbidity_diagnosis(request, comorbidity_id):
     """
     POST request on change select from comorbidity partial
-    Choices for causes fed from SNOMED server
+    Choices for comorbidities fed from SNOMED server
     """
 
     # 35919005 |Pervasive developmental disorder (disorder)|

--- a/epilepsy12/views/multiaxial_diagnosis_views.py
+++ b/epilepsy12/views/multiaxial_diagnosis_views.py
@@ -114,8 +114,6 @@ def multiaxial_diagnosis(request, case_id):
 
     keyword_choices = Keyword.objects.all()
 
-    # epilepsy_causes = EpilepsyCause.objects.all().order_by("preferredTerm")
-
     site = Site.objects.filter(
         site_is_actively_involved_in_epilepsy_care=True,
         site_is_primary_centre_of_epilepsy_care=True,
@@ -132,7 +130,6 @@ def multiaxial_diagnosis(request, case_id):
         "comorbidities": comorbidities,
         "keyword_choices": keyword_choices,
         "epilepsy_cause_selection": EPILEPSY_CAUSES,
-        # "epilepsy_causes": epilepsy_causes,
         "case_id": case_id,
         "audit_progress": registration.audit_progress,
         "active_template": "multiaxial_diagnosis",
@@ -1362,12 +1359,9 @@ def epilepsy_cause_known(request, multiaxial_diagnosis_id):
 
     multiaxial_diagnosis = MultiaxialDiagnosis.objects.get(pk=multiaxial_diagnosis_id)
 
-    # epilepsy_causes = EpilepsyCause.objects.all().order_by("preferredTerm")
-
     context = {
         "multiaxial_diagnosis": multiaxial_diagnosis,
         "epilepsy_cause_selection": EPILEPSY_CAUSES,
-        # "epilepsy_causes": epilepsy_causes,
     }
 
     response = recalculate_form_generate_response(
@@ -1401,12 +1395,12 @@ def epilepsy_cause_known(request, multiaxial_diagnosis_id):
 #     except ValueError as error:
 #         error_message = error
 
-#     # epilepsy_causes = EpilepsyCause.objects.all().order_by("preferredTerm")
+#
 
 #     multiaxial_diagnosis = MultiaxialDiagnosis.objects.get(pk=multiaxial_diagnosis_id)
 
 #     context = {
-#         # "epilepsy_causes": epilepsy_causes,
+#
 #         "multiaxial_diagnosis": multiaxial_diagnosis,
 #         "epilepsy_cause_selection": EPILEPSY_CAUSES,
 #     }

--- a/templates/epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_cause_section.html
+++ b/templates/epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_cause_section.html
@@ -7,6 +7,6 @@
 
 {% if multiaxial_diagnosis.epilepsy_cause_known %}
     <div class='field' id='epilepsy_causes'>
-        {% include 'epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_causes.html' with multiaxial_diagnosis=multiaxial_diagnosis epilepsy_causes=epilepsy_causes %}
+        {% include 'epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_causes.html' with multiaxial_diagnosis=multiaxial_diagnosis %}
     </div>
 {% endif %}

--- a/templates/epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_causes.html
+++ b/templates/epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_causes.html
@@ -2,8 +2,3 @@
 <div class="field" id="epilepsy_cause_categories">
   {% include 'epilepsy12/partials/multiaxial_diagnosis/epilepsy_causes/epilepsy_cause_categories.html' with choices=epilepsy_cause_selection multiaxial_diagnosis=multiaxial_diagnosis %}
 </div>
-
-<div class="field">
-  {% url "epilepsy_cause" multiaxial_diagnosis_id=multiaxial_diagnosis.pk as hx_post %}
-  {% include 'epilepsy12/partials/page_elements/select_model.html' with choices=epilepsy_causes field_name='preferredTerm' field_name2='term' hx_post=hx_post hx_name='epilepsy_cause' hx_default_text='Select a cause (optional field)' hx_swap='innerHTML' hx_target='#epilepsy_causes' hx_trigger='change' test_positive=multiaxial_diagnosis.epilepsy_cause.pk label=multiaxial_diagnosis.get_epilepsy_cause_help_label_text reference=multiaxial_diagnosis.get_epilepsy_cause_help_reference_text enabled=perms.epilepsy12.change_multiaxialdiagnosis allow_none=True %}
-</div>


### PR DESCRIPTION
### Overview

Epilepsy causes are an ongoing discussion. The E12 audit team for the moment have decided to deprecate the SNOMED refset of causes that is seeded in the early migrations straight from our SNOMED server into the E12 database.

This PR does not change the seeding step (that now really only happens in development) nor does it remove any of the code and documentation around causes for the moment.

Instead it:
1. removes the view reference to epilepsy causes and associated htmx urls that call back on change of the dropdown, and passes the epilepsy causes from the table to the template.
2. removes those same views from `urls.py`
3. removes the epilepsy causes dropdown partial from the template in multiaxial diagnosis

This does not have any implications for form scoring since it was not a mandatory field in any case.

Tests updated to remove epilepsy causes.

closes #1224
