### PR TITLE
chore: bump @rcpch/imd-map CDN to v0.3.0 for era-aware map rendering

### DIFF
--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -5,7 +5,7 @@
 {# MapLibre GL JS — loaded here so it is available for the deprivation map below #}
 <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" />
 <script src="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.2.1/dist/umd/rcpch-imd-map.min.js" integrity="sha256-NPAJtBYlHWLlW27+go2Impz/wiD6r9aSqE/SF8nudYo=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.3.0/dist/umd/rcpch-imd-map.min.js" integrity="sha256-VZtQVL5s2CyUmYlw24U2h7pqrj02sMLNqk+7P+1T7j4=" crossorigin="anonymous"></script>
 
 <div class="ui grid container selected_organisation_container">
         <div class="fluid row stackable three column grid">


### PR DESCRIPTION
## What

Bumps the `@rcpch/imd-map` CDN script from `v0.2.1` to `v0.3.0` and updates the SRI integrity hash.

## Why

v0.3.0 introduces proper `initialEra` support for all-UK maps. In v0.2.1, passing `initialEra` to `createImdMap` was silently ignored — all maps rendered the 2011-era tiles regardless.

The view already sets `initialEra` correctly based on cohort:
- England, cohort ≥ 8 → `"2021"` (2021 LSOA boundaries + 2025 IMD data)
- All other cohorts / nations → `"2011"` (2011 LSOA boundaries + 2019 IMD data)

With v0.3.0 that value is now honoured, so the map rendered on the organisation dashboard correctly reflects which IMD dataset applies to each cohort.

## Changes

- `templates/epilepsy12/partials/selected_organisation_summary.html`: CDN URL `@0.2.1` → `@0.3.0`, SRI hash updated to `sha256-VZtQVL5s2CyUmYlw24U2h7pqrj02sMLNqk+7P+1T7j4=`

No view logic, model, or other template changes required.