### PR TITLE
fix/invalid-date-validation-genetic-tests

### DIFF
--- a/epilepsy12/tests/view_tests/db_actions/test_genetic_testing_date_validation.py
+++ b/epilepsy12/tests/view_tests/db_actions/test_genetic_testing_date_validation.py
@@ -1,0 +1,175 @@
+from datetime import date, timedelta
+
+import pytest
+from django.urls import reverse
+
+from epilepsy12.models import Epilepsy12User, Organisation
+from epilepsy12.tests.UserDataClasses import test_user_rcpch_audit_team_data
+from epilepsy12.tests.factories import E12CaseFactory
+from epilepsy12.tests.view_tests.permissions_tests.perm_tests_utils import (
+    twofactor_signin,
+)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("test_name", ["r14", "r27", "r59"])
+def test_genetic_requested_date_after_achieved_is_rejected(
+    client, seed_groups_fixture, seed_users_fixture, test_name
+):
+    test_user_organisation = Organisation.objects.get(
+        ods_code="RP401", trust__ods_code="RP4"
+    )
+    case = E12CaseFactory.create(
+        first_name=f"child_{test_user_organisation.name}",
+        organisations__organisation=test_user_organisation,
+        registration__investigations__genome_sequencing_requested=True,
+    )
+
+    test_user = Epilepsy12User.objects.get(
+        first_name=test_user_rcpch_audit_team_data.role_str
+    )
+
+    client.force_login(test_user)
+    twofactor_signin(client, test_user)
+
+    investigations = case.registration.investigations
+    requested_field_name = f"{test_name}_test_requested_date"
+    achieved_field_name = f"{test_name}_test_achieved_date"
+    status_field_name = f"{test_name}_test_status"
+
+    requested_date = date(2024, 1, 10)
+    achieved_date = date(2024, 1, 20)
+    setattr(investigations, status_field_name, "A")
+    setattr(investigations, requested_field_name, requested_date)
+    setattr(investigations, achieved_field_name, achieved_date)
+    investigations.save()
+
+    invalid_requested_date = achieved_date + timedelta(days=1)
+
+    response = client.post(
+        reverse(
+            "genetic_testing_date_callback",
+            kwargs={
+                "investigations_id": investigations.id,
+                "test_name": test_name,
+                "requested_or_achieved": "requested",
+            },
+        ),
+        headers={
+            "Hx-Trigger-Name": requested_field_name,
+            "Hx-Request": "true",
+        },
+        data={requested_field_name: invalid_requested_date.isoformat()},
+    )
+
+    investigations.refresh_from_db()
+
+    assert getattr(investigations, requested_field_name) == requested_date
+    assert isinstance(response.context["error_message"], ValueError)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("test_name", ["r14", "r27", "r59"])
+def test_genetic_achieved_date_after_requested_is_accepted(
+    client, seed_groups_fixture, seed_users_fixture, test_name
+):
+    test_user_organisation = Organisation.objects.get(
+        ods_code="RP401", trust__ods_code="RP4"
+    )
+    case = E12CaseFactory.create(
+        first_name=f"child_{test_user_organisation.name}",
+        organisations__organisation=test_user_organisation,
+        registration__investigations__genome_sequencing_requested=True,
+    )
+
+    test_user = Epilepsy12User.objects.get(
+        first_name=test_user_rcpch_audit_team_data.role_str
+    )
+
+    client.force_login(test_user)
+    twofactor_signin(client, test_user)
+
+    investigations = case.registration.investigations
+    requested_field_name = f"{test_name}_test_requested_date"
+    achieved_field_name = f"{test_name}_test_achieved_date"
+    status_field_name = f"{test_name}_test_status"
+
+    requested_date = date(2024, 1, 10)
+    original_achieved_date = date(2024, 1, 15)
+    valid_achieved_date = requested_date + timedelta(days=1)
+
+    setattr(investigations, status_field_name, "A")
+    setattr(investigations, requested_field_name, requested_date)
+    setattr(investigations, achieved_field_name, original_achieved_date)
+    investigations.save()
+
+    response = client.post(
+        reverse(
+            "genetic_testing_date_callback",
+            kwargs={
+                "investigations_id": investigations.id,
+                "test_name": test_name,
+                "requested_or_achieved": "achieved",
+            },
+        ),
+        headers={
+            "Hx-Trigger-Name": achieved_field_name,
+            "Hx-Request": "true",
+        },
+        data={achieved_field_name: valid_achieved_date.isoformat()},
+    )
+
+    investigations.refresh_from_db()
+
+    assert getattr(investigations, achieved_field_name) == valid_achieved_date
+    assert response.context["error_message"] is None
+
+
+@pytest.mark.django_db
+def test_genetic_date_callback_rejects_invalid_date_type(
+    client, seed_groups_fixture, seed_users_fixture
+):
+    test_user_organisation = Organisation.objects.get(
+        ods_code="RP401", trust__ods_code="RP4"
+    )
+    case = E12CaseFactory.create(
+        first_name=f"child_{test_user_organisation.name}",
+        organisations__organisation=test_user_organisation,
+        registration__investigations__genome_sequencing_requested=True,
+    )
+
+    test_user = Epilepsy12User.objects.get(
+        first_name=test_user_rcpch_audit_team_data.role_str
+    )
+
+    client.force_login(test_user)
+    twofactor_signin(client, test_user)
+
+    investigations = case.registration.investigations
+    investigations.r14_test_status = "A"
+    investigations.r14_test_requested_date = date(2024, 1, 10)
+    investigations.r14_test_achieved_date = date(2024, 1, 20)
+    investigations.save()
+
+    response = client.post(
+        reverse(
+            "genetic_testing_date_callback",
+            kwargs={
+                "investigations_id": investigations.id,
+                "test_name": "r14",
+                "requested_or_achieved": "invalid-date-type",
+            },
+        ),
+        headers={
+            "Hx-Trigger-Name": "r14_test_requested_date",
+            "Hx-Request": "true",
+        },
+        data={"r14_test_requested_date": date(2024, 1, 11).isoformat()},
+    )
+
+    investigations.refresh_from_db()
+
+    assert investigations.r14_test_requested_date == date(2024, 1, 10)
+    assert investigations.r14_test_achieved_date == date(2024, 1, 20)
+    assert isinstance(response.context["error_message"], ValueError)
+    assert "Invalid date type" in str(response.context["error_message"])

