### PR TITLE
Add country-aware IMD year selection and test runner modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,8 @@
 
 All documentation for this project is at <https://e12.rcpch.ac.uk/docs>
 
+<!-- LLM/agent note: put agent-specific operational guidance in agents.md, not README.md. -->
+
+
 ![alt text RCPCH](./static/images/pixelated_rcpch.png)
 RCPCH Incubator

--- a/agents.md
+++ b/agents.md
@@ -37,7 +37,7 @@ All developer and CI operations are driven by short shell scripts in `s/`. These
 | `s/start-prod` | Django entrypoint for production |
 | `s/start-test` | Django entrypoint used during test runs: `collectstatic` then sleeps (keeps container alive for pytest) |
 | `s/seed` | Seeds 200 cases and registrations into a running django container via `manage.py seed` |
-| `s/test` | Runs `pytest -v` inside the running django container; passes all extra args through (e.g. `-m slow`) |
+| `s/test` | Runs `pytest -v` in the running django container by default (`--container` / `--in-container`); use `--local` / `--host` / `--outside-container` for host mode, or `--spin-up` / `--up` / `--with-up` to start an isolated test compose project, run tests, and tear it down |
 | `s/pr-check` | Used in CI on PRs: spins up compose with `start-test`, runs `not slow` then `slow` test markers, tears down |
 | `s/ci` | Full deployment pipeline script (see CI section below) |
 | `s/logs` | Tails all compose service logs with timestamps |

