### PR TITLE
Upgrade @rcpch/imd-map to v0.4.0 and pass Jersey as channel_islands

### DIFF
--- a/epilepsy12/views/organisation_views.py
+++ b/epilepsy12/views/organisation_views.py
@@ -190,6 +190,7 @@ def selected_organisation_summary(request, organisation_id):
         "W92000004": "wales",
         "S92000003": "scotland",
         "N92000002": "northern_ireland",
+        "JEY": "channel_islands",
     }
     imd_initial_nation = nation_by_boundary_identifier.get(
         selected_organisation.country.boundary_identifier, "all"

--- a/templates/epilepsy12/partials/selected_organisation_summary.html
+++ b/templates/epilepsy12/partials/selected_organisation_summary.html
@@ -5,7 +5,7 @@
 {# MapLibre GL JS — loaded here so it is available for the deprivation map below #}
 <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.css" />
 <script src="https://unpkg.com/maplibre-gl@4/dist/maplibre-gl.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.3.1/dist/umd/rcpch-imd-map.min.js" integrity="sha256-P5JNAUmWKj87ZCq/unS5ukm9/VHgYVzOpJIyuBe+Qaw=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.4.0/dist/umd/rcpch-imd-map.min.js" integrity="sha256-78yGLopfeMuPUoNYJMwHs2BiNz9YoHdjEfeyPUVAp1g=" crossorigin="anonymous"></script>
 
 <div class="ui grid container selected_organisation_container">
         <div class="fluid row stackable three column grid">


### PR DESCRIPTION
## Summary
- upgrade `@rcpch/imd-map` CDN include from `0.3.1` to `0.4.0`
- update SRI hash for the v0.4.0 UMD bundle
- map Jersey (`JEY`) to `channel_islands` in map payload nation mapping

## Why
The map component v0.4.0 adds Channel Islands nation support. This ensures Jersey organisations are initialised with the correct nation parameter.

## Changes
- template script tag updated to v0.4.0 with new integrity hash
- `selected_organisation_summary` nation mapping now includes `"JEY": "channel_islands"`

## Validation
- verified local diagnostics for edited files showed no errors
- confirmed behavior manually: Jersey map initialisation works as expected
<img width="1187" height="761" alt="image" src="https://github.com/user-attachments/assets/8803f0ca-ac18-4d3c-90d8-3247a6bd1083" />