--- a/epilepsy12/views/investigation_views.py
+++ b/epilepsy12/views/investigation_views.py
@@ -75,7 +75,8 @@ def investigations(request, can_edit, case_id):
         mri_brain_declined = False
 
     context = {
-        "can_edit": can_edit and request.user.has_perm("epilepsy12.change_investigations"),
+        "can_edit": can_edit
+        and request.user.has_perm("epilepsy12.change_investigations"),
         "case_id": case_id,
         "registration": registration,
         "investigations": investigations,
@@ -139,7 +140,11 @@ def eeg_indicated(request, can_edit, investigations_id):
     else:
         eeg_declined = False
 
-    context = {"can_edit": can_edit, "investigations": investigations, "eeg_declined": eeg_declined}
+    context = {
+        "can_edit": can_edit,
+        "investigations": investigations,
+        "eeg_declined": eeg_declined,
+    }
 
     template_name = "epilepsy12/partials/investigations/eeg_information.html"
 
@@ -191,7 +196,11 @@ def eeg_request_date(request, can_edit, investigations_id):
     else:
         eeg_declined = False
 
-    context = {"can_edit": can_edit, "investigations": investigations, "eeg_declined": eeg_declined}
+    context = {
+        "can_edit": can_edit,
+        "investigations": investigations,
+        "eeg_declined": eeg_declined,
+    }
 
     response = recalculate_form_generate_response(
         model_instance=investigations,
@@ -240,7 +249,11 @@ def eeg_performed_date(request, can_edit, investigations_id):
     else:
         eeg_declined = False
 
-    context = {"can_edit": can_edit, "investigations": investigations, "eeg_declined": eeg_declined}
+    context = {
+        "can_edit": can_edit,
+        "investigations": investigations,
+        "eeg_declined": eeg_declined,
+    }
 
     template_name = "epilepsy12/partials/investigations/eeg_information.html"
 
@@ -285,7 +298,11 @@ def eeg_declined(request, can_edit, investigations_id, confirm):
 
     investigations.save()
 
-    context = {"can_edit": can_edit, "investigations": investigations, "eeg_declined": eeg_declined}
+    context = {
+        "can_edit": can_edit,
+        "investigations": investigations,
+        "eeg_declined": eeg_declined,
+    }
 
     template_name = "epilepsy12/partials/investigations/eeg_information.html"
 
@@ -662,7 +679,7 @@ def genetic_testing_status_callback(request, can_edit, investigations_id, test_n
         error_message = error
 
     investigations = Investigations.objects.get(pk=investigations_id)
-    
+
     test_status = getattr(investigations, f"{test_name}_test_status")
 
     date_requested_field_name = f"{test_name}_test_requested_date"
@@ -670,7 +687,7 @@ def genetic_testing_status_callback(request, can_edit, investigations_id, test_n
 
     if test_status in ["R", "N"]:
         setattr(investigations, date_achieved_field_name, None)
-    
+
     if test_status == "N":
         setattr(investigations, date_requested_field_name, None)
 
@@ -700,29 +717,34 @@ def genetic_testing_status_callback(request, can_edit, investigations_id, test_n
 @login_and_otp_required()
 @user_may_view_this_child()
 @permission_required("epilepsy12.change_investigations", raise_exception=True)
-def genetic_testing_date_callback(request, can_edit, investigations_id, test_name, requested_or_achieved):
+def genetic_testing_date_callback(
+    request, can_edit, investigations_id, test_name, requested_or_achieved
+):
     try:
         error_message = None
         investigations = Investigations.objects.get(pk=investigations_id)
-        
-        if requested_or_achieved == "achieved":
-            comparison_date_field_name=f"{test_name}_test_requested_date"
+
+        if requested_or_achieved == "requested":
+            comparison_date_field_name = f"{test_name}_test_achieved_date"
+            is_earliest_date = True
+        elif requested_or_achieved == "achieved":
+            comparison_date_field_name = f"{test_name}_test_requested_date"
+            is_earliest_date = False
         else:
-            comparison_date_field_name=None
+            raise ValueError(
+                f"Invalid date type '{requested_or_achieved}'. Expected 'requested' or 'achieved'."
+            )
 
         validation_args = {
             "field_name": f"{test_name}_test_{requested_or_achieved}_date",
             "page_element": "date_field",
             "comparison_date_field_name": comparison_date_field_name,
-            "is_earliest_date": True,
+            "is_earliest_date": is_earliest_date,
             "earliest_allowable_date": investigations.registration.case.date_of_birth,
         }
 
         validate_and_update_model(
-            request,
-            investigations_id,
-            Investigations,
-            **validation_args
+            request, investigations_id, Investigations, **validation_args
         )
 
     except ValueError as error:


### PR DESCRIPTION
### Overview

Current behaviour:
The R14/27/59 genetic tests in the Investigation view incorrectly tag the earliest date as `is_earliest_date`, instead applying it to whichever date is sent to the function by htmx, so that a meaningful comparison is never made. 

Ths PR used a TDD approach to fix the issue:
- ran 6 tests for expected behaviour (valid dates, invalid dates) one for each test to demonstrate failure
- fixed the `is_earliest_date` logic so that all test went green
- add guard path tests for invalid date types 

fixes #1381