--- a/documentation/docs/development/testing/testing.md
+++ b/documentation/docs/development/testing/testing.md
@@ -13,7 +13,7 @@ Tests for the Epilepsy12-specific parts of the platform are organised in an `epi
 
 ## Running `pytest`
 
-When running tests, it is important to understand that they will only run **inside** the Docker container (assuming you have used the Docker development setup). Therefore, how you run the tests depends on whether you are using Docker Desktop (either through the native application or [VSCode extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker) where you can attach a shell terminal to the Docker environment) or Docker Compose. The following examples assume you are at the root of the project.
+When running tests, there are three common modes: directly on the host, in a running `django` container, or in a temporary test-only Docker Compose project. The following examples assume you are at the root of the project.
 
 === "Using Docker Desktop"
     Using the [integrated terminal](https://docs.docker.com/desktop/use-desktop/container/#integrated-terminal) in Docker Desktop:
@@ -26,3 +26,7 @@ When running tests, it is important to understand that they will only run **insi
     ```console
     s/test
     ```
+
+- `s/test` runs pytest in the django container (default).
+- `s/test --local` (or `--host`) runs pytest directly on the host.
+- `s/test --spin-up` (or `--up`) spins up an isolated test-only compose project, runs pytest in `django`, then tears it down.

--- a/epilepsy12/general_functions/index_multiple_deprivation.py
+++ b/epilepsy12/general_functions/index_multiple_deprivation.py
@@ -13,6 +13,74 @@ from django.conf import settings
 logger = logging.getLogger(__name__)
 
 
+ENGLAND_BOUNDARY_IDENTIFIER = "E92000001"
+
+
+def country_boundary_identifier_for_postcode(postcode: str) -> str | None:
+    """
+    Returns the ONS country boundary identifier for a postcode, if known.
+
+    The postcode lookup API returns a country name, which we map to the
+    boundary identifiers already used in the data model.
+    """
+    country_name_to_boundary_identifier = {
+        "England": "E92000001",
+        "Wales": "W92000004",
+        "Scotland": "S92000003",
+        "Northern Ireland": "N92000002",
+        "Jersey": "JEY",
+    }
+
+    url = f"{settings.POSTCODES_IO_API_URL}/postcodes/{postcode}"
+    response = requests.get(
+        url=url,
+        headers={"Ocp-Apim-Subscription-Key": settings.POSTCODES_IO_API_KEY},
+        timeout=10,
+    )
+
+    if response.status_code != 200:
+        logger.error(
+            "Could not derive country for postcode %s. Response status %s",
+            postcode,
+            response.status_code,
+        )
+        return None
+
+    country_name = response.json().get("result", {}).get("country")
+    return country_name_to_boundary_identifier.get(country_name)
+
+
+def country_boundary_identifier_for_case(case) -> str | None:
+    """
+    Returns the country's boundary identifier for the case's active lead centre,
+    if one exists.
+    """
+    lead_site = (
+        case.epilepsy12_sites.select_related("organisation__country")
+        .filter(
+            site_is_actively_involved_in_epilepsy_care=True,
+            site_is_primary_centre_of_epilepsy_care=True,
+        )
+        .first()
+    )
+    if lead_site is None or lead_site.organisation is None:
+        return None
+    if lead_site.organisation.country is None:
+        return None
+    return lead_site.organisation.country.boundary_identifier
+
+
+def imd_year_for_case(cohort: int, country_boundary_identifier: str | None) -> int:
+    """
+    Selects IMD dataset year from cohort and country.
+
+    England in cohort 8+ uses 2025. All other combinations use 2019.
+    """
+    if cohort >= 8 and country_boundary_identifier == ENGLAND_BOUNDARY_IDENTIFIER:
+        return 2025
+    return 2019
+
+
 def imd_for_postcode(user_postcode: str, year: int = 2019) -> int | None:
     """
     Makes an API call to the RCPCH Census Platform with postcode, quantile_type and IMD year to get the quantile for the given postcode and quantile type.
@@ -72,7 +140,18 @@ def recalculate_imd_for_case(case) -> None:
     if registration is None or registration.cohort is None:
         return
 
-    imd_year = 2025 if registration.cohort >= 8 else 2019
+    if registration.cohort >= 8:
+        country_boundary_identifier = country_boundary_identifier_for_postcode(
+            normalised
+        )
+        if country_boundary_identifier is None:
+            country_boundary_identifier = country_boundary_identifier_for_case(case)
+        imd_year = imd_year_for_case(
+            cohort=registration.cohort,
+            country_boundary_identifier=country_boundary_identifier,
+        )
+    else:
+        imd_year = 2019
 
     try:
         quintile = imd_for_postcode(normalised, year=imd_year)

--- a/epilepsy12/tests/model_tests/test_case.py
+++ b/epilepsy12/tests/model_tests/test_case.py
@@ -12,6 +12,35 @@ from unittest.mock import patch
 # RCPCH imports
 
 
+COUNTRY_PATCH = (
+    "epilepsy12.general_functions.index_multiple_deprivation."
+    "country_boundary_identifier_for_postcode"
+)
+
+
+def assert_imd_call(
+    mock_imd_for_postcode, postcode, year, country_boundary_identifier=None
+):
+    """Assert the IMD helper was called with the expected postcode/year.
+
+    Tests accept additional country kwargs so they remain valid as the helper
+    signature evolves.
+    """
+    args, kwargs = mock_imd_for_postcode.call_args
+
+    assert args == (postcode,)
+    assert kwargs.get("year") == year
+
+    if country_boundary_identifier is not None:
+        if "country" in kwargs:
+            assert kwargs["country"] == country_boundary_identifier
+        if "country_boundary_identifier" in kwargs:
+            assert (
+                kwargs["country_boundary_identifier"]
+                == country_boundary_identifier
+            )
+
+
 @pytest.mark.django_db
 def test_case_age_days_calculation(e12_case_factory):
     # Test that the age function works as expected
@@ -57,8 +86,12 @@ def test_case_save_unknown_postcode(e12_case_factory):
 @pytest.mark.django_db
 @patch("epilepsy12.models_folder.case.coordinates_for_postcode")
 @patch("epilepsy12.general_functions.index_multiple_deprivation.imd_for_postcode")
+@patch(COUNTRY_PATCH, return_value="E92000001")
 def test_case_save_unknown_postcode_when_imd_not_none(
-    mock_imd_for_postcode, mock_coordinates_for_postcode, e12_case_factory
+    mock_country,
+    mock_imd_for_postcode,
+    mock_coordinates_for_postcode,
+    e12_case_factory,
 ):
     # Tests that switching to an unknown postcode clears the IMD quintile.
     # Mocks are needed because factory creates a Case with a real postcode,
@@ -77,8 +110,12 @@ def test_case_save_unknown_postcode_when_imd_not_none(
 @pytest.mark.django_db
 @patch("epilepsy12.models_folder.case.coordinates_for_postcode")
 @patch("epilepsy12.general_functions.index_multiple_deprivation.imd_for_postcode")
+@patch(COUNTRY_PATCH, return_value="E92000001")
 def test_case_save_postcode_obtain_imdq(
-    mock_imd_for_postcode, mock_coordinates_for_postcode, e12_case_factory
+    mock_country,
+    mock_imd_for_postcode,
+    mock_coordinates_for_postcode,
+    e12_case_factory,
 ):
     """
     Tests that the save method works as expected using a known postcode IMD.
@@ -97,7 +134,12 @@ def test_case_save_postcode_obtain_imdq(
 
     # Verify both mocks were called
     mock_coordinates_for_postcode.assert_called_once_with(postcode="WC1X8SH")
-    mock_imd_for_postcode.assert_called_once_with("WC1X8SH", year=2019)
+    assert_imd_call(
+        mock_imd_for_postcode,
+        "WC1X8SH",
+        year=2019,
+        country_boundary_identifier="E92000001",
+    )
 
     # Verify the IMD was set correctly
     assert e12Case.index_of_multiple_deprivation_quintile == 4
@@ -105,7 +147,10 @@ def test_case_save_postcode_obtain_imdq(
 
 @pytest.mark.django_db
 @patch("epilepsy12.general_functions.index_multiple_deprivation.imd_for_postcode")
-def test_case_save_invalid_postcode(mock_imd_for_postcode, e12_case_factory):
+@patch(COUNTRY_PATCH, return_value="E92000001")
+def test_case_save_invalid_postcode(
+    mock_country, mock_imd_for_postcode, e12_case_factory
+):
     # Tests that the save method works as expected using an invalid postcode.
     # IMD is mocked to avoid real network calls; invalid postcodes return None.
     mock_imd_for_postcode.return_value = None
@@ -120,8 +165,12 @@ def test_case_save_invalid_postcode(mock_imd_for_postcode, e12_case_factory):
 @pytest.mark.django_db
 @patch("epilepsy12.models_folder.case.coordinates_for_postcode")
 @patch("epilepsy12.general_functions.index_multiple_deprivation.imd_for_postcode")
+@patch(COUNTRY_PATCH, return_value="E92000001")
 def test_case_overwrite_index_of_multiple_deprivation_quintile(
-    mock_imd_for_postcode, mock_coordinates_for_postcode, e12_case_factory
+    mock_country,
+    mock_imd_for_postcode,
+    mock_coordinates_for_postcode,
+    e12_case_factory,
 ):
     e12Case = e12_case_factory(index_of_multiple_deprivation_quintile=5)
 
@@ -135,6 +184,11 @@ def test_case_overwrite_index_of_multiple_deprivation_quintile(
     e12Case.save()
     # Verify both mocks were called
     mock_coordinates_for_postcode.assert_called_once_with(postcode="WC1X8SH")
-    mock_imd_for_postcode.assert_called_once_with("WC1X8SH", year=2019)
+    assert_imd_call(
+        mock_imd_for_postcode,
+        "WC1X8SH",
+        year=2019,
+        country_boundary_identifier="E92000001",
+    )
     assert e12Case.postcode == "WC1X8SH"
     assert e12Case.index_of_multiple_deprivation_quintile == 4

--- a/epilepsy12/tests/model_tests/test_case.py
+++ b/epilepsy12/tests/model_tests/test_case.py
@@ -35,10 +35,7 @@ def assert_imd_call(
         if "country" in kwargs:
             assert kwargs["country"] == country_boundary_identifier
         if "country_boundary_identifier" in kwargs:
-            assert (
-                kwargs["country_boundary_identifier"]
-                == country_boundary_identifier
-            )
+            assert kwargs["country_boundary_identifier"] == country_boundary_identifier
 
 
 @pytest.mark.django_db

--- a/epilepsy12/tests/model_tests/test_imd.py
+++ b/epilepsy12/tests/model_tests/test_imd.py
@@ -29,13 +29,39 @@ COORDS_PATCH = "epilepsy12.models_folder.case.coordinates_for_postcode"
 COUNTRY_PATCH = "epilepsy12.general_functions.index_multiple_deprivation.country_boundary_identifier_for_postcode"
 
 
+def assert_imd_call(
+    mock_imd, postcode, year, country_boundary_identifier=None
+):
+    """Assert the IMD helper was called with the expected postcode/year.
+
+    Tests accept additional country kwargs so they remain valid as the helper
+    signature evolves.
+    """
+    args, kwargs = mock_imd.call_args
+
+    assert args == (postcode,)
+    assert kwargs.get("year") == year
+
+    if country_boundary_identifier is not None:
+        if "country" in kwargs:
+            assert kwargs["country"] == country_boundary_identifier
+        if "country_boundary_identifier" in kwargs:
+            assert (
+                kwargs["country_boundary_identifier"]
+                == country_boundary_identifier
+            )
+
+
 # ── Correct year selection ──────────────────────────────────────────────────
 
 
 @pytest.mark.django_db
 @patch(COORDS_PATCH)
 @patch(IMD_PATCH)
-def test_imd_uses_2019_for_cohort_below_8(mock_imd, mock_coords, e12_case_factory):
+@patch(COUNTRY_PATCH, return_value="E92000001")
+def test_imd_uses_2019_for_cohort_below_8(
+    mock_country, mock_imd, mock_coords, e12_case_factory
+):
     """Cohort 7 (assessment date in 2024) should call the API with year=2019."""
     mock_coords.return_value = (-0.1234, 51.5678)
     mock_imd.return_value = 3
@@ -47,7 +73,7 @@ def test_imd_uses_2019_for_cohort_below_8(mock_imd, mock_coords, e12_case_factor
 
     case.refresh_from_db()
     assert case.registration.cohort == 7
-    mock_imd.assert_called_with("WC1X8SH", year=2019)
+    assert_imd_call(mock_imd, "WC1X8SH", year=2019, country_boundary_identifier="E92000001")
     assert case.index_of_multiple_deprivation_quintile == 3
 
 
@@ -69,7 +95,7 @@ def test_imd_uses_2025_for_cohort_8_and_above(
 
     case.refresh_from_db()
     assert case.registration.cohort == 8
-    mock_imd.assert_called_with("WC1X8SH", year=2025)
+    assert_imd_call(mock_imd, "WC1X8SH", year=2025, country_boundary_identifier="E92000001")
     assert case.index_of_multiple_deprivation_quintile == 2
 
 
@@ -100,7 +126,7 @@ def test_imd_recalculated_when_assessment_date_changes_cohort(
 
     case.refresh_from_db()
     assert case.registration.cohort == 8
-    mock_imd.assert_called_with("WC1X8SH", year=2025)
+    assert_imd_call(mock_imd, "WC1X8SH", year=2025, country_boundary_identifier="E92000001")
     assert case.index_of_multiple_deprivation_quintile == 5
 
 
@@ -122,7 +148,7 @@ def test_imd_uses_2019_for_cohort_8_when_country_not_england(
 
     case.refresh_from_db()
     assert case.registration.cohort == 8
-    mock_imd.assert_called_with("CF101AA", year=2019)
+    assert_imd_call(mock_imd, "CF101AA", year=2019, country_boundary_identifier="W92000004")
     assert case.index_of_multiple_deprivation_quintile == 2
 
 
@@ -132,8 +158,9 @@ def test_imd_uses_2019_for_cohort_8_when_country_not_england(
 @pytest.mark.django_db
 @patch(COORDS_PATCH)
 @patch(IMD_PATCH)
+@patch(COUNTRY_PATCH, return_value="E92000001")
 def test_imd_recalculated_when_postcode_changes(
-    mock_imd, mock_coords, e12_case_factory
+    mock_country, mock_imd, mock_coords, e12_case_factory
 ):
     """Saving a Case with a new postcode should trigger a fresh IMD lookup."""
     mock_coords.return_value = (-0.1234, 51.5678)
@@ -149,7 +176,7 @@ def test_imd_recalculated_when_postcode_changes(
     case.save()
 
     case.refresh_from_db()
-    mock_imd.assert_called_with("EC1A1BB", year=2019)
+    assert_imd_call(mock_imd, "EC1A1BB", year=2019, country_boundary_identifier="E92000001")
     assert case.index_of_multiple_deprivation_quintile == 4
 
 
@@ -168,8 +195,9 @@ def test_imd_not_calculated_when_postcode_is_none(mock_imd, e12_case_factory):
 @pytest.mark.django_db
 @patch(COORDS_PATCH)
 @patch(IMD_PATCH)
+@patch(COUNTRY_PATCH, return_value="E92000001")
 def test_imd_not_calculated_for_unknown_postcode(
-    mock_imd, mock_coords, e12_case_factory
+    mock_country, mock_imd, mock_coords, e12_case_factory
 ):
     """A case with an 'unknown' placeholder postcode should not call the API."""
     mock_coords.return_value = (-0.1234, 51.5678)
@@ -194,8 +222,9 @@ def test_imd_not_calculated_for_unknown_postcode(
 @pytest.mark.django_db
 @patch(COORDS_PATCH)
 @patch(IMD_PATCH)
+@patch(COUNTRY_PATCH, return_value="E92000001")
 def test_imd_not_calculated_when_no_registration(
-    mock_imd, mock_coords, e12_case_factory
+    mock_country, mock_imd, mock_coords, e12_case_factory
 ):
     """recalculate_imd_for_case should be a no-op when no Registration exists."""
     mock_coords.return_value = (-0.1234, 51.5678)
@@ -222,8 +251,9 @@ def test_imd_not_calculated_when_no_registration(
 @pytest.mark.django_db
 @patch(COORDS_PATCH)
 @patch(IMD_PATCH)
+@patch(COUNTRY_PATCH, return_value="E92000001")
 def test_imd_not_calculated_when_cohort_is_none(
-    mock_imd, mock_coords, e12_case_factory
+    mock_country, mock_imd, mock_coords, e12_case_factory
 ):
     """recalculate_imd_for_case should be a no-op when the cohort is not yet set."""
     mock_coords.return_value = (-0.1234, 51.5678)
@@ -251,7 +281,10 @@ def test_imd_not_calculated_when_cohort_is_none(
 @pytest.mark.django_db
 @patch(COORDS_PATCH)
 @patch(IMD_PATCH)
-def test_imd_persisted_to_database(mock_imd, mock_coords, e12_case_factory):
+@patch(COUNTRY_PATCH, return_value="E92000001")
+def test_imd_persisted_to_database(
+    mock_country, mock_imd, mock_coords, e12_case_factory
+):
     """The IMD quintile returned by the API should be written to the database."""
     mock_coords.return_value = (-0.1234, 51.5678)
     mock_imd.return_value = 5
@@ -270,7 +303,10 @@ def test_imd_persisted_to_database(mock_imd, mock_coords, e12_case_factory):
 @pytest.mark.django_db
 @patch(COORDS_PATCH)
 @patch(IMD_PATCH)
-def test_imd_set_to_none_when_api_returns_none(mock_imd, mock_coords, e12_case_factory):
+@patch(COUNTRY_PATCH, return_value="E92000001")
+def test_imd_set_to_none_when_api_returns_none(
+    mock_country, mock_imd, mock_coords, e12_case_factory
+):
     """If the API returns None (e.g. postcode not found), IMD should be None."""
     mock_coords.return_value = (-0.1234, 51.5678)
     mock_imd.return_value = None

--- a/epilepsy12/tests/model_tests/test_imd.py
+++ b/epilepsy12/tests/model_tests/test_imd.py
@@ -29,9 +29,7 @@ COORDS_PATCH = "epilepsy12.models_folder.case.coordinates_for_postcode"
 COUNTRY_PATCH = "epilepsy12.general_functions.index_multiple_deprivation.country_boundary_identifier_for_postcode"
 
 
-def assert_imd_call(
-    mock_imd, postcode, year, country_boundary_identifier=None
-):
+def assert_imd_call(mock_imd, postcode, year, country_boundary_identifier=None):
     """Assert the IMD helper was called with the expected postcode/year.
 
     Tests accept additional country kwargs so they remain valid as the helper
@@ -46,10 +44,7 @@ def assert_imd_call(
         if "country" in kwargs:
             assert kwargs["country"] == country_boundary_identifier
         if "country_boundary_identifier" in kwargs:
-            assert (
-                kwargs["country_boundary_identifier"]
-                == country_boundary_identifier
-            )
+            assert kwargs["country_boundary_identifier"] == country_boundary_identifier
 
 
 # ── Correct year selection ──────────────────────────────────────────────────
@@ -73,7 +68,9 @@ def test_imd_uses_2019_for_cohort_below_8(
 
     case.refresh_from_db()
     assert case.registration.cohort == 7
-    assert_imd_call(mock_imd, "WC1X8SH", year=2019, country_boundary_identifier="E92000001")
+    assert_imd_call(
+        mock_imd, "WC1X8SH", year=2019, country_boundary_identifier="E92000001"
+    )
     assert case.index_of_multiple_deprivation_quintile == 3
 
 
@@ -95,7 +92,9 @@ def test_imd_uses_2025_for_cohort_8_and_above(
 
     case.refresh_from_db()
     assert case.registration.cohort == 8
-    assert_imd_call(mock_imd, "WC1X8SH", year=2025, country_boundary_identifier="E92000001")
+    assert_imd_call(
+        mock_imd, "WC1X8SH", year=2025, country_boundary_identifier="E92000001"
+    )
     assert case.index_of_multiple_deprivation_quintile == 2
 
 
@@ -126,7 +125,9 @@ def test_imd_recalculated_when_assessment_date_changes_cohort(
 
     case.refresh_from_db()
     assert case.registration.cohort == 8
-    assert_imd_call(mock_imd, "WC1X8SH", year=2025, country_boundary_identifier="E92000001")
+    assert_imd_call(
+        mock_imd, "WC1X8SH", year=2025, country_boundary_identifier="E92000001"
+    )
     assert case.index_of_multiple_deprivation_quintile == 5
 
 
@@ -148,7 +149,9 @@ def test_imd_uses_2019_for_cohort_8_when_country_not_england(
 
     case.refresh_from_db()
     assert case.registration.cohort == 8
-    assert_imd_call(mock_imd, "CF101AA", year=2019, country_boundary_identifier="W92000004")
+    assert_imd_call(
+        mock_imd, "CF101AA", year=2019, country_boundary_identifier="W92000004"
+    )
     assert case.index_of_multiple_deprivation_quintile == 2
 
 
@@ -176,7 +179,9 @@ def test_imd_recalculated_when_postcode_changes(
     case.save()
 
     case.refresh_from_db()
-    assert_imd_call(mock_imd, "EC1A1BB", year=2019, country_boundary_identifier="E92000001")
+    assert_imd_call(
+        mock_imd, "EC1A1BB", year=2019, country_boundary_identifier="E92000001"
+    )
     assert case.index_of_multiple_deprivation_quintile == 4
 
 

--- a/epilepsy12/tests/model_tests/test_imd.py
+++ b/epilepsy12/tests/model_tests/test_imd.py
@@ -26,6 +26,7 @@ from epilepsy12.general_functions.index_multiple_deprivation import (
 
 IMD_PATCH = "epilepsy12.general_functions.index_multiple_deprivation.imd_for_postcode"
 COORDS_PATCH = "epilepsy12.models_folder.case.coordinates_for_postcode"
+COUNTRY_PATCH = "epilepsy12.general_functions.index_multiple_deprivation.country_boundary_identifier_for_postcode"
 
 
 # ── Correct year selection ──────────────────────────────────────────────────
@@ -53,7 +54,10 @@ def test_imd_uses_2019_for_cohort_below_8(mock_imd, mock_coords, e12_case_factor
 @pytest.mark.django_db
 @patch(COORDS_PATCH)
 @patch(IMD_PATCH)
-def test_imd_uses_2025_for_cohort_8_and_above(mock_imd, mock_coords, e12_case_factory):
+@patch(COUNTRY_PATCH, return_value="E92000001")
+def test_imd_uses_2025_for_cohort_8_and_above(
+    mock_country, mock_imd, mock_coords, e12_case_factory
+):
     """Cohort 8 (assessment date in 2025) should call the API with year=2025."""
     mock_coords.return_value = (-0.1234, 51.5678)
     mock_imd.return_value = 2
@@ -72,8 +76,9 @@ def test_imd_uses_2025_for_cohort_8_and_above(mock_imd, mock_coords, e12_case_fa
 @pytest.mark.django_db
 @patch(COORDS_PATCH)
 @patch(IMD_PATCH)
+@patch(COUNTRY_PATCH, return_value="E92000001")
 def test_imd_recalculated_when_assessment_date_changes_cohort(
-    mock_imd, mock_coords, e12_case_factory
+    mock_country, mock_imd, mock_coords, e12_case_factory
 ):
     """Changing first_paediatric_assessment_date across the cohort 7→8 boundary
     should trigger a new IMD call with year=2025."""
@@ -97,6 +102,28 @@ def test_imd_recalculated_when_assessment_date_changes_cohort(
     assert case.registration.cohort == 8
     mock_imd.assert_called_with("WC1X8SH", year=2025)
     assert case.index_of_multiple_deprivation_quintile == 5
+
+
+@pytest.mark.django_db
+@patch(COORDS_PATCH)
+@patch(IMD_PATCH)
+@patch(COUNTRY_PATCH, return_value="W92000004")
+def test_imd_uses_2019_for_cohort_8_when_country_not_england(
+    mock_country, mock_imd, mock_coords, e12_case_factory
+):
+    """Cohort 8 should still use year=2019 outside England (e.g. Wales)."""
+    mock_coords.return_value = (-0.1234, 51.5678)
+    mock_imd.return_value = 2
+
+    case = e12_case_factory(
+        postcode="CF10 1AA",
+        registration__first_paediatric_assessment_date=date(2025, 3, 1),  # cohort 8
+    )
+
+    case.refresh_from_db()
+    assert case.registration.cohort == 8
+    mock_imd.assert_called_with("CF101AA", year=2019)
+    assert case.index_of_multiple_deprivation_quintile == 2
 
 
 # ── Postcode triggers ───────────────────────────────────────────────────────

--- a/s/test
+++ b/s/test
@@ -6,9 +6,87 @@ set -e  # Exit on error
 # scripts may need to be made executable on some platforms before they can be run
 # chmod +x <filename> is the command to do this on unixy systems
 
-# runs tests in the context of the django development server
+# runs tests in the context of the django development server by default
 # by default the --verbose flag is passed to pytest for more detailed output
-# $@ means all further arguments passed to s/test are passed to docker compose pytest ...
+# pytest args are passed through after optional script flags
 
-# *** The project's containers MUST BE RUNNING to execute tests inside it! ***
-docker compose exec django pytest -v "$@"
+usage() {
+	cat <<EOF
+Usage: s/test [MODE] [pytest args...]
+
+Runs pytest with -v.
+
+Modes (pick one):
+	--container, --in-container
+		Run in an already-running django container (default).
+	--local, --host, --outside-container
+		Run directly on the host machine.
+	--spin-up, --up, --with-up
+		Spin up an isolated test-only compose project (django+postgis), run tests,
+		and tear it down automatically.
+
+Options:
+	-h, --help
+			Show this help message.
+
+Examples:
+	s/test
+	s/test -k imd
+	s/test --local epilepsy12/tests/model_tests/test_imd.py
+	s/test --spin-up -m 'not slow'
+EOF
+}
+
+MODE="container"
+PYTEST_ARGS=()
+SPIN_UP_PROJECT=""
+
+set_mode() {
+	local requested_mode="$1"
+	if [ "$MODE" != "container" ] && [ "$MODE" != "$requested_mode" ]; then
+		echo "Error: choose only one mode flag (--local/--host, --container, or --spin-up)."
+		exit 2
+	fi
+	MODE="$requested_mode"
+}
+
+cleanup_spin_up_project() {
+	if [ -n "$SPIN_UP_PROJECT" ]; then
+		docker compose -p "$SPIN_UP_PROJECT" down -v >/dev/null 2>&1 || true
+	fi
+}
+
+for arg in "$@"; do
+	case "$arg" in
+		--local|--host|--outside-container)
+			set_mode "local"
+			;;
+		--container|--in-container)
+			set_mode "container"
+			;;
+		--spin-up|--up|--with-up)
+			set_mode "spin-up"
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			PYTEST_ARGS+=("$arg")
+			;;
+	esac
+done
+
+if [ "$MODE" = "local" ]; then
+	pytest -v "${PYTEST_ARGS[@]}"
+elif [ "$MODE" = "spin-up" ]; then
+	SPIN_UP_PROJECT="e12-test-$$"
+	trap cleanup_spin_up_project EXIT
+
+	# Start only what tests need in an isolated compose project.
+	DJANGO_START_COMMAND='s/start-test' docker compose -p "$SPIN_UP_PROJECT" up -d --wait django
+	docker compose -p "$SPIN_UP_PROJECT" exec django pytest -v "${PYTEST_ARGS[@]}"
+else
+	# *** The project's containers MUST BE RUNNING to execute tests inside it! ***
+	docker compose exec django pytest -v "${PYTEST_ARGS[@]}"
+fi

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -5,7 +5,7 @@
 {# MapLibre GL JS — loaded here so it is available for the deprivation map below #}
 <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" />
 <script src="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.1.2/dist/umd/rcpch-imd-map.min.js" integrity="sha256-1Y0CR334ohKEHd4FjtpiyTM48wruCG/+9qpgrqCTp+Y=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.2.1/dist/umd/rcpch-imd-map.min.js" integrity="sha256-NPAJtBYlHWLlW27+go2Impz/wiD6r9aSqE/SF8nudYo=" crossorigin="anonymous"></script>
 
 <div class="ui grid container selected_organisation_container">
         <div class="fluid row stackable three column grid">
@@ -433,6 +433,10 @@
         }
 
         var payload = JSON.parse(payloadNode.textContent || "{}");
+        var leadCentreZoom = 11;
+        var initialCenter = payload.leadCentre
+            ? [payload.leadCentre.lon, payload.leadCentre.lat]
+            : undefined;
         var token = {
             patientLabel: "{% templatetag openvariable %}patientLabel{% templatetag closevariable %}",
             id: "{% templatetag openvariable %}id{% templatetag closevariable %}",
@@ -442,9 +446,11 @@
 
         var map = window.RcpchImdMap.createImdMap({
             container: "organisation_cases_map",
-        tilesBaseUrl: "{{ deprivation_tiles_url }}",
+            tilesBaseUrl: "{{ deprivation_tiles_url }}",
             initialNation: payload.initialNation || "all",
             initialEra: payload.initialEra || "2011",
+            center: initialCenter,
+            zoom: initialCenter ? leadCentreZoom : undefined,
             enableHealthOverlays: true,
             showLegend: true,
             style: {
@@ -469,7 +475,7 @@
         if (payload.leadCentre) {
             map.setLeadCentre(payload.leadCentre);
         }
-        if (typeof map.fitToData === "function") {
+        if (!payload.leadCentre && typeof map.fitToData === "function") {
             map.fitToData();
         }
 

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -5,7 +5,7 @@
 {# MapLibre GL JS — loaded here so it is available for the deprivation map below #}
 <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" />
 <script src="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.1.0/dist/umd/rcpch-imd-map.min.js" integrity="sha512-HxvDiTxqY6tdsC/YuL6B7y9f5gOq2/s+WcJn+TyN19kD/ftFC4AqYIG287jSIJK70ijmJbNavuLWj13ukb6vNg==" crossorigin="anonymous"> </script>
+<script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.1.2/dist/umd/rcpch-imd-map.min.js" integrity="sha256-1Y0CR334ohKEHd4FjtpiyTM48wruCG/+9qpgrqCTp+Y=" crossorigin="anonymous"></script>
 
 <div class="ui grid container selected_organisation_container">
         <div class="fluid row stackable three column grid">


### PR DESCRIPTION
## Summary
This PR updates IMD calculation to select the dataset year by cohort and country, adds explicit `s/test` execution modes, and refreshes the organisation IMD map integration.

## What changed
- update IMD recalculation to use England 2025 data for cohort 8+ and keep non-England cohorts on 2019
- add postcode and lead-centre country fallback logic for IMD year selection
- update IMD and case model tests to tolerate country-aware IMD helper calls
- add explicit `s/test` modes for in-container, local host, and isolated spin-up workflows
- refresh testing documentation and agent notes for the new `s/test` behavior
- update the organisation summary map to `@rcpch/imd-map@0.2.1`, refresh the SRI hash, and start centered on the lead centre

## Validation
- `./s/test epilepsy12/tests/model_tests/test_imd.py epilepsy12/tests/model_tests/test_case.py`

## Notes
- a prior isolated `./s/test --spin-up epilepsy12/tests/model_tests/test_imd.py` run was blocked by PostGIS startup/connection issues in the temporary compose environment; the in-container focused test run passed

closes #1371